### PR TITLE
Track the parent of Python declarations

### DIFF
--- a/client/src/model/PythonClass.test.ts
+++ b/client/src/model/PythonClass.test.ts
@@ -1,4 +1,28 @@
 import PythonClass from "./PythonClass";
+import PythonPackage from "./PythonPackage";
+import PythonModule from "./PythonModule";
+
+test("path without parent", () => {
+    const pythonClass = new PythonClass("Class")
+    expect(pythonClass.path()).toEqual(["Class"])
+})
+
+test("path with ancestors", () => {
+    const pythonClass = new PythonClass("Class")
+    new PythonPackage(
+        "package",
+        [
+            new PythonModule(
+                "module",
+                [],
+                [],
+                [pythonClass]
+            )
+        ]
+    )
+
+    expect(pythonClass.path()).toEqual(["package", "module", "Class"])
+})
 
 test("toString without decorators and superclasses", () => {
     const pythonClass = new PythonClass("Class")

--- a/client/src/model/PythonClass.ts
+++ b/client/src/model/PythonClass.ts
@@ -1,6 +1,8 @@
 import PythonFunction from "./PythonFunction";
+import PythonModule from "./PythonModule";
+import PythonDeclaration from "./PythonDeclaration";
 
-export default class PythonClass {
+export default class PythonClass extends PythonDeclaration {
 
     readonly name: string;
     readonly decorators: string[];
@@ -9,6 +11,7 @@ export default class PythonClass {
     readonly summary: string;
     readonly description: string;
     readonly fullDocstring: string;
+    containingModule: Nullable<PythonModule>;
 
     constructor(
         name: string,
@@ -19,6 +22,8 @@ export default class PythonClass {
         description: string = "",
         fullDocstring: string = "",
     ) {
+        super();
+
         this.name = name;
         this.decorators = decorators;
         this.superclasses = superclasses;
@@ -26,22 +31,31 @@ export default class PythonClass {
         this.summary = summary;
         this.description = description;
         this.fullDocstring = fullDocstring;
+        this.containingModule = null;
+
+        this.methods.forEach(it => {
+            it.containingModuleOrClass = this;
+        });
+    }
+
+    parent(): Nullable<PythonDeclaration> {
+        return this.containingModule;
     }
 
     toString() {
-        let result = ""
+        let result = "";
 
         if (this.decorators.length > 0) {
-            result += this.decorators.map(it => `@${it}`).join(" ")
-            result += " "
+            result += this.decorators.map(it => `@${it}`).join(" ");
+            result += " ";
         }
 
-        result += `class ${this.name}`
+        result += `class ${this.name}`;
 
         if (this.superclasses.length > 0) {
-            result += `(${this.superclasses.join(", ")})`
+            result += `(${this.superclasses.join(", ")})`;
         }
 
-        return result
+        return result;
     }
 }

--- a/client/src/model/PythonDeclaration.ts
+++ b/client/src/model/PythonDeclaration.ts
@@ -1,0 +1,18 @@
+export default abstract class PythonDeclaration {
+    abstract readonly name: string
+
+    abstract parent(): Nullable<PythonDeclaration>
+
+    path(): string[] {
+        let current: Nullable<PythonDeclaration> = this;
+
+        const result: string[] = [];
+
+        while (current != null) {
+            result.unshift(current.name)
+            current = current.parent();
+        }
+
+        return result;
+    }
+}

--- a/client/src/model/PythonFunction.test.ts
+++ b/client/src/model/PythonFunction.test.ts
@@ -1,5 +1,37 @@
 import PythonFunction from "./PythonFunction";
 import PythonParameter from "./PythonParameter";
+import PythonClass from "./PythonClass";
+import PythonPackage from "./PythonPackage";
+import PythonModule from "./PythonModule";
+
+test("path without parent", () => {
+    const pythonFunction = new PythonFunction("function")
+    expect(pythonFunction.path()).toEqual(["function"])
+})
+
+test("path with ancestors", () => {
+    const pythonFunction = new PythonFunction("function")
+    new PythonPackage(
+        "package",
+        [
+            new PythonModule(
+                "module",
+                [],
+                [],
+                [
+                    new PythonClass(
+                        "Class",
+                        [],
+                        [],
+                        [pythonFunction]
+                    )
+                ]
+            )
+        ]
+    )
+
+    expect(pythonFunction.path()).toEqual(["package", "module", "Class", "function"])
+})
 
 test("toString without decorators and parameters", () => {
     const pythonFunction = new PythonFunction("function")

--- a/client/src/model/PythonFunction.ts
+++ b/client/src/model/PythonFunction.ts
@@ -1,7 +1,10 @@
 import PythonParameter from "./PythonParameter";
 import PythonResult from "./PythonResult";
+import PythonClass from "./PythonClass";
+import PythonModule from "./PythonModule";
+import PythonDeclaration from "./PythonDeclaration";
 
-export default class PythonFunction {
+export default class PythonFunction extends PythonDeclaration {
 
     readonly name: string;
     readonly decorators: string[];
@@ -11,6 +14,7 @@ export default class PythonFunction {
     readonly summary: string;
     readonly description: string;
     readonly fullDocstring: string;
+    containingModuleOrClass: Nullable<PythonModule | PythonClass>;
 
     constructor(
         name: string,
@@ -22,6 +26,8 @@ export default class PythonFunction {
         description: string = "",
         fullDocstring: string = "",
     ) {
+        super();
+
         this.name = name;
         this.decorators = decorators;
         this.parameters = parameters;
@@ -30,6 +36,19 @@ export default class PythonFunction {
         this.summary = summary;
         this.description = description;
         this.fullDocstring = fullDocstring;
+        this.containingModuleOrClass = null;
+
+        this.parameters.forEach(it => {
+            it.containingFunction = this
+        })
+
+        this.results.forEach(it => {
+            it.containingFunction = this
+        })
+    }
+
+    parent(): Nullable<PythonModule | PythonClass> {
+        return this.containingModuleOrClass;
     }
 
     toString() {

--- a/client/src/model/PythonModule.test.ts
+++ b/client/src/model/PythonModule.test.ts
@@ -1,4 +1,20 @@
 import PythonModule from "./PythonModule";
+import PythonPackage from "./PythonPackage";
+
+test("path without parent", () => {
+    const pythonModule = new PythonModule("module")
+    expect(pythonModule.path()).toEqual(["module"])
+})
+
+test("path with parent", () => {
+    const pythonModule = new PythonModule("module")
+    new PythonPackage(
+        "package",
+        [pythonModule]
+    )
+
+    expect(pythonModule.path()).toEqual(["package", "module"])
+})
 
 test("toString", () => {
     const pythonModule = new PythonModule("module")

--- a/client/src/model/PythonModule.ts
+++ b/client/src/model/PythonModule.ts
@@ -2,14 +2,17 @@ import PythonFunction from "./PythonFunction";
 import PythonClass from "./PythonClass";
 import PythonFromImport from "./PythonFromImport";
 import PythonImport from "./PythonImport";
+import PythonPackage from "./PythonPackage";
+import PythonDeclaration from "./PythonDeclaration";
 
-export default class PythonModule {
+export default class PythonModule extends PythonDeclaration {
 
     readonly name: string;
     readonly imports: PythonImport[];
     readonly fromImports: PythonFromImport[];
     readonly classes: PythonClass[];
     readonly functions: PythonFunction[];
+    containingPackage: Nullable<PythonPackage>;
 
     constructor(
         name: string,
@@ -18,14 +21,29 @@ export default class PythonModule {
         classes: PythonClass[] = [],
         functions: PythonFunction[] = []
     ) {
+        super();
+
         this.name = name;
         this.imports = imports;
         this.fromImports = fromImports;
         this.classes = classes;
         this.functions = functions;
+        this.containingPackage = null;
+
+        this.classes.forEach(it => {
+            it.containingModule = this
+        });
+
+        this.functions.forEach(it => {
+            it.containingModuleOrClass = this
+        });
+    }
+
+    parent(): Nullable<PythonPackage> {
+        return this.containingPackage;
     }
 
     toString() {
-        return `Module "${this.name}"`
+        return `Module "${this.name}"`;
     }
 }

--- a/client/src/model/PythonPackage.test.ts
+++ b/client/src/model/PythonPackage.test.ts
@@ -1,5 +1,10 @@
 import PythonPackage from "./PythonPackage";
 
+test("path", () => {
+    const pythonPackage = new PythonPackage("package")
+    expect(pythonPackage.path()).toEqual(["package"])
+})
+
 test("toString", () => {
     const pythonPackage = new PythonPackage("package")
     expect(pythonPackage.toString()).toBe(`Package "package"`)

--- a/client/src/model/PythonPackage.ts
+++ b/client/src/model/PythonPackage.ts
@@ -1,16 +1,27 @@
 import PythonModule from "./PythonModule";
+import PythonDeclaration from "./PythonDeclaration";
 
-export default class PythonPackage {
+export default class PythonPackage extends PythonDeclaration {
 
     readonly name: string;
     readonly modules: PythonModule[];
 
     constructor(name: string, modules: PythonModule[] = []) {
+        super();
+
         this.name = name;
         this.modules = modules;
+
+        this.modules.forEach(it => {
+            it.containingPackage = this;
+        });
+    }
+
+    parent(): null {
+        return null;
     }
 
     toString() {
-        return `Package "${this.name}"`
+        return `Package "${this.name}"`;
     }
 }

--- a/client/src/model/PythonParameter.test.ts
+++ b/client/src/model/PythonParameter.test.ts
@@ -1,4 +1,43 @@
 import PythonParameter from "./PythonParameter";
+import PythonFunction from "./PythonFunction";
+import PythonPackage from "./PythonPackage";
+import PythonModule from "./PythonModule";
+import PythonClass from "./PythonClass";
+
+test("path without parent", () => {
+    const pythonParameter = new PythonParameter("param")
+    expect(pythonParameter.path()).toEqual(["param"])
+})
+
+test("path with ancestors", () => {
+    const pythonParameter = new PythonParameter("param")
+    new PythonPackage(
+        "package",
+        [
+            new PythonModule(
+                "module",
+                [],
+                [],
+                [
+                    new PythonClass(
+                        "Class",
+                        [],
+                        [],
+                        [
+                            new PythonFunction(
+                                "function",
+                                [],
+                                [pythonParameter]
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+
+    expect(pythonParameter.path()).toEqual(["package", "module", "Class", "function", "param"])
+})
 
 test("toString", () => {
     const pythonParameter = new PythonParameter("param")

--- a/client/src/model/PythonParameter.ts
+++ b/client/src/model/PythonParameter.ts
@@ -1,4 +1,7 @@
-export default class PythonParameter {
+import PythonFunction from "./PythonFunction";
+import PythonDeclaration from "./PythonDeclaration";
+
+export default class PythonParameter extends PythonDeclaration {
 
     readonly name: string;
     readonly type: string;
@@ -8,6 +11,7 @@ export default class PythonParameter {
     readonly limitation: null;
     readonly ignored: boolean;
     readonly description: string;
+    containingFunction: Nullable<PythonFunction>;
 
     constructor(
         name: string,
@@ -19,6 +23,8 @@ export default class PythonParameter {
         ignored: boolean = false,
         description: string = ""
     ) {
+        super();
+
         this.name = name;
         this.type = type;
         this.typeInDocs = typeInDocs;
@@ -27,9 +33,14 @@ export default class PythonParameter {
         this.limitation = limitation;
         this.ignored = ignored;
         this.description = description;
+        this.containingFunction = null;
+    }
+
+    parent(): Nullable<PythonFunction> {
+        return this.containingFunction;
     }
 
     toString() {
-        return `Parameter "${this.name}"`
+        return `Parameter "${this.name}"`;
     }
 }

--- a/client/src/model/PythonResult.test.ts
+++ b/client/src/model/PythonResult.test.ts
@@ -1,4 +1,44 @@
 import PythonResult from "./PythonResult";
+import PythonPackage from "./PythonPackage";
+import PythonModule from "./PythonModule";
+import PythonClass from "./PythonClass";
+import PythonFunction from "./PythonFunction";
+
+test("path without parent", () => {
+    const pythonResult = new PythonResult("res")
+    expect(pythonResult.path()).toEqual(["res"])
+})
+
+test("path with ancestors", () => {
+    const pythonResult = new PythonResult("res")
+    new PythonPackage(
+        "package",
+        [
+            new PythonModule(
+                "module",
+                [],
+                [],
+                [
+                    new PythonClass(
+                        "Class",
+                        [],
+                        [],
+                        [
+                            new PythonFunction(
+                                "function",
+                                [],
+                                [],
+                                [pythonResult]
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+
+    expect(pythonResult.path()).toEqual(["package", "module", "Class", "function", "res"])
+})
 
 test("toString", () => {
     const pythonResult = new PythonResult("res")

--- a/client/src/model/PythonResult.ts
+++ b/client/src/model/PythonResult.ts
@@ -1,9 +1,13 @@
-export default class PythonResult {
+import PythonFunction from "./PythonFunction";
+import PythonDeclaration from "./PythonDeclaration";
+
+export default class PythonResult extends PythonDeclaration {
 
     readonly name: string;
     readonly type: string;
     readonly typeInDocs: string;
     readonly description: string;
+    containingFunction: Nullable<PythonFunction>;
 
     constructor(
         name: string,
@@ -11,13 +15,20 @@ export default class PythonResult {
         typeInDocs: string = "",
         description: string = ""
     ) {
+        super();
+
         this.name = name;
         this.type = type;
         this.typeInDocs = typeInDocs;
         this.description = description;
+        this.containingFunction = null;
+    }
+
+    parent(): Nullable<PythonFunction> {
+        return this.containingFunction;
     }
 
     toString() {
-        return `Result "${this.name}"`
+        return `Result "${this.name}"`;
     }
 }


### PR DESCRIPTION
This way we can easily reconstruct the path to it (e.g. for breadcrumbs).