### PR TITLE
fix: don't create `@Unused` annotations for parameters

### DIFF
--- a/package-parser/package_parser/commands/generate_annotations/generate_annotations.py
+++ b/package-parser/package_parser/commands/generate_annotations/generate_annotations.py
@@ -102,14 +102,6 @@ def __get_unused_annotations(
     :param annotations: AnnotationStore object
     :return: None
     """
-    for parameter_name in list(api.parameters().keys()):
-        if (
-            parameter_name not in usages.parameter_usages
-            or len(usages.parameter_usages[parameter_name]) == 0
-        ):
-            formatted_name = __qname_to_target_name(api, parameter_name)
-            annotations.unused.append(UnusedAnnotation(formatted_name))
-
     for function_name in list(api.functions.keys()):
         if (
             function_name not in usages.function_usages

--- a/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
+++ b/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
@@ -19,27 +19,8 @@ from package_parser.models.annotation_models import AnnotationStore
 
 UNUSED_EXPECTED: dict[str, dict[str, str]] = {
     "test/test/Unused_Class": {"target": "test/test/Unused_Class"},
-    "test/test/commonly_used_global_function/unused_optional_parameter": {
-        "target": "test/test/commonly_used_global_function/unused_optional_parameter"
-    },
     "test/test/unused_global_function": {"target": "test/test/unused_global_function"},
-    "test/test/unused_global_function/unused_optional_parameter": {
-        "target": "test/test/unused_global_function/unused_optional_parameter"
-    },
-    "test/test/unused_global_function/unused_required_parameter": {
-        "target": "test/test/unused_global_function/unused_required_parameter"
-    },
-    "test/config_context": {"target": "test/config_context"},
-    "test/config_context/assume_finite": {
-        "target": "test/config_context/assume_finite"
-    },
-    "test/config_context/display": {"target": "test/config_context/display"},
-    "test/config_context/print_changed_only": {
-        "target": "test/config_context/print_changed_only"
-    },
-    "test/config_context/working_memory": {
-        "target": "test/config_context/working_memory"
-    },
+    "test/config_context": {"target": "test/config_context"}
 }
 
 

--- a/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
+++ b/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
@@ -20,7 +20,7 @@ from package_parser.models.annotation_models import AnnotationStore
 UNUSED_EXPECTED: dict[str, dict[str, str]] = {
     "test/test/Unused_Class": {"target": "test/test/Unused_Class"},
     "test/test/unused_global_function": {"target": "test/test/unused_global_function"},
-    "test/config_context": {"target": "test/config_context"}
+    "test/config_context": {"target": "test/config_context"},
 }
 
 

--- a/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
+++ b/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
@@ -23,7 +23,7 @@ UNUSED_EXPECTED: dict[str, dict[str, str]] = {
     "test/test/Unused_Class": {"target": "test/test/Unused_Class"},
     "test/test/unused_global_function": {"target": "test/test/unused_global_function"},
     "test/config_context": {"target": "test/config_context"},
-    "test/__init__": {"target": "test/__init__"}
+    "test/__init__": {"target": "test/__init__"},
 }
 
 CONSTANT_EXPECTED: dict[str, dict[str, str]] = {

--- a/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
+++ b/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
@@ -21,34 +21,9 @@ from package_parser.models.annotation_models import AnnotationStore
 
 UNUSED_EXPECTED: dict[str, dict[str, str]] = {
     "test/test/Unused_Class": {"target": "test/test/Unused_Class"},
-    "test/test/commonly_used_global_function/unused_optional_parameter": {
-        "target": "test/test/commonly_used_global_function/unused_optional_parameter"
-    },
     "test/test/unused_global_function": {"target": "test/test/unused_global_function"},
-    "test/test/unused_global_function/unused_optional_parameter": {
-        "target": "test/test/unused_global_function/unused_optional_parameter"
-    },
-    "test/test/unused_global_function/unused_required_parameter": {
-        "target": "test/test/unused_global_function/unused_required_parameter"
-    },
     "test/config_context": {"target": "test/config_context"},
-    "test/config_context/assume_finite": {
-        "target": "test/config_context/assume_finite"
-    },
-    "test/config_context/display": {"target": "test/config_context/display"},
-    "test/config_context/print_changed_only": {
-        "target": "test/config_context/print_changed_only"
-    },
-    "test/config_context/working_memory": {
-        "target": "test/config_context/working_memory"
-    },
-    "test/__init__": {"target": "test/__init__"},
-    "test/__init__/max_df": {"target": "test/__init__/max_df"},
-    "test/__init__/min_df": {"target": "test/__init__/min_df"},
-    "test/__init__/continuous_with_int_bounds": {
-        "target": "test/__init__/continuous_with_int_bounds"
-    },
-    "test/__init__/avg_df": {"target": "test/__init__/avg_df"},
+    "test/__init__": {"target": "test/__init__"}
 }
 
 CONSTANT_EXPECTED: dict[str, dict[str, str]] = {


### PR DESCRIPTION
Closes #476.

### Summary of Changes

* Don't create `@Unused` annotations for parameters anymore

### Testing Instructions

1. Open a terminal in `package-parser`.
2. Run `parse-package generate -a .\tests\data\api_data.json -u .\tests\data\usage_data.json -o .\out\out.json`.
3. Ensure not `@Unused` annotations are created for parameters in `out\out.json`.
