### PR TITLE
feat: hide private declarations by default and prevent annotating them

### DIFF
--- a/api-editor/client/src/common/MenuBar.tsx
+++ b/api-editor/client/src/common/MenuBar.tsx
@@ -49,7 +49,7 @@ import PythonPackage from '../features/packageData/model/PythonPackage';
 import {
     selectShowPrivateDeclarations,
     togglePackageDataImportDialog,
-    toggleShowPrivateDeclarations
+    toggleShowPrivateDeclarations,
 } from '../features/packageData/packageDataSlice';
 import { Setter } from './util/types';
 
@@ -255,12 +255,12 @@ const MenuBar: React.FC<MenuBarProps> = function ({
                 </Box>
                 <Button onClick={exportAnnotations}>Export</Button>
                 <DeleteAllAnnotations />
-                <Button onClick={() => dispatch(toggleShowPrivateDeclarations())}>
-                    {useAppSelector(selectShowPrivateDeclarations) ?
-                        'Hide private declarations'
-                        :
-                        'Show private declarations'
-                    }
+                <Button
+                    onClick={() => dispatch(toggleShowPrivateDeclarations())}
+                >
+                    {useAppSelector(selectShowPrivateDeclarations)
+                        ? 'Hide private declarations'
+                        : 'Show private declarations'}
                 </Button>
                 <Button onClick={toggleColorMode}>
                     Toggle {colorMode === 'light' ? 'dark' : 'light'}

--- a/api-editor/client/src/common/MenuBar.tsx
+++ b/api-editor/client/src/common/MenuBar.tsx
@@ -46,7 +46,11 @@ import {
 import AnnotatedPythonPackageBuilder from '../features/annotatedPackageData/model/AnnotatedPythonPackageBuilder';
 import { PythonFilter } from '../features/packageData/model/PythonFilter';
 import PythonPackage from '../features/packageData/model/PythonPackage';
-import { togglePackageDataImportDialog } from '../features/packageData/packageDataSlice';
+import {
+    selectShowPrivateDeclarations,
+    togglePackageDataImportDialog,
+    toggleShowPrivateDeclarations
+} from '../features/packageData/packageDataSlice';
 import { Setter } from './util/types';
 
 interface MenuBarProps {
@@ -251,6 +255,13 @@ const MenuBar: React.FC<MenuBarProps> = function ({
                 </Box>
                 <Button onClick={exportAnnotations}>Export</Button>
                 <DeleteAllAnnotations />
+                <Button onClick={() => dispatch(toggleShowPrivateDeclarations())}>
+                    {useAppSelector(selectShowPrivateDeclarations) ?
+                        'Hide private declarations'
+                        :
+                        'Show private declarations'
+                    }
+                </Button>
                 <Button onClick={toggleColorMode}>
                     Toggle {colorMode === 'light' ? 'dark' : 'light'}
                 </Button>

--- a/api-editor/client/src/features/packageData/model/PythonClass.ts
+++ b/api-editor/client/src/features/packageData/model/PythonClass.ts
@@ -52,7 +52,7 @@ export default class PythonClass extends PythonDeclaration {
     }
 
     isPublicDeclaration(): boolean {
-        return this.isPublic
+        return this.isPublic;
     }
 
     toString(): string {

--- a/api-editor/client/src/features/packageData/model/PythonClass.ts
+++ b/api-editor/client/src/features/packageData/model/PythonClass.ts
@@ -51,6 +51,10 @@ export default class PythonClass extends PythonDeclaration {
         return this.methods;
     }
 
+    isPublicDeclaration(): boolean {
+        return this.isPublic
+    }
+
     toString(): string {
         let result = '';
 

--- a/api-editor/client/src/features/packageData/model/PythonDeclaration.ts
+++ b/api-editor/client/src/features/packageData/model/PythonDeclaration.ts
@@ -12,6 +12,10 @@ export default abstract class PythonDeclaration {
         return this.name;
     }
 
+    isPublicDeclaration(): boolean {
+        return true
+    }
+
     path(): string[] {
         let current: Optional<PythonDeclaration> = this;
         const result: string[] = [];

--- a/api-editor/client/src/features/packageData/model/PythonDeclaration.ts
+++ b/api-editor/client/src/features/packageData/model/PythonDeclaration.ts
@@ -13,7 +13,7 @@ export default abstract class PythonDeclaration {
     }
 
     isPublicDeclaration(): boolean {
-        return true
+        return true;
     }
 
     path(): string[] {

--- a/api-editor/client/src/features/packageData/model/PythonFunction.ts
+++ b/api-editor/client/src/features/packageData/model/PythonFunction.ts
@@ -62,6 +62,10 @@ export default class PythonFunction extends PythonDeclaration {
         return this.parameters;
     }
 
+    isPublicDeclaration(): boolean {
+        return this.isPublic
+    }
+
     getUniqueName(): string {
         return this.uniqueName;
     }

--- a/api-editor/client/src/features/packageData/model/PythonFunction.ts
+++ b/api-editor/client/src/features/packageData/model/PythonFunction.ts
@@ -63,7 +63,7 @@ export default class PythonFunction extends PythonDeclaration {
     }
 
     isPublicDeclaration(): boolean {
-        return this.isPublic
+        return this.isPublic;
     }
 
     getUniqueName(): string {

--- a/api-editor/client/src/features/packageData/model/PythonParameter.ts
+++ b/api-editor/client/src/features/packageData/model/PythonParameter.ts
@@ -49,6 +49,10 @@ export default class PythonParameter extends PythonDeclaration {
         return [];
     }
 
+    isPublicDeclaration(): boolean {
+        return this.isPublic
+    }
+
     isExplicitParameter(): boolean {
         const containingFunction = this.parent();
         if (!containingFunction) {

--- a/api-editor/client/src/features/packageData/model/PythonParameter.ts
+++ b/api-editor/client/src/features/packageData/model/PythonParameter.ts
@@ -50,7 +50,7 @@ export default class PythonParameter extends PythonDeclaration {
     }
 
     isPublicDeclaration(): boolean {
-        return this.isPublic
+        return this.isPublic;
     }
 
     isExplicitParameter(): boolean {

--- a/api-editor/client/src/features/packageData/packageDataSlice.ts
+++ b/api-editor/client/src/features/packageData/packageDataSlice.ts
@@ -7,6 +7,7 @@ export interface PackageDataState {
     };
     treeViewScrollOffset: number;
     showImportDialog: boolean;
+    showPrivateDeclarations: boolean;
 }
 
 // Initial state -------------------------------------------------------------------------------------------------------
@@ -15,6 +16,7 @@ const initialState: PackageDataState = {
     expandedInTreeView: {},
     treeViewScrollOffset: 0,
     showImportDialog: false,
+    showPrivateDeclarations: false,
 };
 
 // Slice ---------------------------------------------------------------------------------------------------------------
@@ -36,6 +38,9 @@ const packageDataSlice = createSlice({
         toggleImportDialog(state) {
             state.showImportDialog = !state.showImportDialog;
         },
+        toggleShowPrivateDeclarations(state) {
+            state.showPrivateDeclarations = !state.showPrivateDeclarations
+        }
     },
 });
 
@@ -44,6 +49,7 @@ export const {
     toggleIsExpanded: toggleIsExpandedInTreeView,
     setScrollOffset: setTreeViewScrollOffset,
     toggleImportDialog: togglePackageDataImportDialog,
+    toggleShowPrivateDeclarations,
 } = actions;
 export default reducer;
 
@@ -59,3 +65,5 @@ export const selectTreeViewScrollOffset = (state: RootState): number =>
     selectPackageData(state).treeViewScrollOffset;
 export const selectShowPackageDataImportDialog = (state: RootState): boolean =>
     selectPackageData(state).showImportDialog;
+export const selectShowPrivateDeclarations = (state: RootState): boolean =>
+    selectPackageData(state).showPrivateDeclarations;

--- a/api-editor/client/src/features/packageData/packageDataSlice.ts
+++ b/api-editor/client/src/features/packageData/packageDataSlice.ts
@@ -39,8 +39,8 @@ const packageDataSlice = createSlice({
             state.showImportDialog = !state.showImportDialog;
         },
         toggleShowPrivateDeclarations(state) {
-            state.showPrivateDeclarations = !state.showPrivateDeclarations
-        }
+            state.showPrivateDeclarations = !state.showPrivateDeclarations;
+        },
     },
 });
 

--- a/api-editor/client/src/features/packageData/selectionView/ClassView.tsx
+++ b/api-editor/client/src/features/packageData/selectionView/ClassView.tsx
@@ -24,16 +24,17 @@ const ClassView: React.FC<ClassViewProps> = function ({ pythonClass }) {
             <Stack spacing={4}>
                 <HStack>
                     <Heading as="h3" size="lg">
-                        {pythonClass.name} {!pythonClass.isPublic && '(private)'}
+                        {pythonClass.name}{' '}
+                        {!pythonClass.isPublic && '(private)'}
                     </Heading>
-                    {pythonClass.isPublic &&
+                    {pythonClass.isPublic && (
                         <AnnotationDropdown
                             target={id}
                             showMove
                             showRename
                             showUnused
                         />
-                    }
+                    )}
                 </HStack>
 
                 <AnnotationView target={id} />

--- a/api-editor/client/src/features/packageData/selectionView/ClassView.tsx
+++ b/api-editor/client/src/features/packageData/selectionView/ClassView.tsx
@@ -24,14 +24,16 @@ const ClassView: React.FC<ClassViewProps> = function ({ pythonClass }) {
             <Stack spacing={4}>
                 <HStack>
                     <Heading as="h3" size="lg">
-                        {pythonClass.name}
+                        {pythonClass.name} {!pythonClass.isPublic && '(private)'}
                     </Heading>
-                    <AnnotationDropdown
-                        target={id}
-                        showMove
-                        showRename
-                        showUnused
-                    />
+                    {pythonClass.isPublic &&
+                        <AnnotationDropdown
+                            target={id}
+                            showMove
+                            showRename
+                            showUnused
+                        />
+                    }
                 </HStack>
 
                 <AnnotationView target={id} />

--- a/api-editor/client/src/features/packageData/selectionView/FunctionView.tsx
+++ b/api-editor/client/src/features/packageData/selectionView/FunctionView.tsx
@@ -38,22 +38,24 @@ const FunctionView: React.FC<FunctionViewProps> = function ({
             <Stack spacing={4}>
                 <HStack>
                     <Heading as="h3" size="lg">
-                        {pythonFunction.name}
+                        {pythonFunction.name} {!pythonFunction.isPublic && '(private)'}
                     </Heading>
-                    <AnnotationDropdown
-                        target={id}
-                        showCalledAfter={hasRemainingCalledAfters}
-                        showGroup={
-                            pythonFunction.explicitParameters().length >= 2
-                        }
-                        showMove={
-                            pythonFunction.containingModuleOrClass instanceof
-                            PythonModule
-                        }
-                        showPure
-                        showRename
-                        showUnused
-                    />
+                    {pythonFunction.isPublic &&
+                        <AnnotationDropdown
+                            target={id}
+                            showCalledAfter={hasRemainingCalledAfters}
+                            showGroup={
+                                pythonFunction.explicitParameters().length >= 2
+                            }
+                            showMove={
+                                pythonFunction.containingModuleOrClass instanceof
+                                PythonModule
+                            }
+                            showPure
+                            showRename
+                            showUnused
+                        />
+                    }
                 </HStack>
 
                 <AnnotationView target={id} />

--- a/api-editor/client/src/features/packageData/selectionView/FunctionView.tsx
+++ b/api-editor/client/src/features/packageData/selectionView/FunctionView.tsx
@@ -38,9 +38,10 @@ const FunctionView: React.FC<FunctionViewProps> = function ({
             <Stack spacing={4}>
                 <HStack>
                     <Heading as="h3" size="lg">
-                        {pythonFunction.name} {!pythonFunction.isPublic && '(private)'}
+                        {pythonFunction.name}{' '}
+                        {!pythonFunction.isPublic && '(private)'}
                     </Heading>
-                    {pythonFunction.isPublic &&
+                    {pythonFunction.isPublic && (
                         <AnnotationDropdown
                             target={id}
                             showCalledAfter={hasRemainingCalledAfters}
@@ -55,7 +56,7 @@ const FunctionView: React.FC<FunctionViewProps> = function ({
                             showRename
                             showUnused
                         />
-                    }
+                    )}
                 </HStack>
 
                 <AnnotationView target={id} />

--- a/api-editor/client/src/features/packageData/selectionView/ParameterNode.tsx
+++ b/api-editor/client/src/features/packageData/selectionView/ParameterNode.tsx
@@ -31,14 +31,14 @@ const ParameterNode: React.FC<ParameterNodeProps> = function ({
             <HStack>
                 {isTitle ? (
                     <Heading as="h3" size="lg">
-                        {pythonParameter.name}
+                        {pythonParameter.name} {!pythonParameter.isPublic && '(private)'}
                     </Heading>
                 ) : (
                     <Heading as="h4" size="sm">
-                        {pythonParameter.name}
+                        {pythonParameter.name} {!pythonParameter.isPublic && '(private)'}
                     </Heading>
                 )}
-                {isExplicitParameter && (
+                {pythonParameter.isPublic && isExplicitParameter && (
                     <AnnotationDropdown
                         target={id}
                         showAttribute={isConstructorParameter}

--- a/api-editor/client/src/features/packageData/selectionView/ParameterNode.tsx
+++ b/api-editor/client/src/features/packageData/selectionView/ParameterNode.tsx
@@ -31,11 +31,13 @@ const ParameterNode: React.FC<ParameterNodeProps> = function ({
             <HStack>
                 {isTitle ? (
                     <Heading as="h3" size="lg">
-                        {pythonParameter.name} {!pythonParameter.isPublic && '(private)'}
+                        {pythonParameter.name}{' '}
+                        {!pythonParameter.isPublic && '(private)'}
                     </Heading>
                 ) : (
                     <Heading as="h4" size="sm">
-                        {pythonParameter.name} {!pythonParameter.isPublic && '(private)'}
+                        {pythonParameter.name}{' '}
+                        {!pythonParameter.isPublic && '(private)'}
                     </Heading>
                 )}
                 {pythonParameter.isPublic && isExplicitParameter && (

--- a/api-editor/client/src/features/packageData/treeView/ClassNode.tsx
+++ b/api-editor/client/src/features/packageData/treeView/ClassNode.tsx
@@ -3,17 +3,17 @@ import { FaChalkboard } from 'react-icons/fa';
 import { isEmptyList } from '../../../common/util/listOperations';
 import PythonClass from '../model/PythonClass';
 import TreeNode from './TreeNode';
-import {useAppSelector} from "../../../app/hooks";
-import {selectShowPrivateDeclarations} from "../packageDataSlice";
+import { useAppSelector } from '../../../app/hooks';
+import { selectShowPrivateDeclarations } from '../packageDataSlice';
 
 interface ClassNodeProps {
     pythonClass: PythonClass;
 }
 
 const ClassNode: React.FC<ClassNodeProps> = function ({ pythonClass }) {
-    let methods = pythonClass.methods
+    let methods = pythonClass.methods;
     if (!useAppSelector(selectShowPrivateDeclarations)) {
-        methods = methods.filter((it) => it.isPublic)
+        methods = methods.filter((it) => it.isPublic);
     }
     const hasMethods = !isEmptyList(methods);
 

--- a/api-editor/client/src/features/packageData/treeView/ClassNode.tsx
+++ b/api-editor/client/src/features/packageData/treeView/ClassNode.tsx
@@ -3,13 +3,19 @@ import { FaChalkboard } from 'react-icons/fa';
 import { isEmptyList } from '../../../common/util/listOperations';
 import PythonClass from '../model/PythonClass';
 import TreeNode from './TreeNode';
+import {useAppSelector} from "../../../app/hooks";
+import {selectShowPrivateDeclarations} from "../packageDataSlice";
 
 interface ClassNodeProps {
     pythonClass: PythonClass;
 }
 
 const ClassNode: React.FC<ClassNodeProps> = function ({ pythonClass }) {
-    const hasMethods = !isEmptyList(pythonClass.methods);
+    let methods = pythonClass.methods
+    if (!useAppSelector(selectShowPrivateDeclarations)) {
+        methods = methods.filter((it) => it.isPublic)
+    }
+    const hasMethods = !isEmptyList(methods);
 
     return (
         <TreeNode

--- a/api-editor/client/src/features/packageData/treeView/FunctionNode.tsx
+++ b/api-editor/client/src/features/packageData/treeView/FunctionNode.tsx
@@ -3,6 +3,8 @@ import { FaCogs } from 'react-icons/fa';
 import { isEmptyList } from '../../../common/util/listOperations';
 import PythonFunction from '../model/PythonFunction';
 import TreeNode from './TreeNode';
+import {useAppSelector} from "../../../app/hooks";
+import {selectShowPrivateDeclarations} from "../packageDataSlice";
 
 interface FunctionNodeProps {
     pythonFunction: PythonFunction;
@@ -11,7 +13,11 @@ interface FunctionNodeProps {
 const FunctionNode: React.FC<FunctionNodeProps> = function ({
     pythonFunction,
 }) {
-    const hasParameters = !isEmptyList(pythonFunction.parameters);
+    let parameters = pythonFunction.parameters
+    if (!useAppSelector(selectShowPrivateDeclarations)) {
+        parameters = parameters.filter((it) => it.isPublic)
+    }
+    const hasParameters = !isEmptyList(parameters);
 
     return (
         <TreeNode

--- a/api-editor/client/src/features/packageData/treeView/FunctionNode.tsx
+++ b/api-editor/client/src/features/packageData/treeView/FunctionNode.tsx
@@ -3,8 +3,8 @@ import { FaCogs } from 'react-icons/fa';
 import { isEmptyList } from '../../../common/util/listOperations';
 import PythonFunction from '../model/PythonFunction';
 import TreeNode from './TreeNode';
-import {useAppSelector} from "../../../app/hooks";
-import {selectShowPrivateDeclarations} from "../packageDataSlice";
+import { useAppSelector } from '../../../app/hooks';
+import { selectShowPrivateDeclarations } from '../packageDataSlice';
 
 interface FunctionNodeProps {
     pythonFunction: PythonFunction;
@@ -13,9 +13,9 @@ interface FunctionNodeProps {
 const FunctionNode: React.FC<FunctionNodeProps> = function ({
     pythonFunction,
 }) {
-    let parameters = pythonFunction.parameters
+    let parameters = pythonFunction.parameters;
     if (!useAppSelector(selectShowPrivateDeclarations)) {
-        parameters = parameters.filter((it) => it.isPublic)
+        parameters = parameters.filter((it) => it.isPublic);
     }
     const hasParameters = !isEmptyList(parameters);
 

--- a/api-editor/client/src/features/packageData/treeView/ModuleNode.tsx
+++ b/api-editor/client/src/features/packageData/treeView/ModuleNode.tsx
@@ -3,14 +3,24 @@ import { FaArchive } from 'react-icons/fa';
 import { isEmptyList } from '../../../common/util/listOperations';
 import PythonModule from '../model/PythonModule';
 import TreeNode from './TreeNode';
+import {useAppSelector} from "../../../app/hooks";
+import {selectShowPrivateDeclarations} from "../packageDataSlice";
 
 interface ModuleNodeProps {
     pythonModule: PythonModule;
 }
 
 const ModuleNode: React.FC<ModuleNodeProps> = function ({ pythonModule }) {
-    const hasClasses = !isEmptyList(pythonModule.classes);
-    const hasFunctions = !isEmptyList(pythonModule.functions);
+    let classes = pythonModule.classes
+    if (!useAppSelector(selectShowPrivateDeclarations)) {
+        classes = classes.filter((it) => it.isPublic)
+    }
+    const hasClasses = !isEmptyList(classes);
+    let functions = pythonModule.functions
+    if (!useAppSelector(selectShowPrivateDeclarations)) {
+        functions = functions.filter((it) => it.isPublic)
+    }
+    const hasFunctions = !isEmptyList(functions);
     const hasChildren = hasClasses || hasFunctions;
 
     return (

--- a/api-editor/client/src/features/packageData/treeView/ModuleNode.tsx
+++ b/api-editor/client/src/features/packageData/treeView/ModuleNode.tsx
@@ -3,22 +3,22 @@ import { FaArchive } from 'react-icons/fa';
 import { isEmptyList } from '../../../common/util/listOperations';
 import PythonModule from '../model/PythonModule';
 import TreeNode from './TreeNode';
-import {useAppSelector} from "../../../app/hooks";
-import {selectShowPrivateDeclarations} from "../packageDataSlice";
+import { useAppSelector } from '../../../app/hooks';
+import { selectShowPrivateDeclarations } from '../packageDataSlice';
 
 interface ModuleNodeProps {
     pythonModule: PythonModule;
 }
 
 const ModuleNode: React.FC<ModuleNodeProps> = function ({ pythonModule }) {
-    let classes = pythonModule.classes
+    let classes = pythonModule.classes;
     if (!useAppSelector(selectShowPrivateDeclarations)) {
-        classes = classes.filter((it) => it.isPublic)
+        classes = classes.filter((it) => it.isPublic);
     }
     const hasClasses = !isEmptyList(classes);
-    let functions = pythonModule.functions
+    let functions = pythonModule.functions;
     if (!useAppSelector(selectShowPrivateDeclarations)) {
-        functions = functions.filter((it) => it.isPublic)
+        functions = functions.filter((it) => it.isPublic);
     }
     const hasFunctions = !isEmptyList(functions);
     const hasChildren = hasClasses || hasFunctions;

--- a/api-editor/client/src/features/packageData/treeView/TreeView.tsx
+++ b/api-editor/client/src/features/packageData/treeView/TreeView.tsx
@@ -1,8 +1,8 @@
-import { Box } from '@chakra-ui/react';
-import React, { memo, useCallback, useEffect, useRef } from 'react';
+import {Box} from '@chakra-ui/react';
+import React, {memo, useCallback, useEffect, useRef} from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { FixedSizeList, ListChildComponentProps } from 'react-window';
-import { useAppDispatch, useAppSelector } from '../../../app/hooks';
+import {FixedSizeList, ListChildComponentProps} from 'react-window';
+import {useAppDispatch, useAppSelector} from '../../../app/hooks';
 import PythonClass from '../model/PythonClass';
 import PythonDeclaration from '../model/PythonDeclaration';
 import PythonFunction from '../model/PythonFunction';
@@ -11,6 +11,7 @@ import PythonPackage from '../model/PythonPackage';
 import PythonParameter from '../model/PythonParameter';
 import {
     selectAllExpandedInTreeView,
+    selectShowPrivateDeclarations,
     selectTreeViewScrollOffset,
     setTreeViewScrollOffset,
 } from '../packageDataSlice';
@@ -27,11 +28,14 @@ interface TreeViewProps {
     pythonPackage: PythonPackage;
 }
 
-const TreeView: React.FC<TreeViewProps> = memo(({ pythonPackage }) => {
+const TreeView: React.FC<TreeViewProps> = memo(({pythonPackage}) => {
     const dispatch = useAppDispatch();
     const allExpanded = useAppSelector(selectAllExpandedInTreeView);
 
-    const children = walkChildrenInPreorder(allExpanded, pythonPackage);
+    let children = walkChildrenInPreorder(allExpanded, pythonPackage);
+    if (!useAppSelector(selectShowPrivateDeclarations)) {
+        children = children.filter((it) => it.isPublicDeclaration())
+    }
     const previousScrollOffset = useAppSelector(selectTreeViewScrollOffset);
 
     // Keep a reference to the last FixedSizeList before everything is dismounted
@@ -63,7 +67,7 @@ const TreeView: React.FC<TreeViewProps> = memo(({ pythonPackage }) => {
 
     return (
         <AutoSizer disableWidth>
-            {({ height }) => (
+            {({height}) => (
                 <FixedSizeList
                     itemSize={24}
                     itemCount={children.length}
@@ -89,35 +93,37 @@ const walkChildrenInPreorder = function (
     allExpandedItemsInTreeView: { [target: string]: true },
     declaration: PythonDeclaration,
 ): PythonDeclaration[] {
-    return declaration.children().flatMap((it) => {
-        if (allExpandedItemsInTreeView[it.pathAsString()]) {
-            return [
-                it,
-                ...walkChildrenInPreorder(allExpandedItemsInTreeView, it),
-            ];
-        } else {
-            return [it];
-        }
-    });
+    return declaration
+        .children()
+        .flatMap((it) => {
+            if (allExpandedItemsInTreeView[it.pathAsString()]) {
+                return [
+                    it,
+                    ...walkChildrenInPreorder(allExpandedItemsInTreeView, it),
+                ];
+            } else {
+                return [it];
+            }
+        });
 };
 
 const TreeNodeGenerator: React.FC<ListChildComponentProps> = memo(
-    ({ data, index, style }) => {
+    ({data, index, style}) => {
         const declaration = data[index];
 
         return (
             <Box style={style}>
                 {declaration instanceof PythonModule && (
-                    <ModuleNode pythonModule={declaration} />
+                    <ModuleNode pythonModule={declaration}/>
                 )}
                 {declaration instanceof PythonClass && (
-                    <ClassNode pythonClass={declaration} />
+                    <ClassNode pythonClass={declaration}/>
                 )}
                 {declaration instanceof PythonFunction && (
-                    <FunctionNode pythonFunction={declaration} />
+                    <FunctionNode pythonFunction={declaration}/>
                 )}
                 {declaration instanceof PythonParameter && (
-                    <ParameterNode pythonParameter={declaration} />
+                    <ParameterNode pythonParameter={declaration}/>
                 )}
             </Box>
         );

--- a/api-editor/client/src/features/packageData/treeView/TreeView.tsx
+++ b/api-editor/client/src/features/packageData/treeView/TreeView.tsx
@@ -1,8 +1,8 @@
-import {Box} from '@chakra-ui/react';
-import React, {memo, useCallback, useEffect, useRef} from 'react';
+import { Box } from '@chakra-ui/react';
+import React, { memo, useCallback, useEffect, useRef } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import {FixedSizeList, ListChildComponentProps} from 'react-window';
-import {useAppDispatch, useAppSelector} from '../../../app/hooks';
+import { FixedSizeList, ListChildComponentProps } from 'react-window';
+import { useAppDispatch, useAppSelector } from '../../../app/hooks';
 import PythonClass from '../model/PythonClass';
 import PythonDeclaration from '../model/PythonDeclaration';
 import PythonFunction from '../model/PythonFunction';
@@ -28,13 +28,13 @@ interface TreeViewProps {
     pythonPackage: PythonPackage;
 }
 
-const TreeView: React.FC<TreeViewProps> = memo(({pythonPackage}) => {
+const TreeView: React.FC<TreeViewProps> = memo(({ pythonPackage }) => {
     const dispatch = useAppDispatch();
     const allExpanded = useAppSelector(selectAllExpandedInTreeView);
 
     let children = walkChildrenInPreorder(allExpanded, pythonPackage);
     if (!useAppSelector(selectShowPrivateDeclarations)) {
-        children = children.filter((it) => it.isPublicDeclaration())
+        children = children.filter((it) => it.isPublicDeclaration());
     }
     const previousScrollOffset = useAppSelector(selectTreeViewScrollOffset);
 
@@ -67,7 +67,7 @@ const TreeView: React.FC<TreeViewProps> = memo(({pythonPackage}) => {
 
     return (
         <AutoSizer disableWidth>
-            {({height}) => (
+            {({ height }) => (
                 <FixedSizeList
                     itemSize={24}
                     itemCount={children.length}
@@ -93,37 +93,35 @@ const walkChildrenInPreorder = function (
     allExpandedItemsInTreeView: { [target: string]: true },
     declaration: PythonDeclaration,
 ): PythonDeclaration[] {
-    return declaration
-        .children()
-        .flatMap((it) => {
-            if (allExpandedItemsInTreeView[it.pathAsString()]) {
-                return [
-                    it,
-                    ...walkChildrenInPreorder(allExpandedItemsInTreeView, it),
-                ];
-            } else {
-                return [it];
-            }
-        });
+    return declaration.children().flatMap((it) => {
+        if (allExpandedItemsInTreeView[it.pathAsString()]) {
+            return [
+                it,
+                ...walkChildrenInPreorder(allExpandedItemsInTreeView, it),
+            ];
+        } else {
+            return [it];
+        }
+    });
 };
 
 const TreeNodeGenerator: React.FC<ListChildComponentProps> = memo(
-    ({data, index, style}) => {
+    ({ data, index, style }) => {
         const declaration = data[index];
 
         return (
             <Box style={style}>
                 {declaration instanceof PythonModule && (
-                    <ModuleNode pythonModule={declaration}/>
+                    <ModuleNode pythonModule={declaration} />
                 )}
                 {declaration instanceof PythonClass && (
-                    <ClassNode pythonClass={declaration}/>
+                    <ClassNode pythonClass={declaration} />
                 )}
                 {declaration instanceof PythonFunction && (
-                    <FunctionNode pythonFunction={declaration}/>
+                    <FunctionNode pythonFunction={declaration} />
                 )}
                 {declaration instanceof PythonParameter && (
-                    <ParameterNode pythonParameter={declaration}/>
+                    <ParameterNode pythonParameter={declaration} />
                 )}
             </Box>
         );


### PR DESCRIPTION
Closes #400.

### Summary of Changes

* Don't show private declarations in tree view by default
* Add toggle in menu bar to show them anyway
* Always prevent annotating private API elements
* Add a marker `(private)` to private declarations in the details view

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/154478355-f2defb8a-462d-40f3-bf42-4a77193eefc1.png)

![image](https://user-images.githubusercontent.com/2501322/154478391-37376bcd-262e-41fd-bbdd-19b080c5265e.png)

### Testing instructions

1. Check the functionality of the `Show private declarations` button in the menu bar
