### PR TITLE
refactor: Qualified and unique path "pname" variable added to most api elements

### DIFF
--- a/package-parser/package_parser/commands/generate_annotations/generate_annotations.py
+++ b/package-parser/package_parser/commands/generate_annotations/generate_annotations.py
@@ -82,7 +82,10 @@ def __get_constant_annotations(
     for qname in list(usages.value_usages.keys()):
         parameter_info = __get_parameter_info(qname, usages)
 
-        target_name = api.parameters().get(qname).pname
+        param = api.parameters().get(qname)
+        if param is None:
+            continue
+        target_name = param.pname
 
         if parameter_info.type == ParameterType.Constant:
             annotations.constant.append(

--- a/package-parser/package_parser/commands/generate_annotations/generate_annotations.py
+++ b/package-parser/package_parser/commands/generate_annotations/generate_annotations.py
@@ -27,7 +27,7 @@ def generate_annotations(
 ) -> None:
     """
     Generates an annotation file from the given API and UsageStore files, and writes it to the given output file.
-    Annotations that are generated are: unused, constant, required, optional, enum.
+    Annotations that are generated are: unused, constant, required, optional, enum and boundary.
     :param api_file: API file
     :param usages_file: UsageStore file
     :param output_file: Output file

--- a/package-parser/package_parser/commands/generate_annotations/generate_annotations.py
+++ b/package-parser/package_parser/commands/generate_annotations/generate_annotations.py
@@ -98,19 +98,11 @@ def __get_unused_annotations(
     usages: UsageCountStore, api: API, annotations: AnnotationStore
 ) -> None:
     """
-    Collect all parameters, functions and classes that are never used.
+    Collect all functions and classes that are never used.
     :param usages: UsageStore object
     :param api: API object for usages
     :param annotations: AnnotationStore object
-    :return: None
     """
-    for parameter_name, parameter in api.parameters().items():
-        if (
-            parameter_name not in usages.parameter_usages
-            or len(usages.parameter_usages[parameter_name]) == 0
-        ):
-            annotations.unused.append(UnusedAnnotation(parameter.pname))
-
     for function_name, function in api.functions.items():
         if (
             function_name not in usages.function_usages
@@ -134,7 +126,6 @@ def __get_enum_annotations(
     :param usages: UsageStore object
     :param api: API object for usages
     :param annotations: AnnotationStore object
-    :return: None
     """
     for _, parameter in api.parameters().items():
         refined_type = parameter.refined_type.as_dict()
@@ -300,7 +291,7 @@ def __get_optional_annotations(
 
     parameters = api.parameters()
 
-    for qname, parameter in all_parameter:
+    for qname, parameter in parameters.items():
         parameter_info = __get_parameter_info(qname, usages)
 
         if qname in parameters:
@@ -381,7 +372,6 @@ def __get_boundary_annotations(
     for _, parameter in api.parameters().items():
         refined_type = parameter.refined_type.as_dict()
         if "kind" in refined_type and refined_type["kind"] == "BoundaryType":
-            target = __qname_to_target_name(api, parameter.qname)
             min_value = refined_type["min"]
             max_value = refined_type["max"]
 
@@ -408,7 +398,7 @@ def __get_boundary_annotations(
                 upperLimitType=max_limit_type,
             )
             boundary = BoundaryAnnotation(
-                target=target,
+                target=parameter.pname,
                 interval=interval,
             )
             annotations.boundaries.append(boundary)

--- a/package-parser/package_parser/commands/get_api/_ast_visitor.py
+++ b/package-parser/package_parser/commands/get_api/_ast_visitor.py
@@ -25,6 +25,9 @@ class _AstVisitor:
         self.api: API = api
         self.__declaration_stack: list[Union[Module, Class, Function]] = []
 
+    def __get_pname(self, name: str) -> str:
+        return self.api.package + "/" + "/".join([it.name for it in self.__declaration_stack]) + name
+
     def enter_module(self, module_node: astroid.Module):
         imports: list[Import] = []
         from_imports: list[FromImport] = []
@@ -63,6 +66,7 @@ class _AstVisitor:
         # Remember module, so we can later add classes and global functions
         module = Module(
             module_node.qname(),
+            f"{self.api.package}/{module_node.qname()}",
             imports,
             from_imports,
         )
@@ -89,6 +93,7 @@ class _AstVisitor:
         # Remember class, so we can later add methods
         class_ = Class(
             qname,
+            self.__get_pname(class_node.name),
             decorator_names,
             class_node.basenames,
             self.is_public(class_node.name, qname),
@@ -125,8 +130,9 @@ class _AstVisitor:
 
         function = Function(
             qname,
+            self.__get_pname(function_node.name),
             decorator_names,
-            self.__function_parameters(function_node, is_public, qname),
+            self.__function_parameters(function_node, is_public, qname, self.__get_pname(function_node.name)),
             [],  # TODO: results
             is_public,
             _AstVisitor.__description(numpydoc),
@@ -169,7 +175,7 @@ class _AstVisitor:
 
     @staticmethod
     def __function_parameters(
-        node: astroid.FunctionDef, function_is_public: bool, function_qname: str
+        node: astroid.FunctionDef, function_is_public: bool, function_qname: str, function_pname: str
     ) -> list[Parameter]:
         parameters = node.args
         n_implicit_parameters = node.implicit_parameters()
@@ -186,6 +192,7 @@ class _AstVisitor:
             Parameter(
                 it.name,
                 qname=function_qname + "." + it.name,
+                pname=function_pname + "/" + it.name,
                 default_value=None,
                 is_public=function_is_public,
                 assigned_by=ParameterAssignment.POSITION_ONLY,
@@ -199,6 +206,7 @@ class _AstVisitor:
             Parameter(
                 it.name,
                 function_qname + "." + it.name,
+                function_pname + "/" + it.name,
                 _AstVisitor.__parameter_default(
                     parameters.defaults,
                     index - len(parameters.args) + len(parameters.defaults),
@@ -215,6 +223,7 @@ class _AstVisitor:
             Parameter(
                 it.name,
                 function_qname + "." + it.name,
+                function_pname + "/" + it.name,
                 _AstVisitor.__parameter_default(
                     parameters.kw_defaults,
                     index - len(parameters.kwonlyargs) + len(parameters.kw_defaults),

--- a/package-parser/package_parser/commands/get_api/_ast_visitor.py
+++ b/package-parser/package_parser/commands/get_api/_ast_visitor.py
@@ -26,7 +26,12 @@ class _AstVisitor:
         self.__declaration_stack: list[Union[Module, Class, Function]] = []
 
     def __get_pname(self, name: str) -> str:
-        return self.api.package + "/" + "/".join([it.name for it in self.__declaration_stack]) + name
+        return (
+            self.api.package
+            + "/"
+            + "/".join([it.name for it in self.__declaration_stack])
+            + name
+        )
 
     def enter_module(self, module_node: astroid.Module):
         imports: list[Import] = []
@@ -132,7 +137,9 @@ class _AstVisitor:
             qname,
             self.__get_pname(function_node.name),
             decorator_names,
-            self.__function_parameters(function_node, is_public, qname, self.__get_pname(function_node.name)),
+            self.__function_parameters(
+                function_node, is_public, qname, self.__get_pname(function_node.name)
+            ),
             [],  # TODO: results
             is_public,
             _AstVisitor.__description(numpydoc),
@@ -175,7 +182,10 @@ class _AstVisitor:
 
     @staticmethod
     def __function_parameters(
-        node: astroid.FunctionDef, function_is_public: bool, function_qname: str, function_pname: str
+        node: astroid.FunctionDef,
+        function_is_public: bool,
+        function_qname: str,
+        function_pname: str,
     ) -> list[Parameter]:
         parameters = node.args
         n_implicit_parameters = node.implicit_parameters()

--- a/package-parser/package_parser/commands/get_api/_model.py
+++ b/package-parser/package_parser/commands/get_api/_model.py
@@ -141,7 +141,11 @@ class Module:
         return result
 
     def __init__(
-        self, name: str, pname: str, imports: list[Import], from_imports: list[FromImport]
+        self,
+        name: str,
+        pname: str,
+        imports: list[Import],
+        from_imports: list[FromImport],
     ):
         self.name: str = name
         self.pname: str = pname

--- a/package-parser/package_parser/commands/get_api/_model.py
+++ b/package-parser/package_parser/commands/get_api/_model.py
@@ -124,6 +124,7 @@ class Module:
     def from_json(json: Any) -> Module:
         result = Module(
             json["name"],
+            json["pname"],
             [Import.from_json(import_json) for import_json in json["imports"]],
             [
                 FromImport.from_json(from_import_json)
@@ -140,9 +141,10 @@ class Module:
         return result
 
     def __init__(
-        self, name: str, imports: list[Import], from_imports: list[FromImport]
+        self, name: str, pname: str, imports: list[Import], from_imports: list[FromImport]
     ):
         self.name: str = name
+        self.pname: str = pname
         self.imports: list[Import] = imports
         self.from_imports: list[FromImport] = from_imports
         self.classes: list[str] = []
@@ -157,6 +159,7 @@ class Module:
     def to_json(self) -> Any:
         return {
             "name": self.name,
+            "pname": self.pname,
             "imports": [import_.to_json() for import_ in self.imports],
             "from_imports": [
                 from_import.to_json() for from_import in self.from_imports
@@ -202,6 +205,7 @@ class Class:
     def from_json(json: Any) -> Class:
         result = Class(
             json["qname"],
+            json["pname"],
             json["decorators"],
             json["superclasses"],
             json["is_public"],
@@ -218,6 +222,7 @@ class Class:
     def __init__(
         self,
         qname: str,
+        pname: str,
         decorators: list[str],
         superclasses: list[str],
         is_public: bool,
@@ -226,6 +231,7 @@ class Class:
         source_code: str,
     ) -> None:
         self.qname: str = qname
+        self.pname: str = pname
         self.decorators: list[str] = decorators
         self.superclasses: list[str] = superclasses
         self.methods: list[str] = []
@@ -245,6 +251,7 @@ class Class:
         return {
             "name": self.name,
             "qname": self.qname,
+            "pname": self.pname,
             "decorators": self.decorators,
             "superclasses": self.superclasses,
             "methods": self.methods,
@@ -258,6 +265,7 @@ class Class:
 @dataclass
 class Function:
     qname: str
+    pname: str
     decorators: list[str]
     parameters: list[Parameter]
     results: list[Result]
@@ -270,6 +278,7 @@ class Function:
     def from_json(json: Any) -> Function:
         return Function(
             json["qname"],
+            json["pname"],
             json["decorators"],
             [
                 Parameter.from_json(parameter_json)
@@ -325,6 +334,7 @@ class Function:
             "name": self.name,
             "unique_name": self.unique_name,
             "qname": self.qname,
+            "pname": self.pname,
             "unique_qname": self.unique_qname,
             "decorators": self.decorators,
             "parameters": [parameter.to_json() for parameter in self.parameters],
@@ -375,6 +385,7 @@ class Parameter:
         return cls(
             json["name"],
             json["qname"],
+            json["pname"],
             json["default_value"],
             json["is_public"],
             ParameterAssignment[json["assigned_by"]],
@@ -385,6 +396,7 @@ class Parameter:
         self,
         name: str,
         qname: str,
+        pname: str,
         default_value: Optional[str],
         is_public: bool,
         assigned_by: ParameterAssignment,
@@ -392,6 +404,7 @@ class Parameter:
     ) -> None:
         self.name: str = name
         self.qname: str = qname
+        self.pname: str = pname
         self.default_value: Optional[str] = default_value
         self.is_public: bool = is_public
         self.assigned_by: ParameterAssignment = assigned_by
@@ -402,6 +415,7 @@ class Parameter:
         return {
             "name": self.name,
             "qname": self.qname,
+            "pname": self.pname,
             "default_value": self.default_value,
             "is_public": self.is_public,
             "assigned_by": self.assigned_by.name,

--- a/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
+++ b/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
@@ -10,74 +10,13 @@ from package_parser.commands.generate_annotations.generate_annotations import (
     __get_optional_annotations,
     __get_required_annotations,
     __get_unused_annotations,
-    _preprocess_usages,
-    generate_annotations,
+    preprocess_usages,
 )
 from package_parser.commands.get_api import (
     API,
-    Function,
-    Module,
-    Parameter,
-    ParameterAndResultDocstring,
-    ParameterAssignment,
 )
 from package_parser.models import UsageCountStore
 from package_parser.models.annotation_models import AnnotationStore
-
-
-def test_format_function():
-    api = API("test", "test", "0.0.1")
-    api.add_module(Module(name="test", imports=[], from_imports=[]))
-    api.add_function(
-        Function(
-            qname="test.unused_global_function",
-            decorators=[],
-            parameters=[],
-            results=[],
-            is_public=True,
-            description="",
-            docstring="",
-            source_code="",
-        )
-    )
-
-    assert (
-        __qname_to_target_name(api, "test.unused_global_function")
-        == "test/test/unused_global_function"
-    )
-
-
-def test_format_parameter():
-    api = API("test", "test", "0.0.1")
-    api.add_module(Module(name="test", imports=[], from_imports=[]))
-    api.add_function(
-        Function(
-            qname="test.commonly_used_global_function",
-            decorators=[],
-            parameters=[
-                Parameter(
-                    name="useless_required_parameter",
-                    qname="test.commonly_used_global_function.useless_required_parameter",
-                    default_value=None,
-                    is_public=True,
-                    assigned_by=ParameterAssignment.POSITION_OR_NAME,
-                    docstring=ParameterAndResultDocstring(type="str", description=""),
-                )
-            ],
-            results=[],
-            is_public=True,
-            description="",
-            docstring="",
-            source_code="",
-        )
-    )
-
-    assert (
-        __qname_to_target_name(
-            api, "test.commonly_used_global_function.useless_required_parameter"
-        )
-        == "test/test/commonly_used_global_function/useless_required_parameter"
-    )
 
 
 @pytest.mark.parametrize(

--- a/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
+++ b/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
@@ -12,9 +12,7 @@ from package_parser.commands.generate_annotations.generate_annotations import (
     __get_unused_annotations,
     preprocess_usages,
 )
-from package_parser.commands.get_api import (
-    API,
-)
+from package_parser.commands.get_api import API
 from package_parser.models import UsageCountStore
 from package_parser.models.annotation_models import AnnotationStore
 

--- a/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
+++ b/package-parser/tests/commands/generate_annotations/test_generate_annotations.py
@@ -10,8 +10,8 @@ from package_parser.commands.generate_annotations.generate_annotations import (
     __get_optional_annotations,
     __get_required_annotations,
     __get_unused_annotations,
-    __qname_to_target_name,
-    preprocess_usages,
+    _preprocess_usages,
+    generate_annotations,
 )
 from package_parser.commands.get_api import (
     API,

--- a/package-parser/tests/commands/get_dependencies/test_get_dependency.py
+++ b/package-parser/tests/commands/get_dependencies/test_get_dependency.py
@@ -99,6 +99,7 @@ def test_extract_dependencies_from_docstring_pattern_adverbial_clause():
     dependent_param = Parameter(
         name="random_state",
         qname="sklearn.linear_model.LogisticRegression.random_state",
+        pname="sklearn/sklearn.linear_model/LogisticRegression/random_state",
         default_value=None,
         is_public=True,
         assigned_by=ParameterAssignment.NAME_ONLY,
@@ -109,6 +110,7 @@ def test_extract_dependencies_from_docstring_pattern_adverbial_clause():
     dependee_param = Parameter(
         name="probability",
         qname="sklearn.linear_model.LogisticRegression.probability",
+        pname="sklearn/sklearn.linear_model/LogisticRegression/probability",
         default_value=None,
         is_public=True,
         assigned_by=ParameterAssignment.NAME_ONLY,

--- a/package-parser/tests/data/boundaries/api_data.json
+++ b/package-parser/tests/data/boundaries/api_data.json
@@ -5,10 +5,13 @@
     "modules": [
         {
             "name": "test",
+            "pname": "test/test",
             "imports": [],
             "from_imports": [],
             "classes": [],
-            "functions": ["test.some_global_function"]
+            "functions": [
+                "test.some_global_function"
+            ]
         }
     ],
     "classes": [],
@@ -17,12 +20,14 @@
             "name": "some_global_function",
             "unique_name": "some_global_function",
             "qname": "test.some_global_function",
+            "pname": "test/test/some_global_function",
             "unique_qname": "test.some_global_function",
             "decorators": [],
             "parameters": [
                 {
                     "name": "parameter_without_bound",
                     "qname": "test.some_global_function.parameter_without_boundary",
+                    "pname": "test/test/some_global_function/parameter_without_boundary",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -34,6 +39,7 @@
                 {
                     "name": "parameter_with_lower_bound",
                     "qname": "test.some_global_function.parameter_with_lower_bound",
+                    "pname": "test/test/some_global_function/parameter_with_lower_bound",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -45,6 +51,7 @@
                 {
                     "name": "parameter_with_upper_bound",
                     "qname": "test.some_global_function.parameter_with_upper_bound",
+                    "pname": "test/test/some_global_function/parameter_with_upper_bound",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -56,6 +63,7 @@
                 {
                     "name": "parameter_with_interval",
                     "qname": "test.some_global_function.parameter_with_interval",
+                    "pname": "test/test/some_global_function/parameter_with_interval",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",

--- a/package-parser/tests/data/boundaries/api_data.json
+++ b/package-parser/tests/data/boundaries/api_data.json
@@ -9,9 +9,7 @@
             "imports": [],
             "from_imports": [],
             "classes": [],
-            "functions": [
-                "test.some_global_function"
-            ]
+            "functions": ["test.some_global_function"]
         }
     ],
     "classes": [],

--- a/package-parser/tests/data/constants/api_data.json
+++ b/package-parser/tests/data/constants/api_data.json
@@ -5,9 +5,12 @@
     "modules": [
         {
             "name": "test",
+            "pname": "test/test",
             "imports": [],
             "from_imports": [],
-            "classes": ["test.UsedClass"],
+            "classes": [
+                "test.UsedClass"
+            ],
             "functions": [
                 "test.unused_global_function",
                 "test.used_global_function"
@@ -18,6 +21,7 @@
         {
             "name": "UsedClass",
             "qname": "test.UsedClass",
+            "pname": "test/test/UsedClass",
             "decorators": [],
             "is_public": true,
             "description": "",
@@ -35,12 +39,14 @@
             "name": "unused_global_function",
             "unique_name": "unused_global_function",
             "qname": "test.unused_global_function",
+            "pname": "test/test/unused_global_function",
             "unique_qname": "test.unused_global_function",
             "decorators": [],
             "parameters": [
                 {
                     "name": "unused_parameter",
                     "qname": "test.unused_global_function.unused_parameter",
+                    "pname": "test/test/unused_global_function/unused_parameter",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -60,12 +66,14 @@
             "name": "used_global_function",
             "unique_name": "used_global_function",
             "qname": "test.used_global_function",
+            "pname": "test/test/used_global_function",
             "unique_qname": "test.used_global_function",
             "decorators": [],
             "parameters": [
                 {
                     "name": "constant_required_parameter",
                     "qname": "test.used_global_function.constant_required_parameter",
+                    "pname": "test/test/used_global_function/constant_required_parameter",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -77,6 +85,7 @@
                 {
                     "name": "variable_required_parameter",
                     "qname": "test.used_global_function.variable_required_parameter",
+                    "pname": "test/test/used_global_function/variable_required_parameter",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -88,6 +97,7 @@
                 {
                     "name": "constant_optional_parameter",
                     "qname": "test.used_global_function.constant_optional_parameter",
+                    "pname": "test/test/used_global_function/constant_optional_parameter",
                     "default_value": "'test'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -99,6 +109,7 @@
                 {
                     "name": "variable_optional_parameter",
                     "qname": "test.used_global_function.variable_optional_parameter",
+                    "pname": "test/test/used_global_function/variable_optional_parameter",
                     "default_value": "'test'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -118,12 +129,14 @@
             "name": "unused_method",
             "unique_name": "unused_method",
             "qname": "test.UsedClass.unused_method",
+            "pname": "test/test/UsedClass/unused_method",
             "unique_qname": "test.UsedClass.unused_method",
             "decorators": [],
             "parameters": [
                 {
                     "name": "unused_parameter",
                     "qname": "test.UsedClass.unused_method.unused_parameter",
+                    "pname": "test/test/UsedClass/unused_method/unused_parameter",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -143,12 +156,14 @@
             "name": "used_method",
             "unique_name": "used_method",
             "qname": "test.UsedClass.used_method",
+            "pname": "test/test/UsedClass/used_method",
             "unique_qname": "test.UsedClass.used_method",
             "decorators": [],
             "parameters": [
                 {
                     "name": "constant_required_parameter",
                     "qname": "test.UsedClass.used_method.constant_required_parameter",
+                    "pname": "test/test/UsedClass/used_method/constant_required_parameter",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -160,6 +175,7 @@
                 {
                     "name": "variable_required_parameter",
                     "qname": "test.UsedClass.used_method.variable_required_parameter",
+                    "pname": "test/test/UsedClass/used_method/variable_required_parameter",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -171,6 +187,7 @@
                 {
                     "name": "constant_optional_parameter",
                     "qname": "test.UsedClass.used_method.constant_optional_parameter",
+                    "pname": "test/test/UsedClass/used_method/constant_optional_parameter",
                     "default_value": "'test'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -182,6 +199,7 @@
                 {
                     "name": "variable_optional_parameter",
                     "qname": "test.UsedClass.used_method.variable_optional_parameter",
+                    "pname": "test/test/UsedClass/used_method/variable_optional_parameter",
                     "default_value": "'test'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",

--- a/package-parser/tests/data/constants/api_data.json
+++ b/package-parser/tests/data/constants/api_data.json
@@ -8,9 +8,7 @@
             "pname": "test/test",
             "imports": [],
             "from_imports": [],
-            "classes": [
-                "test.UsedClass"
-            ],
+            "classes": ["test.UsedClass"],
             "functions": [
                 "test.unused_global_function",
                 "test.used_global_function"

--- a/package-parser/tests/data/enums/api_data.json
+++ b/package-parser/tests/data/enums/api_data.json
@@ -5,10 +5,13 @@
     "modules": [
         {
             "name": "test",
+            "pname": "test/test",
             "imports": [],
             "from_imports": [],
             "classes": [],
-            "functions": ["test.some_global_function"]
+            "functions": [
+                "test.some_global_function"
+            ]
         }
     ],
     "classes": [],
@@ -17,12 +20,14 @@
             "name": "some_global_function",
             "unique_name": "some_global_function",
             "qname": "test.some_global_function",
+            "pname": "test/test/some_global_function",
             "unique_qname": "test.some_global_function",
             "decorators": [],
             "parameters": [
                 {
                     "name": "string_parameter",
-                    "qname": "test.some_global_function",
+                    "qname": "test.some_global_function/string_parameter",
+                    "pname": "test/test/some_global_function/string_parameter",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -34,6 +39,7 @@
                 {
                     "name": "enum_parameter",
                     "qname": "test.some_global_function.enum_parameter",
+                    "pname": "test/test/some_global_function/enum_parameter",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",

--- a/package-parser/tests/data/enums/api_data.json
+++ b/package-parser/tests/data/enums/api_data.json
@@ -9,9 +9,7 @@
             "imports": [],
             "from_imports": [],
             "classes": [],
-            "functions": [
-                "test.some_global_function"
-            ]
+            "functions": ["test.some_global_function"]
         }
     ],
     "classes": [],

--- a/package-parser/tests/data/optionals/api_data.json
+++ b/package-parser/tests/data/optionals/api_data.json
@@ -5,10 +5,13 @@
     "modules": [
         {
             "name": "test",
+            "pname": "test/test",
             "imports": [],
             "from_imports": [],
             "classes": [],
-            "functions": ["test.some_global_function"]
+            "functions": [
+                "test.some_global_function"
+            ]
         }
     ],
     "classes": [],
@@ -17,12 +20,14 @@
             "name": "some_global_function",
             "unique_name": "some_global_function",
             "qname": "test.some_global_function",
+            "pname": "test/test/some_global_function",
             "unique_qname": "test.some_global_function",
             "decorators": [],
             "parameters": [
                 {
                     "name": "required_parameter_that_should_be_constant",
                     "qname": "test.some_global_function.required_parameter_that_should_be_constant",
+                    "pname": "test/test/some_global_function/required_parameter_that_should_be_constant",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -34,6 +39,7 @@
                 {
                     "name": "required_parameter_that_should_be_required",
                     "qname": "test.some_global_function.required_parameter_that_should_be_required",
+                    "pname": "test/test/some_global_function/required_parameter_that_should_be_required",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -45,6 +51,7 @@
                 {
                     "name": "required_parameter_that_should_be_optional",
                     "qname": "test.some_global_function.required_parameter_that_should_be_optional",
+                    "pname": "test/test/some_global_function/required_parameter_that_should_be_optional",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -56,6 +63,7 @@
                 {
                     "name": "optional_parameter_that_should_be_constant",
                     "qname": "test.some_global_function.optional_parameter_that_should_be_constant",
+                    "pname": "test/test/some_global_function/optional_parameter_that_should_be_constant",
                     "default_value": "'test'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -67,6 +75,7 @@
                 {
                     "name": "optional_parameter_that_should_be_required",
                     "qname": "test.some_global_function.optional_parameter_that_should_be_required",
+                    "pname": "test/test/some_global_function/optional_parameter_that_should_be_required",
                     "default_value": "'test'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -78,6 +87,7 @@
                 {
                     "name": "optional_parameter_that_should_be_optional_with_same_default",
                     "qname": "test.some_global_function.optional_parameter_that_should_be_optional_with_same_default",
+                    "pname": "test/test/some_global_function/optional_parameter_that_should_be_optional_with_same_default",
                     "default_value": "'test'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -89,6 +99,7 @@
                 {
                     "name": "optional_parameter_that_should_be_optional_with_different_default",
                     "qname": "test.some_global_function.optional_parameter_that_should_be_optional_with_different_default",
+                    "pname": "test/test/some_global_function/optional_parameter_that_should_be_optional_with_different_default",
                     "default_value": "'test'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",

--- a/package-parser/tests/data/optionals/api_data.json
+++ b/package-parser/tests/data/optionals/api_data.json
@@ -9,9 +9,7 @@
             "imports": [],
             "from_imports": [],
             "classes": [],
-            "functions": [
-                "test.some_global_function"
-            ]
+            "functions": ["test.some_global_function"]
         }
     ],
     "classes": [],

--- a/package-parser/tests/data/requireds/api_data.json
+++ b/package-parser/tests/data/requireds/api_data.json
@@ -5,10 +5,13 @@
     "modules": [
         {
             "name": "test",
+            "pname": "test/test",
             "imports": [],
             "from_imports": [],
             "classes": [],
-            "functions": ["test.some_global_function"]
+            "functions": [
+                "test.some_global_function"
+            ]
         }
     ],
     "classes": [],
@@ -17,12 +20,14 @@
             "name": "some_global_function",
             "unique_name": "some_global_function",
             "qname": "test.some_global_function",
+            "pname": "test/test/some_global_function",
             "unique_qname": "test.some_global_function",
             "decorators": [],
             "parameters": [
                 {
                     "name": "required_parameter_that_should_be_constant",
                     "qname": "test.some_global_function.required_parameter_that_should_be_constant",
+                    "pname": "test/test/some_global_function/required_parameter_that_should_be_constant",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -34,6 +39,7 @@
                 {
                     "name": "required_parameter_that_should_be_required",
                     "qname": "test.some_global_function.required_parameter_that_should_be_required",
+                    "pname": "test/test/some_global_function/required_parameter_that_should_be_required",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -45,6 +51,7 @@
                 {
                     "name": "required_parameter_that_should_be_optional",
                     "qname": "test.some_global_function.required_parameter_that_should_be_optional",
+                    "pname": "test/test/some_global_function/required_parameter_that_should_be_optional",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -56,6 +63,7 @@
                 {
                     "name": "optional_parameter_that_should_be_constant",
                     "qname": "test.some_global_function.optional_parameter_that_should_be_constant",
+                    "pname": "test/test/some_global_function/optional_parameter_that_should_be_constant",
                     "default_value": "'test'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -67,6 +75,7 @@
                 {
                     "name": "optional_parameter_that_should_be_required",
                     "qname": "test.some_global_function.optional_parameter_that_should_be_required",
+                    "pname": "test/test/some_global_function/optional_parameter_that_should_be_required",
                     "default_value": "'test'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -78,6 +87,7 @@
                 {
                     "name": "optional_parameter_that_should_be_optional_with_same_default",
                     "qname": "test.some_global_function.optional_parameter_that_should_be_optional_with_same_default",
+                    "pname": "test/test/some_global_function/optional_parameter_that_should_be_optional_with_same_default",
                     "default_value": "'test'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -89,6 +99,7 @@
                 {
                     "name": "optional_parameter_that_should_be_optional_with_different_default",
                     "qname": "test.some_global_function.optional_parameter_that_should_be_optional_with_different_default",
+                    "pname": "test/test/some_global_function/optional_parameter_that_should_be_optional_with_different_default",
                     "default_value": "'test'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",

--- a/package-parser/tests/data/requireds/api_data.json
+++ b/package-parser/tests/data/requireds/api_data.json
@@ -9,9 +9,7 @@
             "imports": [],
             "from_imports": [],
             "classes": [],
-            "functions": [
-                "test.some_global_function"
-            ]
+            "functions": ["test.some_global_function"]
         }
     ],
     "classes": [],

--- a/package-parser/tests/data/unuseds/api_data.json
+++ b/package-parser/tests/data/unuseds/api_data.json
@@ -8,10 +8,7 @@
             "pname": "test/test",
             "imports": [],
             "from_imports": [],
-            "classes": [
-                "test.UnusedClass",
-                "test.UsedClass"
-            ],
+            "classes": ["test.UnusedClass", "test.UsedClass"],
             "functions": [
                 "test.unused_global_function",
                 "test.used_global_function"
@@ -29,9 +26,7 @@
             "docstring": "",
             "superclasses": [],
             "source_code": "",
-            "methods": [
-                "test.UnusedClass.unused_method"
-            ]
+            "methods": ["test.UnusedClass.unused_method"]
         },
         {
             "name": "UsedClass",

--- a/package-parser/tests/data/unuseds/api_data.json
+++ b/package-parser/tests/data/unuseds/api_data.json
@@ -5,9 +5,13 @@
     "modules": [
         {
             "name": "test",
+            "pname": "test/test",
             "imports": [],
             "from_imports": [],
-            "classes": ["test.UnusedClass", "test.UsedClass"],
+            "classes": [
+                "test.UnusedClass",
+                "test.UsedClass"
+            ],
             "functions": [
                 "test.unused_global_function",
                 "test.used_global_function"
@@ -18,17 +22,21 @@
         {
             "name": "UnusedClass",
             "qname": "test.UnusedClass",
+            "pname": "test/test/UnusedClass",
             "decorators": [],
             "is_public": true,
             "description": "",
             "docstring": "",
             "superclasses": [],
             "source_code": "",
-            "methods": ["test.UnusedClass.unused_method"]
+            "methods": [
+                "test.UnusedClass.unused_method"
+            ]
         },
         {
             "name": "UsedClass",
             "qname": "test.UsedClass",
+            "pname": "test/test/UsedClass",
             "decorators": [],
             "is_public": true,
             "description": "",
@@ -46,12 +54,14 @@
             "name": "unused_global_function",
             "unique_name": "unused_global_function",
             "qname": "test.unused_global_function",
+            "pname": "test/test/unused_global_function",
             "unique_qname": "test.unused_global_function",
             "decorators": [],
             "parameters": [
                 {
                     "name": "unused_parameter",
                     "qname": "test.unused_global_function.unused_parameter",
+                    "pname": "test/test/unused_global_function/unused_parameter",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -63,6 +73,7 @@
                 {
                     "name": "used_parameter",
                     "qname": "test.unused_global_function.used_parameter",
+                    "pname": "test/test/unused_global_function/used_parameter",
                     "default_value": "'bla'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -82,12 +93,14 @@
             "name": "used_global_function",
             "unique_name": "used_global_function",
             "qname": "test.used_global_function",
+            "pname": "test/test/used_global_function",
             "unique_qname": "test.used_global_function",
             "decorators": [],
             "parameters": [
                 {
                     "name": "unused_parameter",
                     "qname": "test.used_global_function.unused_parameter",
+                    "pname": "test/test/used_global_function/unused_parameter",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -99,6 +112,7 @@
                 {
                     "name": "used_parameter",
                     "qname": "test.used_global_function.used_parameter",
+                    "pname": "test/test/used_global_function/used_parameter",
                     "default_value": "'bla'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -118,12 +132,14 @@
             "name": "unused_method",
             "unique_name": "unused_method",
             "qname": "test.UnusedClass.unused_method",
+            "pname": "test/test/UnusedClass/unused_method",
             "unique_qname": "test.UnusedClass.unused_method",
             "decorators": [],
             "parameters": [
                 {
                     "name": "unused_parameter",
                     "qname": "test.UnusedClass.unused_method.unused_parameter",
+                    "pname": "test/test/UnusedClass/unused_method/unused_parameter",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -135,6 +151,7 @@
                 {
                     "name": "used_parameter",
                     "qname": "test.UnusedClass.unused_method.used_parameter",
+                    "pname": "test/test/UnusedClass/unused_method/used_parameter",
                     "default_value": "'bla'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -154,12 +171,14 @@
             "name": "unused_method",
             "unique_name": "unused_method",
             "qname": "test.UsedClass.unused_method",
+            "pname": "test/test/UsedClass/unused_method",
             "unique_qname": "test.UsedClass.unused_method",
             "decorators": [],
             "parameters": [
                 {
                     "name": "unused_parameter",
                     "qname": "test.UsedClass.unused_method.unused_parameter",
+                    "pname": "test/test/UsedClass/unused_method/unused_parameter",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -171,6 +190,7 @@
                 {
                     "name": "used_parameter",
                     "qname": "test.UsedClass.unused_method.used_parameter",
+                    "pname": "test/test/UsedClass/unused_method/used_parameter",
                     "default_value": "'bla'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -190,12 +210,14 @@
             "name": "used_method",
             "unique_name": "used_method",
             "qname": "test.UsedClass.used_method",
+            "pname": "test/test/UsedClass/used_method",
             "unique_qname": "test.UsedClass.used_method",
             "decorators": [],
             "parameters": [
                 {
                     "name": "unused_parameter",
                     "qname": "test.UsedClass.used_method.unused_parameter",
+                    "pname": "test/test/UsedClass/used_method/unused_parameter",
                     "default_value": null,
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",
@@ -207,6 +229,7 @@
                 {
                     "name": "used_parameter",
                     "qname": "test.UsedClass.used_method.used_parameter",
+                    "pname": "test/test/UsedClass/used_method/used_parameter",
                     "default_value": "'bla'",
                     "is_public": true,
                     "assigned_by": "POSITION_OR_NAME",


### PR DESCRIPTION
Closes #449.

### Summary of Changes

Added pname parameter to module, class, function and parameter api elements. pname parameter should be a qualified and unique pathname, unlike qname and name.

pname format: "package/module/class/function/parameter"
module can be: "module.name"

### Testing Instructions

Execute:
parse-package api <package> <out> 

And check that the pname parameter is set for every module, class, function and parameter.