### PR TITLE
api-editor-76 Change indentation and open/close icons of nodes in the tree view

### DIFF
--- a/client/src/Components/Tree/TreeNode.tsx
+++ b/client/src/Components/Tree/TreeNode.tsx
@@ -26,7 +26,7 @@ export default function TreeNode(props: TreeNodeProps): JSX.Element {
 
     const level = levelOf(props.declaration);
     const style = {
-        paddingLeft: (level === 0 ? '1rem' : `calc(${level} * (1.25em + 0.25rem) + 1rem)`)
+        paddingLeft: (level === 0 ? '1rem' : `calc(0.5 * ${level} * (1.25em + 0.25rem) + 1rem)`)
     };
 
     const handleClick = () => {
@@ -41,6 +41,7 @@ export default function TreeNode(props: TreeNodeProps): JSX.Element {
                     className={TreeNodeCSS.icon}
                     hasChildren={props.isExpandable}
                     showChildren={showChildren}
+                    isSelected={isSelected(props.declaration, props.selection)}
                 />
                 <FontAwesomeIcon
                     className={TreeNodeCSS.icon}

--- a/client/src/Components/Util/VisibilityIndicator.module.css
+++ b/client/src/Components/Util/VisibilityIndicator.module.css
@@ -1,3 +1,3 @@
-.visibilityIndicator {
-
+.closed {
+    color: #BBB;
 }

--- a/client/src/Components/Util/VisibilityIndicator.tsx
+++ b/client/src/Components/Util/VisibilityIndicator.tsx
@@ -1,4 +1,4 @@
-import {faChevronCircleDown, faChevronCircleRight} from "@fortawesome/free-solid-svg-icons";
+import {faChevronDown, faChevronRight} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
 import React from "react";
@@ -8,17 +8,31 @@ import VisibilityIndicatorCSS from "./VisibilityIndicator.module.css";
 
 interface VisibilityIndicatorProps extends ClassNameProp {
     hasChildren: boolean,
-    showChildren: boolean
+    showChildren: boolean,
+    isSelected?: boolean,
 }
 
-export default function VisibilityIndicator(props: VisibilityIndicatorProps): JSX.Element {
-    const className = classNames(VisibilityIndicatorCSS.visibilityIndicator, props.className);
+export default function VisibilityIndicator(
+    {
+        className,
+        hasChildren,
+        showChildren,
+        isSelected = false
+    }: VisibilityIndicatorProps
+): JSX.Element {
 
-    if (props.hasChildren) {
+    const cssClasses = classNames(
+        className,
+        {
+            [VisibilityIndicatorCSS.closed]: !isSelected && !showChildren
+        }
+    );
+
+    if (hasChildren) {
         return (
             <FontAwesomeIcon
-                className={className}
-                icon={props.showChildren ? faChevronCircleDown : faChevronCircleRight}
+                className={cssClasses}
+                icon={showChildren ? faChevronDown : faChevronRight}
                 fixedWidth
             />
         );


### PR DESCRIPTION
Closes #76.

## Summary of Changes
* Indent levels in the tree view only by half the width on the icons (+padding)
* Change icons of the visibility indicator (open/close)
* Change color of the visibility indicator for the "closed" state

## Screenshots (if necessary)

### Before
![Screenshot 2021-07-02 at 10-25-11 API Editor](https://user-images.githubusercontent.com/2501322/124245024-dc371a80-db1f-11eb-8035-b495aa291e9f.png)

![image](https://user-images.githubusercontent.com/2501322/124246440-371d4180-db21-11eb-88b1-798fb48a4a63.png)


### After
![image](https://user-images.githubusercontent.com/2501322/124244888-b578e400-db1f-11eb-8fa8-819ba2dde14d.png)

![image](https://user-images.githubusercontent.com/2501322/124246372-279df880-db21-11eb-965a-4ae0b826fdf8.png)

## Testing instructions
* Ensure the tree view looks correct
* Ensure the "read more" option in the documentation looks correct
