### PR TITLE
ci: cancel outdated workflow runs triggered by PRs

### DIFF
--- a/.github/workflows/pr-target.yml
+++ b/.github/workflows/pr-target.yml
@@ -8,6 +8,10 @@ on:
       - synchronize
       - reopened
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   title:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #227.

### Summary of Changes

Cancel pending and running workflow runs triggered by pushes to a branch for which a Pull Request has been created.
