### PR TITLE
fix: Duplicate documentation parameter view

### DIFF
--- a/client/src/Components/SelectionView/ParameterView.tsx
+++ b/client/src/Components/SelectionView/ParameterView.tsx
@@ -20,7 +20,12 @@ export default function ParameterView(props: ParameterViewProps): JSX.Element {
             {props.pythonParameter.hasDefault &&
             <TitleValueViewPair title="Default value" value={props.pythonParameter.defaultValue}/>}
             {props.pythonParameter.type &&
-            <><h2>Type</h2><span className="pl-1rem">{props.pythonParameter.type}</span></>}
+            <>
+                <h2>Type</h2>
+                <span className="pl-1rem">
+                    {props.pythonParameter.type}
+                </span>
+            </>}
         </div>
     );
 }


### PR DESCRIPTION
Closes #126

## Summary of Changes
Removed the parameter description in ParameterView since it's already in ParameterNode.

## Testing instructions
Check whether or not the description still appears two times.
