### PR TITLE
Moved Dialog-window to the left and added some spacing from the top

### DIFF
--- a/client/src/Components/ParameterView/ParameterView.css
+++ b/client/src/Components/ParameterView/ParameterView.css
@@ -55,7 +55,15 @@
 .documentation-text {
     clear: both;
 }
+
 .modal-dialog {
-    margin-left: 10rem;
     margin-top: 5rem;
+}
+
+@media screen and (min-width: 1200px) {
+    .modal-dialog {
+        /* Centers the dialog over the left pane */
+        margin-left: calc(25vw - 250px);
+        width: 500px;
+    }
 }


### PR DESCRIPTION
Closes #84.

## Summary of Changes
Rename-Window opens at the left side of screen

## Screenshots (if necessary)

Before:
![изображение](https://user-images.githubusercontent.com/33559230/125086811-4164b000-e0cc-11eb-9f63-9cfad7e25c88.png)

After:
![изображение](https://user-images.githubusercontent.com/33559230/125086877-55101680-e0cc-11eb-8ea4-0f96f6adcbe1.png)

