### PR TITLE
Added Read More to collapsible text in documentation

### DIFF
--- a/client/src/Components/ParameterView/DocumentationText.tsx
+++ b/client/src/Components/ParameterView/DocumentationText.tsx
@@ -35,13 +35,6 @@ export default function DocumentationText({inputText = ""}: DocumentationTextPro
                 <VisibilityIndicator hasChildren={hasMultipleLines} showChildren={readMore}/>
             </div>
 
-            {/*<ReactMarkdown*/}
-            {/*    remarkPlugins={[remarkGfm, remarkMath]}*/}
-            {/*    rehypePlugins={[rehypeKatex]}*/}
-            {/*>*/}
-            {/*    The lift coefficient ($C_L$) is a dimensionless coefficient.*/}
-            {/*</ReactMarkdown>*/}
-
             <ReactMarkdown className={cssClasses} rehypePlugins={[rehypeKatex]} remarkPlugins={[remarkGfm, remarkMath]}>
                 {readMore || !hasMultipleLines ? preprocessedText : shortenedText + " [Read More...]"}
             </ReactMarkdown>


### PR DESCRIPTION
Closes #87.

## Summary of Changes
Added [Read More...] at the end of cut text

Before:
![изображение](https://user-images.githubusercontent.com/33559230/125086092-92c06f80-e0cb-11eb-9ce5-1afac118fefa.png)

After:
![изображение](https://user-images.githubusercontent.com/33559230/125086433-ed59cb80-e0cb-11eb-84f7-934e3c467870.png)


