### PR TITLE
api-editor-55 Path durch Breadcrumb aus React-Bootstrap ersetzen

### DIFF
--- a/client/src/Components/ParameterView/ParameterView.css
+++ b/client/src/Components/ParameterView/ParameterView.css
@@ -1,8 +1,5 @@
 .parameter-view {
     padding: 1rem;
-    position: -webkit-sticky;
-    position: sticky;
-    top: 0;
     overflow-x: hidden;
 }
 
@@ -64,8 +61,4 @@
 
 .documentation-text {
     clear: both;
-}
-
-.parameter-view-path {
-    height: 1.5rem;
 }

--- a/client/src/Components/ParameterView/ParameterView.tsx
+++ b/client/src/Components/ParameterView/ParameterView.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import PythonParameter from "../../model/PythonParameter";
 import PythonFunction from "../../model/PythonFunction";
 import DocumentationText from "./DocumentationText";
+import {Breadcrumb} from "react-bootstrap";
 
 type ParameterViewProps = {
     inputParameters: PythonParameter[],
@@ -17,10 +18,14 @@ export default function ParameterView({inputParameters, selection, selectedFunct
     return (
         <div className="parameter-view">
             <div className="parameter-view-path">
-                {selection.length > 0 ?
-                    selection.map<React.ReactNode>((n, index) => <a href="#" key={index}>{n}</a>)
-                        .reduce((p, c, index) => [p, (<span key={index}> / </span>), c]) :
-                    ""}
+                <Breadcrumb>
+                    {(!selection || selection.length === 0) && (
+                        <Breadcrumb.Item active>Nothing selected.</Breadcrumb.Item>
+                    )}
+                    {selection.map((name, index) => (
+                        <Breadcrumb.Item active key={index}>{name}</Breadcrumb.Item>
+                    ))}
+                </Breadcrumb>
             </div>
             {selectedFunction !== null &&
             <>


### PR DESCRIPTION
Closes #55.

## Vorher:
![Screenshot 2021-06-20 115910](https://user-images.githubusercontent.com/2501322/122669823-592cd080-d1bf-11eb-9022-77b169721cf1.png)

## Nachher:
![Screenshot 2021-06-20 115809](https://user-images.githubusercontent.com/2501322/122669807-4fa36880-d1bf-11eb-9cca-e00183d331fd.png)
