### PR TITLE
refactor: use TypeScript parameter properties

### DIFF
--- a/api-editor/client/src/features/annotatedPackageData/model/AnnotatedPythonClass.ts
+++ b/api-editor/client/src/features/annotatedPackageData/model/AnnotatedPythonClass.ts
@@ -1,36 +1,16 @@
-import { InferableAnnotation } from './InferableAnnotation';
+import {InferableAnnotation} from './InferableAnnotation';
 import AnnotatedPythonFunction from './AnnotatedPythonFunction';
 
 export default class AnnotatedPythonClass {
-    readonly name: string;
-    readonly qualifiedName: string;
-    readonly decorators: string[];
-    readonly superclasses: string[];
-    readonly methods: AnnotatedPythonFunction[];
-    readonly isPublic: boolean;
-    readonly description: string;
-    readonly fullDocstring: string;
-    readonly annotations: InferableAnnotation[];
-
     constructor(
-        name: string,
-        qualifiedName: string,
-        decorators: string[] = [],
-        superclasses: string[] = [],
-        methods: AnnotatedPythonFunction[] = [],
-        isPublic: boolean = true,
-        description: string = '',
-        fullDocstring: string = '',
-        annotations: InferableAnnotation[] = [],
-    ) {
-        this.name = name;
-        this.qualifiedName = qualifiedName;
-        this.decorators = decorators;
-        this.superclasses = superclasses;
-        this.methods = methods;
-        this.isPublic = isPublic;
-        this.description = description;
-        this.fullDocstring = fullDocstring;
-        this.annotations = annotations;
-    }
+        readonly name: string,
+        readonly qualifiedName: string,
+        readonly decorators: string[] = [],
+        readonly superclasses: string[] = [],
+        readonly methods: AnnotatedPythonFunction[] = [],
+        readonly isPublic: boolean = true,
+        readonly description: string = '',
+        readonly fullDocstring: string = '',
+        readonly annotations: InferableAnnotation[] = [],
+    ) {}
 }

--- a/api-editor/client/src/features/annotatedPackageData/model/AnnotatedPythonClass.ts
+++ b/api-editor/client/src/features/annotatedPackageData/model/AnnotatedPythonClass.ts
@@ -1,4 +1,4 @@
-import {InferableAnnotation} from './InferableAnnotation';
+import { InferableAnnotation } from './InferableAnnotation';
 import AnnotatedPythonFunction from './AnnotatedPythonFunction';
 
 export default class AnnotatedPythonClass {

--- a/api-editor/client/src/features/annotatedPackageData/model/AnnotatedPythonFunction.ts
+++ b/api-editor/client/src/features/annotatedPackageData/model/AnnotatedPythonFunction.ts
@@ -3,35 +3,15 @@ import AnnotatedPythonParameter from './AnnotatedPythonParameter';
 import AnnotatedPythonResult from './AnnotatedPythonResult';
 
 export default class AnnotatedPythonFunction {
-    readonly name: string;
-    readonly qualifiedName: string;
-    readonly decorators: string[];
-    readonly parameters: AnnotatedPythonParameter[];
-    readonly results: AnnotatedPythonResult[];
-    readonly isPublic: boolean;
-    readonly description: string;
-    readonly fullDocstring: string;
-    readonly annotations: InferableAnnotation[];
-
     constructor(
-        name: string,
-        qualifiedName: string,
-        decorators: string[] = [],
-        parameters: AnnotatedPythonParameter[] = [],
-        results: AnnotatedPythonResult[] = [],
-        isPublic: boolean = false,
-        description: string = '',
-        fullDocstring: string = '',
-        annotations: InferableAnnotation[] = [],
-    ) {
-        this.name = name;
-        this.qualifiedName = qualifiedName;
-        this.decorators = decorators;
-        this.parameters = parameters;
-        this.results = results;
-        this.isPublic = isPublic;
-        this.description = description;
-        this.fullDocstring = fullDocstring;
-        this.annotations = annotations;
-    }
+        readonly name: string,
+        readonly qualifiedName: string,
+        readonly decorators: string[] = [],
+        readonly parameters: AnnotatedPythonParameter[] = [],
+        readonly results: AnnotatedPythonResult[] = [],
+        readonly isPublic: boolean = false,
+        readonly description: string = '',
+        readonly fullDocstring: string = '',
+        readonly annotations: InferableAnnotation[] = [],
+    ) {}
 }

--- a/api-editor/client/src/features/annotatedPackageData/model/AnnotatedPythonModule.ts
+++ b/api-editor/client/src/features/annotatedPackageData/model/AnnotatedPythonModule.ts
@@ -5,26 +5,12 @@ import AnnotatedPythonClass from './AnnotatedPythonClass';
 import AnnotatedPythonFunction from './AnnotatedPythonFunction';
 
 export default class AnnotatedPythonModule {
-    readonly name: string;
-    readonly imports: PythonImport[];
-    readonly fromImports: PythonFromImport[];
-    readonly classes: AnnotatedPythonClass[];
-    readonly functions: AnnotatedPythonFunction[];
-    readonly annotations: InferableAnnotation[];
-
     constructor(
-        name: string,
-        imports: PythonImport[] = [],
-        fromImports: PythonFromImport[] = [],
-        classes: AnnotatedPythonClass[] = [],
-        functions: AnnotatedPythonFunction[] = [],
-        annotations: InferableAnnotation[] = [],
-    ) {
-        this.name = name;
-        this.imports = imports;
-        this.fromImports = fromImports;
-        this.classes = classes;
-        this.functions = functions;
-        this.annotations = annotations;
-    }
+        readonly name: string,
+        readonly imports: PythonImport[] = [],
+        readonly fromImports: PythonFromImport[] = [],
+        readonly classes: AnnotatedPythonClass[] = [],
+        readonly functions: AnnotatedPythonFunction[] = [],
+        readonly annotations: InferableAnnotation[] = [],
+    ) {}
 }

--- a/api-editor/client/src/features/annotatedPackageData/model/AnnotatedPythonPackage.ts
+++ b/api-editor/client/src/features/annotatedPackageData/model/AnnotatedPythonPackage.ts
@@ -2,23 +2,11 @@ import { InferableAnnotation } from './InferableAnnotation';
 import AnnotatedPythonModule from './AnnotatedPythonModule';
 
 export default class AnnotatedPythonPackage {
-    readonly distribution: string;
-    readonly name: string;
-    readonly version: string;
-    readonly modules: AnnotatedPythonModule[];
-    readonly annotations: InferableAnnotation[];
-
     constructor(
-        distribution: string,
-        name: string,
-        version: string,
-        modules: AnnotatedPythonModule[] = [],
-        annotations: InferableAnnotation[] = [],
-    ) {
-        this.distribution = distribution;
-        this.name = name;
-        this.version = version;
-        this.modules = modules;
-        this.annotations = annotations;
-    }
+        readonly distribution: string,
+        readonly name: string,
+        readonly version: string,
+        readonly modules: AnnotatedPythonModule[] = [],
+        readonly annotations: InferableAnnotation[] = [],
+    ) {}
 }

--- a/api-editor/client/src/features/annotatedPackageData/model/AnnotatedPythonResult.ts
+++ b/api-editor/client/src/features/annotatedPackageData/model/AnnotatedPythonResult.ts
@@ -1,23 +1,11 @@
 import { InferableAnnotation } from './InferableAnnotation';
 
 export default class AnnotatedPythonResult {
-    readonly name: string;
-    readonly type: string;
-    readonly typeInDocs: string;
-    readonly description: string;
-    readonly annotations: InferableAnnotation[];
-
     constructor(
-        name: string,
-        type: string = 'Any',
-        typeInDocs: string = '',
-        description: string = '',
-        annotations: InferableAnnotation[] = [],
-    ) {
-        this.name = name;
-        this.type = type;
-        this.typeInDocs = typeInDocs;
-        this.description = description;
-        this.annotations = annotations;
-    }
+        readonly name: string,
+        readonly type: string = 'Any',
+        readonly typeInDocs: string = '',
+        readonly description: string = '',
+        readonly annotations: InferableAnnotation[] = [],
+    ) {}
 }

--- a/api-editor/client/src/features/packageData/model/PythonClass.ts
+++ b/api-editor/client/src/features/packageData/model/PythonClass.ts
@@ -6,36 +6,20 @@ import PythonFunction from './PythonFunction';
 import PythonModule from './PythonModule';
 
 export default class PythonClass extends PythonDeclaration {
-    readonly name: string;
-    readonly qualifiedName: string;
-    readonly decorators: string[];
-    readonly superclasses: string[];
-    readonly methods: PythonFunction[];
-    readonly isPublic: boolean;
-    readonly description: string;
-    readonly fullDocstring: string;
     containingModule: Optional<PythonModule>;
 
     constructor(
-        name: string,
-        qualifiedName: string,
-        decorators: string[] = [],
-        superclasses: string[] = [],
-        methods: PythonFunction[] = [],
-        isPublic: boolean = true,
-        description = '',
-        fullDocstring = '',
+        readonly name: string,
+        readonly qualifiedName: string,
+        readonly decorators: string[] = [],
+        readonly superclasses: string[] = [],
+        readonly methods: PythonFunction[] = [],
+        readonly isPublic: boolean = true,
+        readonly description = '',
+        readonly fullDocstring = '',
     ) {
         super();
 
-        this.name = name;
-        this.qualifiedName = qualifiedName;
-        this.decorators = decorators;
-        this.superclasses = superclasses;
-        this.methods = methods;
-        this.isPublic = isPublic;
-        this.description = description;
-        this.fullDocstring = fullDocstring;
         this.containingModule = null;
 
         this.methods.forEach((it) => {

--- a/api-editor/client/src/features/packageData/model/PythonFilter.ts
+++ b/api-editor/client/src/features/packageData/model/PythonFilter.ts
@@ -1,22 +1,12 @@
 export type FilterString = string;
 
 export class PythonFilter {
-    readonly pythonModule: FilterString | void;
-    readonly pythonClass: FilterString | void;
-    readonly pythonFunction: FilterString | void;
-    readonly pythonParameter: FilterString | void;
-
     constructor(
-        pythonModule: FilterString | void,
-        pythonClass: FilterString | void,
-        pythonFunction: FilterString | void,
-        pythonParameter: FilterString | void,
-    ) {
-        this.pythonModule = pythonModule;
-        this.pythonClass = pythonClass;
-        this.pythonFunction = pythonFunction;
-        this.pythonParameter = pythonParameter;
-    }
+        readonly pythonModule: FilterString | void,
+        readonly pythonClass: FilterString | void,
+        readonly pythonFunction: FilterString | void,
+        readonly pythonParameter: FilterString | void,
+    ) {}
 
     static fromFilterBoxInput(filterBoxInput: string): PythonFilter | void {
         let pythonModule;

--- a/api-editor/client/src/features/packageData/model/PythonFromImport.ts
+++ b/api-editor/client/src/features/packageData/model/PythonFromImport.ts
@@ -1,19 +1,11 @@
 import { Optional } from '../../../common/util/types';
 
 export default class PythonFromImport {
-    readonly module: string;
-    readonly declaration: string;
-    readonly alias: Optional<string>;
-
     constructor(
-        module: string,
-        declaration: string,
-        alias: Optional<string> = null,
-    ) {
-        this.module = module;
-        this.declaration = declaration;
-        this.alias = alias;
-    }
+        readonly module: string,
+        readonly declaration: string,
+        readonly alias: Optional<string> = null,
+    ) {}
 
     toString(): string {
         if (this.alias === null) {

--- a/api-editor/client/src/features/packageData/model/PythonFunction.ts
+++ b/api-editor/client/src/features/packageData/model/PythonFunction.ts
@@ -7,42 +7,22 @@ import PythonParameter from './PythonParameter';
 import PythonResult from './PythonResult';
 
 export default class PythonFunction extends PythonDeclaration {
-    readonly name: string;
-    readonly uniqueName: string;
-    readonly qualifiedName: string;
-    readonly uniqueQualifiedName: string;
-    readonly decorators: string[];
-    readonly parameters: PythonParameter[];
-    readonly results: PythonResult[];
-    readonly isPublic: boolean;
-    readonly description: string;
-    readonly fullDocstring: string;
     containingModuleOrClass: Optional<PythonModule | PythonClass>;
 
     constructor(
-        name: string,
-        uniqueName: string,
-        qualifiedName: string,
-        uniqueQualifiedName: string,
-        decorators: string[] = [],
-        parameters: PythonParameter[] = [],
-        results: PythonResult[] = [],
-        isPublic: boolean = false,
-        description = '',
-        fullDocstring = '',
+        readonly name: string,
+        readonly uniqueName: string,
+        readonly qualifiedName: string,
+        readonly uniqueQualifiedName: string,
+        readonly decorators: string[] = [],
+        readonly parameters: PythonParameter[] = [],
+        readonly results: PythonResult[] = [],
+        readonly isPublic: boolean = false,
+        readonly description = '',
+        readonly fullDocstring = '',
     ) {
         super();
 
-        this.name = name;
-        this.uniqueName = uniqueName;
-        this.qualifiedName = qualifiedName;
-        this.uniqueQualifiedName = uniqueQualifiedName;
-        this.decorators = decorators;
-        this.parameters = parameters;
-        this.results = results;
-        this.isPublic = isPublic;
-        this.description = description;
-        this.fullDocstring = fullDocstring;
         this.containingModuleOrClass = null;
 
         this.parameters.forEach((it) => {

--- a/api-editor/client/src/features/packageData/model/PythonImport.ts
+++ b/api-editor/client/src/features/packageData/model/PythonImport.ts
@@ -3,7 +3,7 @@ import { Optional } from '../../../common/util/types';
 export default class PythonImport {
     constructor(
         readonly module: string,
-        readonly alias: Optional<string> = null
+        readonly alias: Optional<string> = null,
     ) {}
 
     toString(): string {

--- a/api-editor/client/src/features/packageData/model/PythonImport.ts
+++ b/api-editor/client/src/features/packageData/model/PythonImport.ts
@@ -1,13 +1,10 @@
 import { Optional } from '../../../common/util/types';
 
 export default class PythonImport {
-    readonly module: string;
-    readonly alias: Optional<string>;
-
-    constructor(module: string, alias: Optional<string> = null) {
-        this.module = module;
-        this.alias = alias;
-    }
+    constructor(
+        readonly module: string,
+        readonly alias: Optional<string> = null
+    ) {}
 
     toString(): string {
         if (this.alias === null) {

--- a/api-editor/client/src/features/packageData/model/PythonModule.ts
+++ b/api-editor/client/src/features/packageData/model/PythonModule.ts
@@ -9,27 +9,17 @@ import PythonImport from './PythonImport';
 import PythonPackage from './PythonPackage';
 
 export default class PythonModule extends PythonDeclaration {
-    readonly name: string;
-    readonly imports: PythonImport[];
-    readonly fromImports: PythonFromImport[];
-    readonly classes: PythonClass[];
-    readonly functions: PythonFunction[];
     containingPackage: Optional<PythonPackage>;
 
     constructor(
-        name: string,
-        imports: PythonImport[] = [],
-        fromImports: PythonFromImport[] = [],
-        classes: PythonClass[] = [],
-        functions: PythonFunction[] = [],
+        readonly name: string,
+        readonly imports: PythonImport[] = [],
+        readonly fromImports: PythonFromImport[] = [],
+        readonly classes: PythonClass[] = [],
+        readonly functions: PythonFunction[] = [],
     ) {
         super();
 
-        this.name = name;
-        this.imports = imports;
-        this.fromImports = fromImports;
-        this.classes = classes;
-        this.functions = functions;
         this.containingPackage = null;
 
         this.classes.forEach((it) => {

--- a/api-editor/client/src/features/packageData/model/PythonPackage.ts
+++ b/api-editor/client/src/features/packageData/model/PythonPackage.ts
@@ -4,23 +4,13 @@ import { PythonFilter } from './PythonFilter';
 import PythonModule from './PythonModule';
 
 export default class PythonPackage extends PythonDeclaration {
-    readonly distribution: string;
-    readonly name: string;
-    readonly version: string;
-    readonly modules: PythonModule[];
-
     constructor(
-        distribution: string,
-        name: string,
-        version: string,
-        modules: PythonModule[] = [],
+        readonly distribution: string,
+        readonly name: string,
+        readonly version: string,
+        readonly modules: PythonModule[] = [],
     ) {
         super();
-
-        this.distribution = distribution;
-        this.name = name;
-        this.version = version;
-        this.modules = modules;
 
         this.modules.forEach((it) => {
             it.containingPackage = this;

--- a/api-editor/client/src/features/packageData/model/PythonParameter.ts
+++ b/api-editor/client/src/features/packageData/model/PythonParameter.ts
@@ -1,4 +1,4 @@
-import {Optional} from '../../../common/util/types';
+import { Optional } from '../../../common/util/types';
 import PythonDeclaration from './PythonDeclaration';
 import PythonFunction from './PythonFunction';
 import PythonModule from './PythonModule';

--- a/api-editor/client/src/features/packageData/model/PythonParameter.ts
+++ b/api-editor/client/src/features/packageData/model/PythonParameter.ts
@@ -1,4 +1,4 @@
-import { Optional } from '../../../common/util/types';
+import {Optional} from '../../../common/util/types';
 import PythonDeclaration from './PythonDeclaration';
 import PythonFunction from './PythonFunction';
 import PythonModule from './PythonModule';
@@ -10,34 +10,21 @@ export enum PythonParameterAssignment {
 }
 
 export default class PythonParameter extends PythonDeclaration {
-    readonly name: string;
-
-    /**
-     * If this is `null` or `undefined` the parameter is required.
-     */
-    readonly defaultValue: Optional<string>;
-    readonly assignedBy: PythonParameterAssignment;
-    readonly isPublic: boolean;
-    readonly typeInDocs: string;
-    readonly description: string;
     containingFunction: Optional<PythonFunction>;
 
+    /**
+     * @param defaultValue If this is `null` or `undefined` the parameter is required.
+     */
     constructor(
-        name: string,
-        defaultValue: Optional<string> = null,
-        assignedBy: PythonParameterAssignment = PythonParameterAssignment.POSITION_OR_NAME,
-        isPublic: boolean = false,
-        typeInDocs: string = '',
-        description: string = '',
+        readonly name: string,
+        readonly defaultValue: Optional<string> = null,
+        readonly assignedBy: PythonParameterAssignment = PythonParameterAssignment.POSITION_OR_NAME,
+        readonly isPublic: boolean = false,
+        readonly typeInDocs: string = '',
+        readonly description: string = '',
     ) {
         super();
 
-        this.name = name;
-        this.defaultValue = defaultValue;
-        this.assignedBy = assignedBy;
-        this.isPublic = isPublic;
-        this.typeInDocs = typeInDocs;
-        this.description = description;
         this.containingFunction = null;
     }
 

--- a/api-editor/client/src/features/packageData/model/PythonResult.ts
+++ b/api-editor/client/src/features/packageData/model/PythonResult.ts
@@ -1,21 +1,18 @@
-import { Optional } from '../../../common/util/types';
+import {Optional} from '../../../common/util/types';
 import PythonDeclaration from './PythonDeclaration';
 import PythonFunction from './PythonFunction';
 
 export default class PythonResult extends PythonDeclaration {
-    readonly name: string;
-    readonly type: string;
-    readonly typeInDocs: string;
-    readonly description: string;
     containingFunction: Optional<PythonFunction>;
 
-    constructor(name: string, type = 'Any', typeInDocs = '', description = '') {
+    constructor(
+        readonly name: string,
+        readonly type: string = 'Any',
+        readonly typeInDocs: string = '',
+        readonly description: string = ''
+    ) {
         super();
 
-        this.name = name;
-        this.type = type;
-        this.typeInDocs = typeInDocs;
-        this.description = description;
         this.containingFunction = null;
     }
 

--- a/api-editor/client/src/features/packageData/model/PythonResult.ts
+++ b/api-editor/client/src/features/packageData/model/PythonResult.ts
@@ -1,4 +1,4 @@
-import {Optional} from '../../../common/util/types';
+import { Optional } from '../../../common/util/types';
 import PythonDeclaration from './PythonDeclaration';
 import PythonFunction from './PythonFunction';
 
@@ -9,7 +9,7 @@ export default class PythonResult extends PythonDeclaration {
         readonly name: string,
         readonly type: string = 'Any',
         readonly typeInDocs: string = '',
-        readonly description: string = ''
+        readonly description: string = '',
     ) {
         super();
 


### PR DESCRIPTION
### Summary of Changes

* Use [parameter properties](https://www.typescriptlang.org/docs/handbook/2/classes.html#parameter-properties) from TypeScript
