### PR TITLE
fix: `FileNotFoundError` during `generate` command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
         run: poetry run parse-package api -p sklearn -o out
 
       - name: Smoke test (generate)
-        run: poetry run parse-package generate -a tests/data/api_data.json -u tests/data/usage_data.json -o annotations.json
+        run: poetry run parse-package generate -a tests/data/api_data.json -u tests/data/usage_data.json -o out/annotations.json
 
       # Requires installation of pytest and pytest-cov
       - name: Test with pytest

--- a/package-parser/package_parser/commands/generate_annotations/generate_annotations.py
+++ b/package-parser/package_parser/commands/generate_annotations/generate_annotations.py
@@ -17,7 +17,7 @@ from package_parser.models.annotation_models import (
     RequiredAnnotation,
     UnusedAnnotation,
 )
-from package_parser.utils import parent_qname
+from package_parser.utils import parent_qname, ensure_file_exists
 
 
 def generate_annotations(
@@ -52,6 +52,7 @@ def generate_annotations(
 
     __generate_annotation_dict(api, usages, annotations, annotation_functions)
 
+    ensure_file_exists(output_file)
     with output_file.open("w") as f:
         json.dump(annotations.to_json(), f, indent=2)
 

--- a/package-parser/package_parser/commands/generate_annotations/generate_annotations.py
+++ b/package-parser/package_parser/commands/generate_annotations/generate_annotations.py
@@ -17,7 +17,7 @@ from package_parser.models.annotation_models import (
     RequiredAnnotation,
     UnusedAnnotation,
 )
-from package_parser.utils import parent_qname, ensure_file_exists
+from package_parser.utils import ensure_file_exists, parent_qname
 
 
 def generate_annotations(


### PR DESCRIPTION
Closes #477.

### Summary of Changes

* Fix possible `FileNotFoundError` during `generate` command
* Update smoke test to catch this issue

### Testing Instructions

1. Open terminal in `package-parser` directory.
2. Run `parse-package generate -a .\tests\data\api_data.json -u .\tests\data\usage_data.json -o .\doesNotExistYet\out.json` where `doesNotExistYet` should, surprisingly, be a directory that does not exist yet.
