### PR TITLE
feat: grid columns are now resizable

### DIFF
--- a/client/src/Components/App/App.module.css
+++ b/client/src/Components/App/App.module.css
@@ -1,8 +1,8 @@
 .app {
     display: grid;
     grid-template-areas: "menu menu" "leftPane rightPane";
-    grid-template-columns: 50% 50%;
     grid-auto-rows: 0fr 1fr;
+    grid-auto-columns: 0fr 1fr;
     height: 100vh;
     width: 100vw;
 }
@@ -15,6 +15,9 @@
     border-right: 1px solid gray;
     grid-area: leftPane;
     overflow: auto;
+    resize: horizontal;
+    min-width: 20vw;
+    max-width: 80vw;
 }
 
 .rightPane {


### PR DESCRIPTION
Closes #136 

## Summary of Changes
Die Trennung zwischen TreeView und SelectionView ist jetzt nicht mehr fix auf 50% beschränkt. Beide Seiten können nur einen Wert zwischen 20 und 80% annehmen und unten auf dem Icon verschoben werden durch eine Drag-Bewegung mit der Maus.

## Screenshots
![image](https://user-images.githubusercontent.com/45012526/126668503-be0dbee2-b9bc-4228-8ce3-320866f9f370.png)
![image](https://user-images.githubusercontent.com/45012526/126668565-1857e58d-e081-4471-9e49-c6dc0c8d9712.png)

## Testing instructions
Trennung zwischen TreeView und SelectionView hin und her schieben und gucken was passiert.
