### PR TITLE
feat: add docstrings in generated python code

### DIFF
--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGenerator.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGenerator.kt
@@ -125,6 +125,7 @@ fun PythonClass.toPythonCode() = buildString {
     if (docstring.isNotBlank()) {
         appendIndented("\"\"\"\n")
         appendIndented(docstring)
+        appendLine()
         appendIndented("\"\"\"\n\n")
     }
     if (constructorString.isNotBlank()) {
@@ -217,6 +218,7 @@ fun PythonFunction.toPythonCode() = buildString {
     if (docstring.isNotBlank()) {
         appendIndented("\"\"\"\n")
         appendIndented(docstring)
+        appendLine()
         appendIndented("\"\"\"\n\n")
     }
     if (boundariesString.isNotBlank()) {

--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGenerator.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGenerator.kt
@@ -117,10 +117,16 @@ fun PythonAttribute.toPythonCode() = buildString {
 }
 
 fun PythonClass.toPythonCode() = buildString {
+    val docstring = docstring()
     val constructorString = constructor?.toPythonCode() ?: ""
     val methodsString = methods.joinToString("\n\n") { it.toPythonCode() }
 
     appendLine("class $name:")
+    if (docstring.isNotBlank()) {
+        appendIndented("\"\"\"\n")
+        appendIndented(docstring)
+        appendIndented("\"\"\"\n\n")
+    }
     if (constructorString.isNotBlank()) {
         appendIndented(constructorString)
         if (methodsString.isNotBlank()) {
@@ -196,6 +202,7 @@ fun PythonEnumInstance.toPythonCode(enumName: String): String {
 
 fun PythonFunction.toPythonCode() = buildString {
     val parametersString = parameters.toPythonCode()
+    val docstring = docstring()
     val boundariesString = parameters
         .mapNotNull { it.boundary?.toPythonCode(it.name) }
         .joinToString("\n")
@@ -207,6 +214,11 @@ fun PythonFunction.toPythonCode() = buildString {
         appendLine("@staticmethod")
     }
     appendLine("def $name($parametersString):")
+    if (docstring.isNotBlank()) {
+        appendIndented("\"\"\"\n")
+        appendIndented(docstring)
+        appendIndented("\"\"\"\n\n")
+    }
     if (boundariesString.isNotBlank()) {
         appendIndented(boundariesString)
         if (callString.isNotBlank()) {
@@ -342,30 +354,4 @@ fun Boundary.toPythonCode(parameterName: String) = buildString {
         appendLine("if not $parameterName <= $upperIntervalLimit:")
         appendIndented("raise ValueError(f'Valid values of $parameterName must be less than or equal to $upperIntervalLimit, but {$parameterName} was assigned.')")
     }
-}
-
-/* ********************************************************************************************************************
- * Util
- * ********************************************************************************************************************/
-
-private fun String.prependIndentUnlessBlank(indent: String = "    "): String {
-    return lineSequence()
-        .map {
-            when {
-                it.isBlank() -> it.trim()
-                else -> it.prependIndent(indent)
-            }
-        }
-        .joinToString("\n")
-}
-
-private fun StringBuilder.appendIndented(init: StringBuilder.() -> Unit): StringBuilder {
-    val stringToIndent = StringBuilder().apply(init).toString()
-    append(stringToIndent.prependIndentUnlessBlank())
-    return this
-}
-
-private fun StringBuilder.appendIndented(value: String): StringBuilder {
-    append(value.prependIndentUnlessBlank())
-    return this
 }

--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/PythonDocstringGenerator.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/PythonDocstringGenerator.kt
@@ -1,0 +1,80 @@
+package com.larsreimann.api_editor.codegen
+
+import com.larsreimann.api_editor.mutable_model.PythonAttribute
+import com.larsreimann.api_editor.mutable_model.PythonClass
+import com.larsreimann.api_editor.mutable_model.PythonFunction
+import com.larsreimann.api_editor.mutable_model.PythonParameter
+
+private fun attributesDocstring(attributes: List<PythonAttribute>) = buildString {
+    if (attributes.all { it.description.isBlank() }) {
+        return@buildString
+    }
+
+    appendLine("Attributes")
+    appendLine("----------")
+    append(attributes.joinToString("\n") { it.docstring() })
+}
+
+private fun PythonAttribute.docstring() = buildString {
+    append(name)
+    type.toPythonCodeOrNull()?.let { append(" : $it") }
+    if (description.isNotBlank()) {
+        appendLine()
+        appendIndented(description)
+    }
+}
+
+fun PythonClass.docstring() = buildString {
+    if (description.isNotBlank()) {
+        append(description)
+    }
+
+    val parameterSection = constructor?.parameters?.let { parametersDocstring(it) } ?: ""
+    if (parameterSection.isNotBlank()) {
+        if (description.isNotBlank()) {
+            append("\n\n")
+        }
+        append(parameterSection)
+    }
+
+    val attributesSection = attributesDocstring(attributes)
+    if (attributesSection.isNotBlank()) {
+        if (description.isNotBlank() || parameterSection.isNotBlank()) {
+            append("\n\n")
+        }
+        appendLine(attributesSection)
+    }
+}
+
+fun PythonFunction.docstring() = buildString {
+    if (description.isNotBlank()) {
+        appendLine(description)
+    }
+
+    val parameterSection = parametersDocstring(parameters)
+    if (parameterSection.isNotBlank()) {
+        if (description.isNotBlank()) {
+            appendLine()
+        }
+        appendLine(parameterSection)
+    }
+}
+
+private fun parametersDocstring(parameters: List<PythonParameter>) = buildString {
+    if (parameters.all { it.description.isBlank() }) {
+        return@buildString
+    }
+
+    appendLine("Parameters")
+    appendLine("----------")
+    append(parameters.joinToString("\n") { it.docstring() })
+}
+
+private fun PythonParameter.docstring() = buildString {
+    append(name)
+    type.toPythonCodeOrNull()?.let { append(" : $it") }
+    if (description.isNotBlank()) {
+        appendLine()
+        appendIndented(description)
+    }
+}

--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/PythonDocstringGenerator.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/PythonDocstringGenerator.kt
@@ -1,5 +1,6 @@
 package com.larsreimann.api_editor.codegen
 
+import com.larsreimann.api_editor.model.PythonParameterAssignment
 import com.larsreimann.api_editor.mutable_model.PythonAttribute
 import com.larsreimann.api_editor.mutable_model.PythonClass
 import com.larsreimann.api_editor.mutable_model.PythonFunction
@@ -61,13 +62,15 @@ fun PythonFunction.docstring() = buildString {
 }
 
 private fun parametersDocstring(parameters: List<PythonParameter>) = buildString {
-    if (parameters.all { it.description.isBlank() }) {
+    val explicitParameters = parameters.filter { it.assignedBy != PythonParameterAssignment.IMPLICIT }
+
+    if (explicitParameters.all { it.description.isBlank() }) {
         return@buildString
     }
 
     appendLine("Parameters")
     appendLine("----------")
-    append(parameters.joinToString("\n") { it.docstring() })
+    append(explicitParameters.joinToString("\n") { it.docstring() })
 }
 
 private fun PythonParameter.docstring() = buildString {

--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/PythonDocstringGenerator.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/PythonDocstringGenerator.kt
@@ -42,21 +42,21 @@ fun PythonClass.docstring() = buildString {
         if (description.isNotBlank() || parameterSection.isNotBlank()) {
             append("\n\n")
         }
-        appendLine(attributesSection)
+        append(attributesSection)
     }
 }
 
 fun PythonFunction.docstring() = buildString {
     if (description.isNotBlank()) {
-        appendLine(description)
+        append(description)
     }
 
     val parameterSection = parametersDocstring(parameters)
     if (parameterSection.isNotBlank()) {
         if (description.isNotBlank()) {
-            appendLine()
+            append("\n\n")
         }
-        appendLine(parameterSection)
+        append(parameterSection)
     }
 }
 

--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/Util.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/Util.kt
@@ -1,0 +1,23 @@
+package com.larsreimann.api_editor.codegen
+
+internal fun String.prependIndentUnlessBlank(indent: String = "    "): String {
+    return lineSequence()
+        .map {
+            when {
+                it.isBlank() -> it.trim()
+                else -> it.prependIndent(indent)
+            }
+        }
+        .joinToString("\n")
+}
+
+internal fun StringBuilder.appendIndented(init: StringBuilder.() -> Unit): StringBuilder {
+    val stringToIndent = StringBuilder().apply(init).toString()
+    append(stringToIndent.prependIndentUnlessBlank())
+    return this
+}
+
+internal fun StringBuilder.appendIndented(value: String): StringBuilder {
+    append(value.prependIndentUnlessBlank())
+    return this
+}

--- a/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/ConstructorPythonCodeGeneratorFullPipelineTest.kt
+++ b/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/ConstructorPythonCodeGeneratorFullPipelineTest.kt
@@ -1,6 +1,5 @@
-package com.larsreimann.api_editor.codegen.python_code_gen
+package com.larsreimann.api_editor.codegen
 
-import com.larsreimann.api_editor.codegen.toPythonCode
 import com.larsreimann.api_editor.model.BoundaryAnnotation
 import com.larsreimann.api_editor.model.ComparisonOperator
 import com.larsreimann.api_editor.model.DefaultBoolean
@@ -24,7 +23,7 @@ import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class ConstructorPythonCodeGeneratorTest {
+class ConstructorPythonCodeGeneratorFullPipelineTest {
     private lateinit var testParameter1: PythonParameter
     private lateinit var testParameter2: PythonParameter
     private lateinit var testParameter3: PythonParameter

--- a/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/FunctionPythonCodeGeneratorFullPipelineTest.kt
+++ b/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/FunctionPythonCodeGeneratorFullPipelineTest.kt
@@ -1,19 +1,18 @@
-package com.larsreimann.api_editor.codegen.python_code_gen
+package com.larsreimann.api_editor.codegen
 
-import com.larsreimann.api_editor.codegen.toPythonCode
 import com.larsreimann.api_editor.model.BoundaryAnnotation
 import com.larsreimann.api_editor.model.ComparisonOperator
 import com.larsreimann.api_editor.model.DefaultBoolean
 import com.larsreimann.api_editor.model.DefaultNumber
+import com.larsreimann.api_editor.model.DefaultString
 import com.larsreimann.api_editor.model.EnumAnnotation
 import com.larsreimann.api_editor.model.EnumPair
 import com.larsreimann.api_editor.model.GroupAnnotation
+import com.larsreimann.api_editor.model.MoveAnnotation
 import com.larsreimann.api_editor.model.OptionalAnnotation
 import com.larsreimann.api_editor.model.RenameAnnotation
 import com.larsreimann.api_editor.model.RequiredAnnotation
-import com.larsreimann.api_editor.mutable_model.PythonClass
 import com.larsreimann.api_editor.mutable_model.PythonFunction
-import com.larsreimann.api_editor.mutable_model.PythonInt
 import com.larsreimann.api_editor.mutable_model.PythonModule
 import com.larsreimann.api_editor.mutable_model.PythonPackage
 import com.larsreimann.api_editor.mutable_model.PythonParameter
@@ -23,43 +22,36 @@ import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class MethodPythonCodeGeneratorTest {
-    private lateinit var testParameterSelf: PythonParameter
+class FunctionPythonCodeGeneratorFullPipelineTest {
     private lateinit var testParameter1: PythonParameter
     private lateinit var testParameter2: PythonParameter
     private lateinit var testParameter3: PythonParameter
-    private lateinit var testClass: PythonClass
     private lateinit var testFunction: PythonFunction
     private lateinit var testModule: PythonModule
     private lateinit var testPackage: PythonPackage
 
     @BeforeEach
     fun reset() {
-        testParameterSelf = PythonParameter(
-            name = "self"
-        )
         testParameter1 = PythonParameter(
-            name = "testParameter1"
+            name = "testParameter1",
         )
         testParameter2 = PythonParameter(
-            name = "testParameter2"
+            name = "testParameter2",
         )
         testParameter3 = PythonParameter(
-            name = "testParameter3"
+            name = "testParameter3",
         )
         testFunction = PythonFunction(
-            name = "testMethod",
+            name = "testFunction",
             parameters = mutableListOf(
-                testParameterSelf,
                 testParameter1,
                 testParameter2,
                 testParameter3
             )
         )
-        testClass = PythonClass(name = "testClass", methods = mutableListOf(testFunction))
         testModule = PythonModule(
             name = "testModule",
-            classes = mutableListOf(testClass)
+            functions = mutableListOf(testFunction)
         )
         testPackage = PythonPackage(
             distribution = "testPackage",
@@ -70,7 +62,7 @@ class MethodPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Boundary- and GroupAnnotation on class method level`() {
+    fun `should process Boundary- and GroupAnnotation on function level`() {
         // given
         testParameter1.annotations.add(
             BoundaryAnnotation(
@@ -84,7 +76,7 @@ class MethodPythonCodeGeneratorTest {
         testFunction.annotations.add(
             GroupAnnotation(
                 groupName = "TestGroup",
-                parameters = mutableListOf("testParameter1", "testParameter2")
+                parameters = mutableListOf("testParameter1", "testParameter3")
             )
         )
         // when
@@ -98,22 +90,18 @@ class MethodPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
-            |class testClass:
-            |    def __init__():
-            |        self.instance = testModule.testClass()
-            |
-            |    def testMethod(self, testGroup: TestGroup, testParameter3):
-            |        return self.instance.testMethod(testGroup.testParameter1, testGroup.testParameter2, testParameter3)
-            |
             |class TestGroup:
-            |    def __init__(self, testParameter1, testParameter2):
+            |    def __init__(self, testParameter1, testParameter3):
             |        if not (isinstance(testParameter1, int) or (isinstance(testParameter1, float) and testParameter1.is_integer())):
             |            raise ValueError(f'testParameter1 needs to be an integer, but {testParameter1} was assigned.')
             |        if not 0.0 <= testParameter1 <= 1.0:
             |            raise ValueError(f'Valid values of testParameter1 must be in [0.0, 1.0], but {testParameter1} was assigned.')
             |
             |        self.testParameter1 = testParameter1
-            |        self.testParameter2 = testParameter2
+            |        self.testParameter3 = testParameter3
+            |
+            |def testFunction(testGroup: TestGroup, testParameter2):
+            |    return testModule.testFunction(testGroup.testParameter1, testParameter2, testGroup.testParameter3)
             |
             """.trimMargin()
 
@@ -121,63 +109,7 @@ class MethodPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Boundary-, Group- and OptionalAnnotation on class method level`() {
-        // given
-        testParameter2.annotations.add(
-            BoundaryAnnotation(
-                isDiscrete = true,
-                lowerIntervalLimit = 0.0,
-                lowerLimitType = ComparisonOperator.UNRESTRICTED,
-                upperIntervalLimit = 1.0,
-                upperLimitType = ComparisonOperator.LESS_THAN
-            )
-        )
-        testParameter2.annotations.add(
-            OptionalAnnotation(
-                DefaultNumber(0.5)
-            )
-        )
-        testFunction.annotations.add(
-            GroupAnnotation(
-                groupName = "TestGroup",
-                parameters = mutableListOf("testParameter1", "testParameter2")
-            )
-        )
-        // when
-        testPackage.transform()
-        val moduleContent = testPackage.modules[0].toPythonCode()
-
-        // then
-        val expectedModuleContent: String =
-            """
-            |import testModule
-            |
-            |from __future__ import annotations
-            |
-            |class testClass:
-            |    def __init__():
-            |        self.instance = testModule.testClass()
-            |
-            |    def testMethod(self, testGroup: TestGroup, testParameter3):
-            |        return self.instance.testMethod(testGroup.testParameter1, testGroup.testParameter2, testParameter3)
-            |
-            |class TestGroup:
-            |    def __init__(self, testParameter1, *, testParameter2=0.5):
-            |        if not (isinstance(testParameter2, int) or (isinstance(testParameter2, float) and testParameter2.is_integer())):
-            |            raise ValueError(f'testParameter2 needs to be an integer, but {testParameter2} was assigned.')
-            |        if not testParameter2 < 1.0:
-            |            raise ValueError(f'Valid values of testParameter2 must be less than 1.0, but {testParameter2} was assigned.')
-            |
-            |        self.testParameter1 = testParameter1
-            |        self.testParameter2 = testParameter2
-            |
-            """.trimMargin()
-
-        moduleContent shouldBe expectedModuleContent
-    }
-
-    @Test
-    fun `should process Boundary-, Group- and RequiredAnnotation on class method level`() {
+    fun `should process Boundary-, Group- and OptionalAnnotation on function level`() {
         // given
         testParameter2.annotations.add(
             BoundaryAnnotation(
@@ -189,9 +121,10 @@ class MethodPythonCodeGeneratorTest {
             )
         )
         testParameter2.annotations.add(
-            RequiredAnnotation
+            OptionalAnnotation(
+                DefaultNumber(0.5)
+            )
         )
-        testParameter2.defaultValue = PythonInt(0)
         testFunction.annotations.add(
             GroupAnnotation(
                 groupName = "TestGroup",
@@ -209,12 +142,55 @@ class MethodPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
-            |class testClass:
-            |    def __init__():
-            |        self.instance = testModule.testClass()
+            |class TestGroup:
+            |    def __init__(self, testParameter3, *, testParameter2=0.5):
+            |        if not (isinstance(testParameter2, int) or (isinstance(testParameter2, float) and testParameter2.is_integer())):
+            |            raise ValueError(f'testParameter2 needs to be an integer, but {testParameter2} was assigned.')
+            |        if not 0.0 <= testParameter2 <= 1.0:
+            |            raise ValueError(f'Valid values of testParameter2 must be in [0.0, 1.0], but {testParameter2} was assigned.')
             |
-            |    def testMethod(self, testParameter1, testGroup: TestGroup):
-            |        return self.instance.testMethod(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
+            |        self.testParameter3 = testParameter3
+            |        self.testParameter2 = testParameter2
+            |
+            |def testFunction(testParameter1, testGroup: TestGroup):
+            |    return testModule.testFunction(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
+            |
+            """.trimMargin()
+
+        moduleContent shouldBe expectedModuleContent
+    }
+
+    @Test
+    fun `should process Boundary-, Group- and RequiredAnnotation on function level`() {
+        // given
+        testParameter2.annotations.add(
+            BoundaryAnnotation(
+                isDiscrete = true,
+                lowerIntervalLimit = 0.0,
+                lowerLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS,
+                upperIntervalLimit = 1.0,
+                upperLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS
+            )
+        )
+        testParameter2.annotations.add(
+            RequiredAnnotation
+        )
+        testFunction.annotations.add(
+            GroupAnnotation(
+                groupName = "TestGroup",
+                parameters = mutableListOf("testParameter2", "testParameter3")
+            )
+        )
+        // when
+        testPackage.transform()
+        val moduleContent = testPackage.modules[0].toPythonCode()
+
+        // then
+        val expectedModuleContent: String =
+            """
+            |import testModule
+            |
+            |from __future__ import annotations
             |
             |class TestGroup:
             |    def __init__(self, testParameter2, testParameter3):
@@ -226,13 +202,16 @@ class MethodPythonCodeGeneratorTest {
             |        self.testParameter2 = testParameter2
             |        self.testParameter3 = testParameter3
             |
+            |def testFunction(testParameter1, testGroup: TestGroup):
+            |    return testModule.testFunction(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
+            |
             """.trimMargin()
 
         moduleContent shouldBe expectedModuleContent
     }
 
     @Test
-    fun `should process Boundary- and OptionalAnnotation on class method level`() {
+    fun `should process Boundary- and OptionalAnnotation on function level`() {
         // given
         testParameter1.annotations.add(
             BoundaryAnnotation(
@@ -259,17 +238,13 @@ class MethodPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
-            |class testClass:
-            |    def __init__():
-            |        self.instance = testModule.testClass()
+            |def testFunction(testParameter2, testParameter3, *, testParameter1=0.5):
+            |    if not (isinstance(testParameter1, int) or (isinstance(testParameter1, float) and testParameter1.is_integer())):
+            |        raise ValueError(f'testParameter1 needs to be an integer, but {testParameter1} was assigned.')
+            |    if not 0.0 <= testParameter1 <= 1.0:
+            |        raise ValueError(f'Valid values of testParameter1 must be in [0.0, 1.0], but {testParameter1} was assigned.')
             |
-            |    def testMethod(self, testParameter2, testParameter3, *, testParameter1=0.5):
-            |        if not (isinstance(testParameter1, int) or (isinstance(testParameter1, float) and testParameter1.is_integer())):
-            |            raise ValueError(f'testParameter1 needs to be an integer, but {testParameter1} was assigned.')
-            |        if not 0.0 <= testParameter1 <= 1.0:
-            |            raise ValueError(f'Valid values of testParameter1 must be in [0.0, 1.0], but {testParameter1} was assigned.')
-            |
-            |        return self.instance.testMethod(testParameter1, testParameter2, testParameter3)
+            |    return testModule.testFunction(testParameter1, testParameter2, testParameter3)
             |
             """.trimMargin()
 
@@ -277,15 +252,15 @@ class MethodPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Boundary- and RequiredAnnotation on class method level`() {
+    fun `should process Boundary- and RequiredAnnotation on function level`() {
         // given
         testParameter1.annotations.add(
             BoundaryAnnotation(
                 isDiscrete = true,
                 lowerIntervalLimit = 0.0,
-                lowerLimitType = ComparisonOperator.LESS_THAN,
+                lowerLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS,
                 upperIntervalLimit = 1.0,
-                upperLimitType = ComparisonOperator.UNRESTRICTED
+                upperLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS
             )
         )
         testParameter1.annotations.add(
@@ -303,17 +278,13 @@ class MethodPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
-            |class testClass:
-            |    def __init__():
-            |        self.instance = testModule.testClass()
+            |def testFunction(testParameter1, testParameter2, testParameter3):
+            |    if not (isinstance(testParameter1, int) or (isinstance(testParameter1, float) and testParameter1.is_integer())):
+            |        raise ValueError(f'testParameter1 needs to be an integer, but {testParameter1} was assigned.')
+            |    if not 0.0 <= testParameter1 <= 1.0:
+            |        raise ValueError(f'Valid values of testParameter1 must be in [0.0, 1.0], but {testParameter1} was assigned.')
             |
-            |    def testMethod(self, testParameter1, testParameter2, testParameter3):
-            |        if not (isinstance(testParameter1, int) or (isinstance(testParameter1, float) and testParameter1.is_integer())):
-            |            raise ValueError(f'testParameter1 needs to be an integer, but {testParameter1} was assigned.')
-            |        if not 0.0 < testParameter1:
-            |            raise ValueError(f'Valid values of testParameter1 must be greater than 0.0, but {testParameter1} was assigned.')
-            |
-            |        return self.instance.testMethod(testParameter1, testParameter2, testParameter3)
+            |    return testModule.testFunction(testParameter1, testParameter2, testParameter3)
             |
             """.trimMargin()
 
@@ -321,7 +292,7 @@ class MethodPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Enum- and GroupAnnotation on class method level`() {
+    fun `should process Enum- and GroupAnnotation on function level`() {
         // given
         testParameter1.annotations.add(
             EnumAnnotation(
@@ -351,17 +322,13 @@ class MethodPythonCodeGeneratorTest {
             |from abc import ABC
             |from dataclasses import dataclass
             |
-            |class testClass:
-            |    def __init__():
-            |        self.instance = testModule.testClass()
-            |
-            |    def testMethod(self, testGroup: TestGroup, testParameter3):
-            |        return self.instance.testMethod(testGroup.testParameter1.value, testGroup.testParameter2, testParameter3)
-            |
             |class TestGroup:
             |    def __init__(self, testParameter1: TestEnum, testParameter2):
             |        self.testParameter1: TestEnum = testParameter1
             |        self.testParameter2 = testParameter2
+            |
+            |def testFunction(testGroup: TestGroup, testParameter3):
+            |    return testModule.testFunction(testGroup.testParameter1.value, testGroup.testParameter2, testParameter3)
             |
             |class TestEnum(ABC):
             |    value: str
@@ -382,7 +349,7 @@ class MethodPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Enum-, Required- and GroupAnnotation on class method level`() {
+    fun `should process Enum-, Required- and GroupAnnotation on function level`() {
         // given
         testParameter1.annotations.add(
             EnumAnnotation(
@@ -396,6 +363,7 @@ class MethodPythonCodeGeneratorTest {
         testParameter1.annotations.add(
             RequiredAnnotation
         )
+        testParameter1.defaultValue = PythonStringifiedExpression("toRemove")
         testFunction.annotations.add(
             GroupAnnotation(
                 groupName = "TestGroup",
@@ -415,17 +383,13 @@ class MethodPythonCodeGeneratorTest {
             |from abc import ABC
             |from dataclasses import dataclass
             |
-            |class testClass:
-            |    def __init__():
-            |        self.instance = testModule.testClass()
-            |
-            |    def testMethod(self, testGroup: TestGroup, testParameter3):
-            |        return self.instance.testMethod(testGroup.testParameter1.value, testGroup.testParameter2, testParameter3)
-            |
             |class TestGroup:
             |    def __init__(self, testParameter1: TestEnum, testParameter2):
             |        self.testParameter1: TestEnum = testParameter1
             |        self.testParameter2 = testParameter2
+            |
+            |def testFunction(testGroup: TestGroup, testParameter3):
+            |    return testModule.testFunction(testGroup.testParameter1.value, testGroup.testParameter2, testParameter3)
             |
             |class TestEnum(ABC):
             |    value: str
@@ -446,7 +410,7 @@ class MethodPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Enum- and RequiredAnnotation on class method level`() {
+    fun `should process Enum- and RequiredAnnotation on function level`() {
         // given
         testParameter1.annotations.add(
             EnumAnnotation(
@@ -474,12 +438,8 @@ class MethodPythonCodeGeneratorTest {
             |from abc import ABC
             |from dataclasses import dataclass
             |
-            |class testClass:
-            |    def __init__():
-            |        self.instance = testModule.testClass()
-            |
-            |    def testMethod(self, testParameter1: TestEnum, testParameter2, testParameter3):
-            |        return self.instance.testMethod(testParameter1.value, testParameter2, testParameter3)
+            |def testFunction(testParameter1: TestEnum, testParameter2, testParameter3):
+            |    return testModule.testFunction(testParameter1.value, testParameter2, testParameter3)
             |
             |class TestEnum(ABC):
             |    value: str
@@ -500,12 +460,13 @@ class MethodPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Group- and RequiredAnnotation on class method level`() {
+    fun `should process Group- and RequiredAnnotation on function level`() {
         // given
         testParameter2.annotations.add(
             RequiredAnnotation
         )
         testParameter2.defaultValue = PythonStringifiedExpression("toRemove")
+        testParameter1.defaultValue = PythonStringifiedExpression("defaultValue")
         testFunction.annotations.add(
             GroupAnnotation(
                 groupName = "TestGroup",
@@ -522,30 +483,26 @@ class MethodPythonCodeGeneratorTest {
             |import testModule
             |
             |from __future__ import annotations
-            |
-            |class testClass:
-            |    def __init__():
-            |        self.instance = testModule.testClass()
-            |
-            |    def testMethod(self, testParameter1, testGroup: TestGroup):
-            |        return self.instance.testMethod(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
             |
             |class TestGroup:
             |    def __init__(self, testParameter2, testParameter3):
             |        self.testParameter2 = testParameter2
             |        self.testParameter3 = testParameter3
             |
+            |def testFunction(testGroup: TestGroup, *, testParameter1=defaultValue):
+            |    return testModule.testFunction(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
+            |
             """.trimMargin()
 
         moduleContent shouldBe expectedModuleContent
     }
 
     @Test
-    fun `should process Group- and OptionalAnnotation on class method level`() {
+    fun `should process Group- and OptionalAnnotation on function level`() {
         // given
         testParameter2.annotations.add(
             OptionalAnnotation(
-                DefaultBoolean(false)
+                DefaultString("string")
             )
         )
         testFunction.annotations.add(
@@ -565,17 +522,13 @@ class MethodPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
-            |class testClass:
-            |    def __init__():
-            |        self.instance = testModule.testClass()
-            |
-            |    def testMethod(self, testParameter1, testGroup: TestGroup):
-            |        return self.instance.testMethod(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
-            |
             |class TestGroup:
-            |    def __init__(self, testParameter3, *, testParameter2=False):
+            |    def __init__(self, testParameter3, *, testParameter2='string'):
             |        self.testParameter3 = testParameter3
             |        self.testParameter2 = testParameter2
+            |
+            |def testFunction(testParameter1, testGroup: TestGroup):
+            |    return testModule.testFunction(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
             |
             """.trimMargin()
 
@@ -583,7 +536,7 @@ class MethodPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Group-, Required- and OptionalAnnotation on class method level`() {
+    fun `should process Group-, Required- and OptionalAnnotation on function level`() {
         // given
         testParameter2.annotations.add(
             OptionalAnnotation(
@@ -611,17 +564,13 @@ class MethodPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
-            |class testClass:
-            |    def __init__():
-            |        self.instance = testModule.testClass()
-            |
-            |    def testMethod(self, testParameter1, testGroup: TestGroup):
-            |        return self.instance.testMethod(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
-            |
             |class TestGroup:
             |    def __init__(self, testParameter3, *, testParameter2=False):
             |        self.testParameter3 = testParameter3
             |        self.testParameter2 = testParameter2
+            |
+            |def testFunction(testParameter1, testGroup: TestGroup):
+            |    return testModule.testFunction(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
             |
             """.trimMargin()
 
@@ -629,16 +578,22 @@ class MethodPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process GroupAnnotation on class method with RenameAnnotation on parameter level`() {
+    fun `should process Boundary- and RenameAnnotation on parameter on a function with RenameAnnotation`() {
         // given
-        testFunction.annotations.add(
-            GroupAnnotation(
-                groupName = "TestGroup",
-                parameters = mutableListOf("testParameter1", "testParameter2")
+        testParameter1.annotations.add(
+            BoundaryAnnotation(
+                isDiscrete = true,
+                lowerIntervalLimit = 0.0,
+                lowerLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS,
+                upperIntervalLimit = 1.0,
+                upperLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS
             )
         )
         testParameter1.annotations.add(
             RenameAnnotation("renamedTestParameter1")
+        )
+        testFunction.annotations.add(
+            RenameAnnotation("renamedTestFunction")
         )
         // when
         testPackage.transform()
@@ -651,17 +606,129 @@ class MethodPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
-            |class testClass:
-            |    def __init__():
-            |        self.instance = testModule.testClass()
+            |def renamedTestFunction(renamedTestParameter1, testParameter2, testParameter3):
+            |    if not (isinstance(renamedTestParameter1, int) or (isinstance(renamedTestParameter1, float) and renamedTestParameter1.is_integer())):
+            |        raise ValueError(f'renamedTestParameter1 needs to be an integer, but {renamedTestParameter1} was assigned.')
+            |    if not 0.0 <= renamedTestParameter1 <= 1.0:
+            |        raise ValueError(f'Valid values of renamedTestParameter1 must be in [0.0, 1.0], but {renamedTestParameter1} was assigned.')
             |
-            |    def testMethod(self, testGroup: TestGroup, testParameter3):
-            |        return self.instance.testMethod(testGroup.renamedTestParameter1, testGroup.testParameter2, testParameter3)
+            |    return testModule.testFunction(renamedTestParameter1, testParameter2, testParameter3)
+            |
+            """.trimMargin()
+
+        moduleContent shouldBe expectedModuleContent
+    }
+
+    @Test
+    fun `should process Enum- and GroupAnnotation on function with MoveAnnotation`() {
+        // given
+        testParameter1.annotations.add(
+            EnumAnnotation(
+                "TestEnum",
+                listOf(
+                    EnumPair("testValue1", "testName1"),
+                    EnumPair("testValue2", "testName2")
+                )
+            )
+        )
+        testFunction.annotations.add(
+            GroupAnnotation(
+                groupName = "TestGroup",
+                parameters = mutableListOf("testParameter1", "testParameter2")
+            )
+        )
+        testFunction.annotations.add(
+            MoveAnnotation("movedTestModule")
+        )
+        // when
+        testPackage.transform()
+        val moduleContent = testPackage.modules[0].toPythonCode()
+
+        // then
+        val expectedModuleContent: String =
+            """
+            |import testModule
+            |
+            |from __future__ import annotations
+            |from abc import ABC
+            |from dataclasses import dataclass
             |
             |class TestGroup:
-            |    def __init__(self, renamedTestParameter1, testParameter2):
-            |        self.renamedTestParameter1 = renamedTestParameter1
+            |    def __init__(self, testParameter1: TestEnum, testParameter2):
+            |        self.testParameter1: TestEnum = testParameter1
             |        self.testParameter2 = testParameter2
+            |
+            |def testFunction(testGroup: TestGroup, testParameter3):
+            |    return testModule.testFunction(testGroup.testParameter1.value, testGroup.testParameter2, testParameter3)
+            |
+            |class TestEnum(ABC):
+            |    value: str
+            |
+            |@dataclass
+            |class _testName1(TestEnum):
+            |    value = 'testValue1'
+            |TestEnum.testName1 = _testName1
+            |
+            |@dataclass
+            |class _testName2(TestEnum):
+            |    value = 'testValue2'
+            |TestEnum.testName2 = _testName2
+            |
+            """.trimMargin()
+
+        moduleContent shouldBe expectedModuleContent
+        testPackage.modules[0].name shouldBe "movedTestModule"
+    }
+
+    @Test
+    fun `should process Rename-, Boundary-, Group- and OptionalAnnotation on function level`() {
+        // given
+        testParameter2.annotations.add(
+            BoundaryAnnotation(
+                isDiscrete = true,
+                lowerIntervalLimit = 0.0,
+                lowerLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS,
+                upperIntervalLimit = 1.0,
+                upperLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS
+            )
+        )
+        testParameter2.annotations.add(
+            OptionalAnnotation(
+                DefaultNumber(0.5)
+            )
+        )
+        testParameter2.annotations.add(
+            RenameAnnotation("renamedTestParameter2")
+        )
+        testFunction.annotations.add(
+            GroupAnnotation(
+                groupName = "TestGroup",
+                parameters = mutableListOf("testParameter2", "testParameter3")
+            )
+        )
+        // when
+        testPackage.transform()
+        val moduleContent = testPackage.modules[0].toPythonCode()
+
+        // then
+        val expectedModuleContent: String =
+            """
+            |import testModule
+            |
+            |from __future__ import annotations
+            |
+            |class TestGroup:
+            |    def __init__(self, testParameter3, *, renamedTestParameter2=0.5):
+            |        if not (isinstance(renamedTestParameter2, int) or (isinstance(renamedTestParameter2, float) and renamedTestParameter2.is_integer())):
+            |            raise ValueError(f'renamedTestParameter2 needs to be an integer, but {renamedTestParameter2} was assigned.')
+            |        if not 0.0 <= renamedTestParameter2 <= 1.0:
+            |            raise ValueError(f'Valid values of renamedTestParameter2 must be in [0.0, 1.0], but {renamedTestParameter2} was assigned.')
+            |
+            |        self.testParameter3 = testParameter3
+            |        self.renamedTestParameter2 = renamedTestParameter2
+            |
+            |def testFunction(testParameter1, testGroup: TestGroup):
+            |    return testModule.testFunction(testParameter1, testGroup.renamedTestParameter2, testGroup.testParameter3)
             |
             """.trimMargin()
 

--- a/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/MethodPythonCodeGeneratorFullPipelineTest.kt
+++ b/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/MethodPythonCodeGeneratorFullPipelineTest.kt
@@ -1,19 +1,18 @@
-package com.larsreimann.api_editor.codegen.python_code_gen
+package com.larsreimann.api_editor.codegen
 
-import com.larsreimann.api_editor.codegen.toPythonCode
 import com.larsreimann.api_editor.model.BoundaryAnnotation
 import com.larsreimann.api_editor.model.ComparisonOperator
 import com.larsreimann.api_editor.model.DefaultBoolean
 import com.larsreimann.api_editor.model.DefaultNumber
-import com.larsreimann.api_editor.model.DefaultString
 import com.larsreimann.api_editor.model.EnumAnnotation
 import com.larsreimann.api_editor.model.EnumPair
 import com.larsreimann.api_editor.model.GroupAnnotation
-import com.larsreimann.api_editor.model.MoveAnnotation
 import com.larsreimann.api_editor.model.OptionalAnnotation
 import com.larsreimann.api_editor.model.RenameAnnotation
 import com.larsreimann.api_editor.model.RequiredAnnotation
+import com.larsreimann.api_editor.mutable_model.PythonClass
 import com.larsreimann.api_editor.mutable_model.PythonFunction
+import com.larsreimann.api_editor.mutable_model.PythonInt
 import com.larsreimann.api_editor.mutable_model.PythonModule
 import com.larsreimann.api_editor.mutable_model.PythonPackage
 import com.larsreimann.api_editor.mutable_model.PythonParameter
@@ -23,36 +22,43 @@ import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class FunctionPythonCodeGeneratorTest {
+class MethodPythonCodeGeneratorFullPipelineTest {
+    private lateinit var testParameterSelf: PythonParameter
     private lateinit var testParameter1: PythonParameter
     private lateinit var testParameter2: PythonParameter
     private lateinit var testParameter3: PythonParameter
+    private lateinit var testClass: PythonClass
     private lateinit var testFunction: PythonFunction
     private lateinit var testModule: PythonModule
     private lateinit var testPackage: PythonPackage
 
     @BeforeEach
     fun reset() {
+        testParameterSelf = PythonParameter(
+            name = "self"
+        )
         testParameter1 = PythonParameter(
-            name = "testParameter1",
+            name = "testParameter1"
         )
         testParameter2 = PythonParameter(
-            name = "testParameter2",
+            name = "testParameter2"
         )
         testParameter3 = PythonParameter(
-            name = "testParameter3",
+            name = "testParameter3"
         )
         testFunction = PythonFunction(
-            name = "testFunction",
+            name = "testMethod",
             parameters = mutableListOf(
+                testParameterSelf,
                 testParameter1,
                 testParameter2,
                 testParameter3
             )
         )
+        testClass = PythonClass(name = "testClass", methods = mutableListOf(testFunction))
         testModule = PythonModule(
             name = "testModule",
-            functions = mutableListOf(testFunction)
+            classes = mutableListOf(testClass)
         )
         testPackage = PythonPackage(
             distribution = "testPackage",
@@ -63,7 +69,7 @@ class FunctionPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Boundary- and GroupAnnotation on function level`() {
+    fun `should process Boundary- and GroupAnnotation on class method level`() {
         // given
         testParameter1.annotations.add(
             BoundaryAnnotation(
@@ -77,7 +83,7 @@ class FunctionPythonCodeGeneratorTest {
         testFunction.annotations.add(
             GroupAnnotation(
                 groupName = "TestGroup",
-                parameters = mutableListOf("testParameter1", "testParameter3")
+                parameters = mutableListOf("testParameter1", "testParameter2")
             )
         )
         // when
@@ -91,18 +97,22 @@ class FunctionPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
+            |class testClass:
+            |    def __init__():
+            |        self.instance = testModule.testClass()
+            |
+            |    def testMethod(self, testGroup: TestGroup, testParameter3):
+            |        return self.instance.testMethod(testGroup.testParameter1, testGroup.testParameter2, testParameter3)
+            |
             |class TestGroup:
-            |    def __init__(self, testParameter1, testParameter3):
+            |    def __init__(self, testParameter1, testParameter2):
             |        if not (isinstance(testParameter1, int) or (isinstance(testParameter1, float) and testParameter1.is_integer())):
             |            raise ValueError(f'testParameter1 needs to be an integer, but {testParameter1} was assigned.')
             |        if not 0.0 <= testParameter1 <= 1.0:
             |            raise ValueError(f'Valid values of testParameter1 must be in [0.0, 1.0], but {testParameter1} was assigned.')
             |
             |        self.testParameter1 = testParameter1
-            |        self.testParameter3 = testParameter3
-            |
-            |def testFunction(testGroup: TestGroup, testParameter2):
-            |    return testModule.testFunction(testGroup.testParameter1, testParameter2, testGroup.testParameter3)
+            |        self.testParameter2 = testParameter2
             |
             """.trimMargin()
 
@@ -110,15 +120,15 @@ class FunctionPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Boundary-, Group- and OptionalAnnotation on function level`() {
+    fun `should process Boundary-, Group- and OptionalAnnotation on class method level`() {
         // given
         testParameter2.annotations.add(
             BoundaryAnnotation(
                 isDiscrete = true,
                 lowerIntervalLimit = 0.0,
-                lowerLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS,
+                lowerLimitType = ComparisonOperator.UNRESTRICTED,
                 upperIntervalLimit = 1.0,
-                upperLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS
+                upperLimitType = ComparisonOperator.LESS_THAN
             )
         )
         testParameter2.annotations.add(
@@ -129,7 +139,7 @@ class FunctionPythonCodeGeneratorTest {
         testFunction.annotations.add(
             GroupAnnotation(
                 groupName = "TestGroup",
-                parameters = mutableListOf("testParameter2", "testParameter3")
+                parameters = mutableListOf("testParameter1", "testParameter2")
             )
         )
         // when
@@ -143,18 +153,22 @@ class FunctionPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
+            |class testClass:
+            |    def __init__():
+            |        self.instance = testModule.testClass()
+            |
+            |    def testMethod(self, testGroup: TestGroup, testParameter3):
+            |        return self.instance.testMethod(testGroup.testParameter1, testGroup.testParameter2, testParameter3)
+            |
             |class TestGroup:
-            |    def __init__(self, testParameter3, *, testParameter2=0.5):
+            |    def __init__(self, testParameter1, *, testParameter2=0.5):
             |        if not (isinstance(testParameter2, int) or (isinstance(testParameter2, float) and testParameter2.is_integer())):
             |            raise ValueError(f'testParameter2 needs to be an integer, but {testParameter2} was assigned.')
-            |        if not 0.0 <= testParameter2 <= 1.0:
-            |            raise ValueError(f'Valid values of testParameter2 must be in [0.0, 1.0], but {testParameter2} was assigned.')
+            |        if not testParameter2 < 1.0:
+            |            raise ValueError(f'Valid values of testParameter2 must be less than 1.0, but {testParameter2} was assigned.')
             |
-            |        self.testParameter3 = testParameter3
+            |        self.testParameter1 = testParameter1
             |        self.testParameter2 = testParameter2
-            |
-            |def testFunction(testParameter1, testGroup: TestGroup):
-            |    return testModule.testFunction(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
             |
             """.trimMargin()
 
@@ -162,7 +176,7 @@ class FunctionPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Boundary-, Group- and RequiredAnnotation on function level`() {
+    fun `should process Boundary-, Group- and RequiredAnnotation on class method level`() {
         // given
         testParameter2.annotations.add(
             BoundaryAnnotation(
@@ -176,6 +190,7 @@ class FunctionPythonCodeGeneratorTest {
         testParameter2.annotations.add(
             RequiredAnnotation
         )
+        testParameter2.defaultValue = PythonInt(0)
         testFunction.annotations.add(
             GroupAnnotation(
                 groupName = "TestGroup",
@@ -193,6 +208,13 @@ class FunctionPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
+            |class testClass:
+            |    def __init__():
+            |        self.instance = testModule.testClass()
+            |
+            |    def testMethod(self, testParameter1, testGroup: TestGroup):
+            |        return self.instance.testMethod(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
+            |
             |class TestGroup:
             |    def __init__(self, testParameter2, testParameter3):
             |        if not (isinstance(testParameter2, int) or (isinstance(testParameter2, float) and testParameter2.is_integer())):
@@ -203,16 +225,13 @@ class FunctionPythonCodeGeneratorTest {
             |        self.testParameter2 = testParameter2
             |        self.testParameter3 = testParameter3
             |
-            |def testFunction(testParameter1, testGroup: TestGroup):
-            |    return testModule.testFunction(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
-            |
             """.trimMargin()
 
         moduleContent shouldBe expectedModuleContent
     }
 
     @Test
-    fun `should process Boundary- and OptionalAnnotation on function level`() {
+    fun `should process Boundary- and OptionalAnnotation on class method level`() {
         // given
         testParameter1.annotations.add(
             BoundaryAnnotation(
@@ -239,13 +258,17 @@ class FunctionPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
-            |def testFunction(testParameter2, testParameter3, *, testParameter1=0.5):
-            |    if not (isinstance(testParameter1, int) or (isinstance(testParameter1, float) and testParameter1.is_integer())):
-            |        raise ValueError(f'testParameter1 needs to be an integer, but {testParameter1} was assigned.')
-            |    if not 0.0 <= testParameter1 <= 1.0:
-            |        raise ValueError(f'Valid values of testParameter1 must be in [0.0, 1.0], but {testParameter1} was assigned.')
+            |class testClass:
+            |    def __init__():
+            |        self.instance = testModule.testClass()
             |
-            |    return testModule.testFunction(testParameter1, testParameter2, testParameter3)
+            |    def testMethod(self, testParameter2, testParameter3, *, testParameter1=0.5):
+            |        if not (isinstance(testParameter1, int) or (isinstance(testParameter1, float) and testParameter1.is_integer())):
+            |            raise ValueError(f'testParameter1 needs to be an integer, but {testParameter1} was assigned.')
+            |        if not 0.0 <= testParameter1 <= 1.0:
+            |            raise ValueError(f'Valid values of testParameter1 must be in [0.0, 1.0], but {testParameter1} was assigned.')
+            |
+            |        return self.instance.testMethod(testParameter1, testParameter2, testParameter3)
             |
             """.trimMargin()
 
@@ -253,15 +276,15 @@ class FunctionPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Boundary- and RequiredAnnotation on function level`() {
+    fun `should process Boundary- and RequiredAnnotation on class method level`() {
         // given
         testParameter1.annotations.add(
             BoundaryAnnotation(
                 isDiscrete = true,
                 lowerIntervalLimit = 0.0,
-                lowerLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS,
+                lowerLimitType = ComparisonOperator.LESS_THAN,
                 upperIntervalLimit = 1.0,
-                upperLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS
+                upperLimitType = ComparisonOperator.UNRESTRICTED
             )
         )
         testParameter1.annotations.add(
@@ -279,13 +302,17 @@ class FunctionPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
-            |def testFunction(testParameter1, testParameter2, testParameter3):
-            |    if not (isinstance(testParameter1, int) or (isinstance(testParameter1, float) and testParameter1.is_integer())):
-            |        raise ValueError(f'testParameter1 needs to be an integer, but {testParameter1} was assigned.')
-            |    if not 0.0 <= testParameter1 <= 1.0:
-            |        raise ValueError(f'Valid values of testParameter1 must be in [0.0, 1.0], but {testParameter1} was assigned.')
+            |class testClass:
+            |    def __init__():
+            |        self.instance = testModule.testClass()
             |
-            |    return testModule.testFunction(testParameter1, testParameter2, testParameter3)
+            |    def testMethod(self, testParameter1, testParameter2, testParameter3):
+            |        if not (isinstance(testParameter1, int) or (isinstance(testParameter1, float) and testParameter1.is_integer())):
+            |            raise ValueError(f'testParameter1 needs to be an integer, but {testParameter1} was assigned.')
+            |        if not 0.0 < testParameter1:
+            |            raise ValueError(f'Valid values of testParameter1 must be greater than 0.0, but {testParameter1} was assigned.')
+            |
+            |        return self.instance.testMethod(testParameter1, testParameter2, testParameter3)
             |
             """.trimMargin()
 
@@ -293,7 +320,7 @@ class FunctionPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Enum- and GroupAnnotation on function level`() {
+    fun `should process Enum- and GroupAnnotation on class method level`() {
         // given
         testParameter1.annotations.add(
             EnumAnnotation(
@@ -323,13 +350,17 @@ class FunctionPythonCodeGeneratorTest {
             |from abc import ABC
             |from dataclasses import dataclass
             |
+            |class testClass:
+            |    def __init__():
+            |        self.instance = testModule.testClass()
+            |
+            |    def testMethod(self, testGroup: TestGroup, testParameter3):
+            |        return self.instance.testMethod(testGroup.testParameter1.value, testGroup.testParameter2, testParameter3)
+            |
             |class TestGroup:
             |    def __init__(self, testParameter1: TestEnum, testParameter2):
             |        self.testParameter1: TestEnum = testParameter1
             |        self.testParameter2 = testParameter2
-            |
-            |def testFunction(testGroup: TestGroup, testParameter3):
-            |    return testModule.testFunction(testGroup.testParameter1.value, testGroup.testParameter2, testParameter3)
             |
             |class TestEnum(ABC):
             |    value: str
@@ -350,7 +381,7 @@ class FunctionPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Enum-, Required- and GroupAnnotation on function level`() {
+    fun `should process Enum-, Required- and GroupAnnotation on class method level`() {
         // given
         testParameter1.annotations.add(
             EnumAnnotation(
@@ -364,7 +395,6 @@ class FunctionPythonCodeGeneratorTest {
         testParameter1.annotations.add(
             RequiredAnnotation
         )
-        testParameter1.defaultValue = PythonStringifiedExpression("toRemove")
         testFunction.annotations.add(
             GroupAnnotation(
                 groupName = "TestGroup",
@@ -384,13 +414,17 @@ class FunctionPythonCodeGeneratorTest {
             |from abc import ABC
             |from dataclasses import dataclass
             |
+            |class testClass:
+            |    def __init__():
+            |        self.instance = testModule.testClass()
+            |
+            |    def testMethod(self, testGroup: TestGroup, testParameter3):
+            |        return self.instance.testMethod(testGroup.testParameter1.value, testGroup.testParameter2, testParameter3)
+            |
             |class TestGroup:
             |    def __init__(self, testParameter1: TestEnum, testParameter2):
             |        self.testParameter1: TestEnum = testParameter1
             |        self.testParameter2 = testParameter2
-            |
-            |def testFunction(testGroup: TestGroup, testParameter3):
-            |    return testModule.testFunction(testGroup.testParameter1.value, testGroup.testParameter2, testParameter3)
             |
             |class TestEnum(ABC):
             |    value: str
@@ -411,7 +445,7 @@ class FunctionPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Enum- and RequiredAnnotation on function level`() {
+    fun `should process Enum- and RequiredAnnotation on class method level`() {
         // given
         testParameter1.annotations.add(
             EnumAnnotation(
@@ -439,8 +473,12 @@ class FunctionPythonCodeGeneratorTest {
             |from abc import ABC
             |from dataclasses import dataclass
             |
-            |def testFunction(testParameter1: TestEnum, testParameter2, testParameter3):
-            |    return testModule.testFunction(testParameter1.value, testParameter2, testParameter3)
+            |class testClass:
+            |    def __init__():
+            |        self.instance = testModule.testClass()
+            |
+            |    def testMethod(self, testParameter1: TestEnum, testParameter2, testParameter3):
+            |        return self.instance.testMethod(testParameter1.value, testParameter2, testParameter3)
             |
             |class TestEnum(ABC):
             |    value: str
@@ -461,13 +499,12 @@ class FunctionPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Group- and RequiredAnnotation on function level`() {
+    fun `should process Group- and RequiredAnnotation on class method level`() {
         // given
         testParameter2.annotations.add(
             RequiredAnnotation
         )
         testParameter2.defaultValue = PythonStringifiedExpression("toRemove")
-        testParameter1.defaultValue = PythonStringifiedExpression("defaultValue")
         testFunction.annotations.add(
             GroupAnnotation(
                 groupName = "TestGroup",
@@ -484,26 +521,30 @@ class FunctionPythonCodeGeneratorTest {
             |import testModule
             |
             |from __future__ import annotations
+            |
+            |class testClass:
+            |    def __init__():
+            |        self.instance = testModule.testClass()
+            |
+            |    def testMethod(self, testParameter1, testGroup: TestGroup):
+            |        return self.instance.testMethod(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
             |
             |class TestGroup:
             |    def __init__(self, testParameter2, testParameter3):
             |        self.testParameter2 = testParameter2
             |        self.testParameter3 = testParameter3
             |
-            |def testFunction(testGroup: TestGroup, *, testParameter1=defaultValue):
-            |    return testModule.testFunction(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
-            |
             """.trimMargin()
 
         moduleContent shouldBe expectedModuleContent
     }
 
     @Test
-    fun `should process Group- and OptionalAnnotation on function level`() {
+    fun `should process Group- and OptionalAnnotation on class method level`() {
         // given
         testParameter2.annotations.add(
             OptionalAnnotation(
-                DefaultString("string")
+                DefaultBoolean(false)
             )
         )
         testFunction.annotations.add(
@@ -523,13 +564,17 @@ class FunctionPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
+            |class testClass:
+            |    def __init__():
+            |        self.instance = testModule.testClass()
+            |
+            |    def testMethod(self, testParameter1, testGroup: TestGroup):
+            |        return self.instance.testMethod(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
+            |
             |class TestGroup:
-            |    def __init__(self, testParameter3, *, testParameter2='string'):
+            |    def __init__(self, testParameter3, *, testParameter2=False):
             |        self.testParameter3 = testParameter3
             |        self.testParameter2 = testParameter2
-            |
-            |def testFunction(testParameter1, testGroup: TestGroup):
-            |    return testModule.testFunction(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
             |
             """.trimMargin()
 
@@ -537,7 +582,7 @@ class FunctionPythonCodeGeneratorTest {
     }
 
     @Test
-    fun `should process Group-, Required- and OptionalAnnotation on function level`() {
+    fun `should process Group-, Required- and OptionalAnnotation on class method level`() {
         // given
         testParameter2.annotations.add(
             OptionalAnnotation(
@@ -565,81 +610,34 @@ class FunctionPythonCodeGeneratorTest {
             |
             |from __future__ import annotations
             |
+            |class testClass:
+            |    def __init__():
+            |        self.instance = testModule.testClass()
+            |
+            |    def testMethod(self, testParameter1, testGroup: TestGroup):
+            |        return self.instance.testMethod(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
+            |
             |class TestGroup:
             |    def __init__(self, testParameter3, *, testParameter2=False):
             |        self.testParameter3 = testParameter3
             |        self.testParameter2 = testParameter2
             |
-            |def testFunction(testParameter1, testGroup: TestGroup):
-            |    return testModule.testFunction(testParameter1, testGroup.testParameter2, testGroup.testParameter3)
-            |
             """.trimMargin()
 
         moduleContent shouldBe expectedModuleContent
     }
 
     @Test
-    fun `should process Boundary- and RenameAnnotation on parameter on a function with RenameAnnotation`() {
+    fun `should process GroupAnnotation on class method with RenameAnnotation on parameter level`() {
         // given
-        testParameter1.annotations.add(
-            BoundaryAnnotation(
-                isDiscrete = true,
-                lowerIntervalLimit = 0.0,
-                lowerLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS,
-                upperIntervalLimit = 1.0,
-                upperLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS
-            )
-        )
-        testParameter1.annotations.add(
-            RenameAnnotation("renamedTestParameter1")
-        )
-        testFunction.annotations.add(
-            RenameAnnotation("renamedTestFunction")
-        )
-        // when
-        testPackage.transform()
-        val moduleContent = testPackage.modules[0].toPythonCode()
-
-        // then
-        val expectedModuleContent: String =
-            """
-            |import testModule
-            |
-            |from __future__ import annotations
-            |
-            |def renamedTestFunction(renamedTestParameter1, testParameter2, testParameter3):
-            |    if not (isinstance(renamedTestParameter1, int) or (isinstance(renamedTestParameter1, float) and renamedTestParameter1.is_integer())):
-            |        raise ValueError(f'renamedTestParameter1 needs to be an integer, but {renamedTestParameter1} was assigned.')
-            |    if not 0.0 <= renamedTestParameter1 <= 1.0:
-            |        raise ValueError(f'Valid values of renamedTestParameter1 must be in [0.0, 1.0], but {renamedTestParameter1} was assigned.')
-            |
-            |    return testModule.testFunction(renamedTestParameter1, testParameter2, testParameter3)
-            |
-            """.trimMargin()
-
-        moduleContent shouldBe expectedModuleContent
-    }
-
-    @Test
-    fun `should process Enum- and GroupAnnotation on function with MoveAnnotation`() {
-        // given
-        testParameter1.annotations.add(
-            EnumAnnotation(
-                "TestEnum",
-                listOf(
-                    EnumPair("testValue1", "testName1"),
-                    EnumPair("testValue2", "testName2")
-                )
-            )
-        )
         testFunction.annotations.add(
             GroupAnnotation(
                 groupName = "TestGroup",
                 parameters = mutableListOf("testParameter1", "testParameter2")
             )
         )
-        testFunction.annotations.add(
-            MoveAnnotation("movedTestModule")
+        testParameter1.annotations.add(
+            RenameAnnotation("renamedTestParameter1")
         )
         // when
         testPackage.transform()
@@ -651,85 +649,18 @@ class FunctionPythonCodeGeneratorTest {
             |import testModule
             |
             |from __future__ import annotations
-            |from abc import ABC
-            |from dataclasses import dataclass
+            |
+            |class testClass:
+            |    def __init__():
+            |        self.instance = testModule.testClass()
+            |
+            |    def testMethod(self, testGroup: TestGroup, testParameter3):
+            |        return self.instance.testMethod(testGroup.renamedTestParameter1, testGroup.testParameter2, testParameter3)
             |
             |class TestGroup:
-            |    def __init__(self, testParameter1: TestEnum, testParameter2):
-            |        self.testParameter1: TestEnum = testParameter1
+            |    def __init__(self, renamedTestParameter1, testParameter2):
+            |        self.renamedTestParameter1 = renamedTestParameter1
             |        self.testParameter2 = testParameter2
-            |
-            |def testFunction(testGroup: TestGroup, testParameter3):
-            |    return testModule.testFunction(testGroup.testParameter1.value, testGroup.testParameter2, testParameter3)
-            |
-            |class TestEnum(ABC):
-            |    value: str
-            |
-            |@dataclass
-            |class _testName1(TestEnum):
-            |    value = 'testValue1'
-            |TestEnum.testName1 = _testName1
-            |
-            |@dataclass
-            |class _testName2(TestEnum):
-            |    value = 'testValue2'
-            |TestEnum.testName2 = _testName2
-            |
-            """.trimMargin()
-
-        moduleContent shouldBe expectedModuleContent
-        testPackage.modules[0].name shouldBe "movedTestModule"
-    }
-
-    @Test
-    fun `should process Rename-, Boundary-, Group- and OptionalAnnotation on function level`() {
-        // given
-        testParameter2.annotations.add(
-            BoundaryAnnotation(
-                isDiscrete = true,
-                lowerIntervalLimit = 0.0,
-                lowerLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS,
-                upperIntervalLimit = 1.0,
-                upperLimitType = ComparisonOperator.LESS_THAN_OR_EQUALS
-            )
-        )
-        testParameter2.annotations.add(
-            OptionalAnnotation(
-                DefaultNumber(0.5)
-            )
-        )
-        testParameter2.annotations.add(
-            RenameAnnotation("renamedTestParameter2")
-        )
-        testFunction.annotations.add(
-            GroupAnnotation(
-                groupName = "TestGroup",
-                parameters = mutableListOf("testParameter2", "testParameter3")
-            )
-        )
-        // when
-        testPackage.transform()
-        val moduleContent = testPackage.modules[0].toPythonCode()
-
-        // then
-        val expectedModuleContent: String =
-            """
-            |import testModule
-            |
-            |from __future__ import annotations
-            |
-            |class TestGroup:
-            |    def __init__(self, testParameter3, *, renamedTestParameter2=0.5):
-            |        if not (isinstance(renamedTestParameter2, int) or (isinstance(renamedTestParameter2, float) and renamedTestParameter2.is_integer())):
-            |            raise ValueError(f'renamedTestParameter2 needs to be an integer, but {renamedTestParameter2} was assigned.')
-            |        if not 0.0 <= renamedTestParameter2 <= 1.0:
-            |            raise ValueError(f'Valid values of renamedTestParameter2 must be in [0.0, 1.0], but {renamedTestParameter2} was assigned.')
-            |
-            |        self.testParameter3 = testParameter3
-            |        self.renamedTestParameter2 = renamedTestParameter2
-            |
-            |def testFunction(testParameter1, testGroup: TestGroup):
-            |    return testModule.testFunction(testParameter1, testGroup.renamedTestParameter2, testGroup.testParameter3)
             |
             """.trimMargin()
 

--- a/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGeneratorTest.kt
+++ b/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGeneratorTest.kt
@@ -179,6 +179,65 @@ class PythonCodeGeneratorTest {
                     |        self.instance = testModule.TestClass()
             """.trimMargin()
         }
+
+        @Test
+        fun `should store description if it is not blank`() {
+            val testClass = PythonClass(
+                name = "TestClass",
+                constructor = PythonConstructor(
+                    parameters = listOf(
+                        PythonParameter(
+                            name = "testParameter1",
+                            description = "Test parameter 1"
+                        ),
+                        PythonParameter(
+                            name = "testParameter2",
+                            type = PythonStringifiedType("int"),
+                            description = "Test parameter 2"
+                        )
+                    )
+                ),
+                attributes = listOf(
+                    PythonAttribute(
+                        name = "testAttribute1",
+                        value = PythonInt(1),
+                        description = "Test attribute 1"
+                    ),
+                    PythonAttribute(
+                        name = "testAttribute1",
+                        type = PythonStringifiedType("int"),
+                        value = PythonInt(2),
+                        description = "Test attribute 2"
+                    ),
+                ),
+                description = "Lorem ipsum"
+            )
+
+            testClass.toPythonCode() shouldBe """
+                    |class TestClass:
+                    |    \"\"\"
+                    |    Lorem ipsum
+                    |
+                    |    Parameters
+                    |    ----------
+                    |    testParameter1 : str
+                    |        Test parameter 1
+                    |    testParameter2 : int
+                    |        Test parameter 2
+                    |
+                    |    Attributes
+                    |    ----------
+                    |    testAttribute1 : str
+                    |        Test attribute 1
+                    |    testAttribute2 : int
+                    |        Test attribute 2
+                    |    \"\"\"
+                    |
+                    |    def __init__():
+                    |        self.testAttribute = 1
+                    |        self.testAttribute = 2
+            """.trimMargin()
+        }
     }
 
     @Nested
@@ -591,6 +650,41 @@ class PythonCodeGeneratorTest {
                 |        raise ValueError(f'Valid values of testParameter2 must be greater than 0.0, but {testParameter2} was assigned.')
                 |
                 |    return testModule.testFunction()
+            """.trimMargin()
+        }
+
+        @Test
+        fun `should store description if it is not blank`() {
+            val testFunction = PythonFunction(
+                name = "testFunction",
+                parameters = listOf(
+                    PythonParameter(
+                        name = "testParameter1",
+                        description = "Test parameter 1"
+                    ),
+                    PythonParameter(
+                        name = "testParameter2",
+                        type = PythonStringifiedType("int"),
+                        description = "Test parameter 2"
+                    )
+                ),
+                description = "Lorem ipsum"
+            )
+
+            testFunction.toPythonCode() shouldBe """
+                    |def testFunction(testParameter1, testParameter2: int):
+                    |    \"\"\"
+                    |    Lorem ipsum
+                    |
+                    |    Parameters
+                    |    ----------
+                    |    testParameter1 : str
+                    |        Test parameter 1
+                    |    testParameter2 : int
+                    |        Test parameter 2
+                    |    \"\"\"
+                    |
+                    |    pass
             """.trimMargin()
         }
     }

--- a/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGeneratorTest.kt
+++ b/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGeneratorTest.kt
@@ -204,7 +204,7 @@ class PythonCodeGeneratorTest {
                         description = "Test attribute 1"
                     ),
                     PythonAttribute(
-                        name = "testAttribute1",
+                        name = "testAttribute2",
                         type = PythonStringifiedType("int"),
                         value = PythonInt(2),
                         description = "Test attribute 2"
@@ -215,27 +215,27 @@ class PythonCodeGeneratorTest {
 
             testClass.toPythonCode() shouldBe """
                     |class TestClass:
-                    |    \"\"\"
+                    |    ${"\"\"\""}
                     |    Lorem ipsum
                     |
                     |    Parameters
                     |    ----------
-                    |    testParameter1 : str
+                    |    testParameter1
                     |        Test parameter 1
                     |    testParameter2 : int
                     |        Test parameter 2
                     |
                     |    Attributes
                     |    ----------
-                    |    testAttribute1 : str
+                    |    testAttribute1
                     |        Test attribute 1
                     |    testAttribute2 : int
                     |        Test attribute 2
-                    |    \"\"\"
+                    |    ${"\"\"\""}
                     |
-                    |    def __init__():
-                    |        self.testAttribute = 1
-                    |        self.testAttribute = 2
+                    |    def __init__(testParameter1, testParameter2: int):
+                    |        self.testAttribute1 = 1
+                    |        self.testAttribute2: int = 2
             """.trimMargin()
         }
     }
@@ -673,16 +673,16 @@ class PythonCodeGeneratorTest {
 
             testFunction.toPythonCode() shouldBe """
                     |def testFunction(testParameter1, testParameter2: int):
-                    |    \"\"\"
+                    |    ${"\"\"\""}
                     |    Lorem ipsum
                     |
                     |    Parameters
                     |    ----------
-                    |    testParameter1 : str
+                    |    testParameter1
                     |        Test parameter 1
                     |    testParameter2 : int
                     |        Test parameter 2
-                    |    \"\"\"
+                    |    ${"\"\"\""}
                     |
                     |    pass
             """.trimMargin()

--- a/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonDocstringGeneratorTest.kt
+++ b/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonDocstringGeneratorTest.kt
@@ -1,0 +1,384 @@
+package com.larsreimann.api_editor.codegen
+
+import com.larsreimann.api_editor.model.Boundary
+import com.larsreimann.api_editor.model.ComparisonOperator.LESS_THAN
+import com.larsreimann.api_editor.model.ComparisonOperator.LESS_THAN_OR_EQUALS
+import com.larsreimann.api_editor.model.ComparisonOperator.UNRESTRICTED
+import com.larsreimann.api_editor.mutable_model.PythonAttribute
+import com.larsreimann.api_editor.mutable_model.PythonCall
+import com.larsreimann.api_editor.mutable_model.PythonClass
+import com.larsreimann.api_editor.mutable_model.PythonConstructor
+import com.larsreimann.api_editor.mutable_model.PythonFunction
+import com.larsreimann.api_editor.mutable_model.PythonInt
+import com.larsreimann.api_editor.mutable_model.PythonParameter
+import com.larsreimann.api_editor.mutable_model.PythonReference
+import com.larsreimann.api_editor.mutable_model.PythonStringifiedType
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PDocstringGeneratorTest {
+
+    @Nested
+    inner class ClassDocstring {
+        private lateinit var testClass: PythonClass
+
+        @BeforeEach
+        fun reset() {
+            testClass = PythonClass(
+                name = "TestClass",
+                constructor = PythonConstructor(
+                    parameters = listOf(
+                        PythonParameter(
+                            name = "testParameter1",
+                            description = "Test parameter 1"
+                        ),
+                        PythonParameter(
+                            name = "testParameter2",
+                            type = PythonStringifiedType("int"),
+                            description = "Test parameter 2"
+                        ),
+                        PythonParameter(
+                            name = "testParameter3"
+                        ),
+                        PythonParameter(
+                            name = "testParameter4",
+                            type = PythonStringifiedType("str")
+                        )
+                    )
+                ),
+                attributes = listOf(
+                    PythonAttribute(
+                        name = "testAttribute1",
+                        value = PythonInt(1),
+                        description = "Test attribute 1"
+                    ),
+                    PythonAttribute(
+                        name = "testAttribute2",
+                        type = PythonStringifiedType("int"),
+                        value = PythonInt(2),
+                        description = "Test attribute 2"
+                    ),
+                    PythonAttribute(
+                        name = "testAttribute3",
+                        value = PythonInt(3),
+                    ),
+                    PythonAttribute(
+                        name = "testAttribute4",
+                        type = PythonStringifiedType("str"),
+                        value = PythonInt(4),
+                    )
+                ),
+                description = "Lorem ipsum"
+            )
+        }
+
+        @Test
+        fun `should create docstring (no description, no parameters, no attributes)`() {
+            testClass.description = ""
+            testClass.constructor = null
+            testClass.attributes.clear()
+
+            testClass.toPythonCode() shouldBe ""
+        }
+
+        @Test
+        fun `should create docstring (no description, no parameters, attributes)`() {
+            testClass.description = ""
+            testClass.constructor = null
+
+            testClass.toPythonCode() shouldBe """
+                    |class TestClass:
+                    |    ${"\"\"\""}
+                    |    Attributes
+                    |    ----------
+                    |    testAttribute1
+                    |        Test attribute 1
+                    |    testAttribute2 : int
+                    |        Test attribute 2
+                    |    testAttribute3
+                    |    testAttribute4 : str
+                    |    ${"\"\"\""}
+                    |
+                    |    def __init__():
+                    |        self.testAttribute1 = 1
+                    |        self.testAttribute2: int = 2
+                    |        self.testAttribute3 = 3
+                    |        self.testAttribute4: str = 4
+            """.trimMargin()
+        }
+
+        @Test
+        fun `should create docstring (no description, parameters, no attributes)`() {
+
+            testClass.toPythonCode() shouldBe """
+                    |class TestClass:
+                    |    ${"\"\"\""}
+                    |    Lorem ipsum
+                    |
+                    |    Parameters
+                    |    ----------
+                    |    testParameter1
+                    |        Test parameter 1
+                    |    testParameter2 : int
+                    |        Test parameter 2
+                    |    testParameter3
+                    |    testParameter4 : str
+                    |
+                    |    Attributes
+                    |    ----------
+                    |    testAttribute1
+                    |        Test attribute 1
+                    |    testAttribute2 : int
+                    |        Test attribute 2
+                    |    testAttribute3
+                    |    testAttribute4 : str
+                    |    ${"\"\"\""}
+                    |
+                    |    def __init__(testParameter1, testParameter2: int, testParameter3, testParameter4: str):
+                    |        self.testAttribute1 = 1
+                    |        self.testAttribute2: int = 2
+                    |        self.testAttribute3 = 3
+                    |        self.testAttribute4: str = 4
+            """.trimMargin()
+        }
+
+        @Test
+        fun `should create docstring (no description, parameters, attributes)`() {
+
+            testClass.toPythonCode() shouldBe """
+                    |class TestClass:
+                    |    ${"\"\"\""}
+                    |    Lorem ipsum
+                    |
+                    |    Parameters
+                    |    ----------
+                    |    testParameter1
+                    |        Test parameter 1
+                    |    testParameter2 : int
+                    |        Test parameter 2
+                    |    testParameter3
+                    |    testParameter4 : str
+                    |
+                    |    Attributes
+                    |    ----------
+                    |    testAttribute1
+                    |        Test attribute 1
+                    |    testAttribute2 : int
+                    |        Test attribute 2
+                    |    testAttribute3
+                    |    testAttribute4 : str
+                    |    ${"\"\"\""}
+                    |
+                    |    def __init__(testParameter1, testParameter2: int, testParameter3, testParameter4: str):
+                    |        self.testAttribute1 = 1
+                    |        self.testAttribute2: int = 2
+                    |        self.testAttribute3 = 3
+                    |        self.testAttribute4: str = 4
+            """.trimMargin()
+        }
+
+        @Test
+        fun `should create docstring (description, no parameter, no attributes)`() {
+            testClass.constructor = null
+            testClass.attributes.clear()
+
+            testClass.toPythonCode() shouldBe """
+                    |class TestClass:
+                    |    ${"\"\"\""}
+                    |    Lorem ipsum
+                    |    ${"\"\"\""}
+                    |
+                    |    pass
+            """.trimMargin()
+        }
+
+        @Test
+        fun `should create docstring (description, no parameters, attributes)`() {
+
+            testClass.toPythonCode() shouldBe """
+                    |class TestClass:
+                    |    ${"\"\"\""}
+                    |    Lorem ipsum
+                    |
+                    |    Parameters
+                    |    ----------
+                    |    testParameter1
+                    |        Test parameter 1
+                    |    testParameter2 : int
+                    |        Test parameter 2
+                    |    testParameter3
+                    |    testParameter4 : str
+                    |
+                    |    Attributes
+                    |    ----------
+                    |    testAttribute1
+                    |        Test attribute 1
+                    |    testAttribute2 : int
+                    |        Test attribute 2
+                    |    testAttribute3
+                    |    testAttribute4 : str
+                    |    ${"\"\"\""}
+                    |
+                    |    def __init__(testParameter1, testParameter2: int, testParameter3, testParameter4: str):
+                    |        self.testAttribute1 = 1
+                    |        self.testAttribute2: int = 2
+                    |        self.testAttribute3 = 3
+                    |        self.testAttribute4: str = 4
+            """.trimMargin()
+        }
+
+        @Test
+        fun `should create docstring (description, parameters, no attributes)`() {
+
+            testClass.toPythonCode() shouldBe """
+                    |class TestClass:
+                    |    ${"\"\"\""}
+                    |    Lorem ipsum
+                    |
+                    |    Parameters
+                    |    ----------
+                    |    testParameter1
+                    |        Test parameter 1
+                    |    testParameter2 : int
+                    |        Test parameter 2
+                    |    testParameter3
+                    |    testParameter4 : str
+                    |
+                    |    Attributes
+                    |    ----------
+                    |    testAttribute1
+                    |        Test attribute 1
+                    |    testAttribute2 : int
+                    |        Test attribute 2
+                    |    testAttribute3
+                    |    testAttribute4 : str
+                    |    ${"\"\"\""}
+                    |
+                    |    def __init__(testParameter1, testParameter2: int, testParameter3, testParameter4: str):
+                    |        self.testAttribute1 = 1
+                    |        self.testAttribute2: int = 2
+                    |        self.testAttribute3 = 3
+                    |        self.testAttribute4: str = 4
+            """.trimMargin()
+        }
+
+
+        @Test
+        fun `should create docstring (description, parameters, attributes)`() {
+            testClass.toPythonCode() shouldBe """
+                    |class TestClass:
+                    |    ${"\"\"\""}
+                    |    Lorem ipsum
+                    |
+                    |    Parameters
+                    |    ----------
+                    |    testParameter1
+                    |        Test parameter 1
+                    |    testParameter2 : int
+                    |        Test parameter 2
+                    |    testParameter3
+                    |    testParameter4 : str
+                    |
+                    |    Attributes
+                    |    ----------
+                    |    testAttribute1
+                    |        Test attribute 1
+                    |    testAttribute2 : int
+                    |        Test attribute 2
+                    |    testAttribute3
+                    |    testAttribute4 : str
+                    |    ${"\"\"\""}
+                    |
+                    |    def __init__(testParameter1, testParameter2: int, testParameter3, testParameter4: str):
+                    |        self.testAttribute1 = 1
+                    |        self.testAttribute2: int = 2
+                    |        self.testAttribute3 = 3
+                    |        self.testAttribute4: str = 4
+            """.trimMargin()
+        }
+    }
+
+    @Nested
+    inner class FunctionToPythonCode {
+
+        private lateinit var callToOriginalAPI: PythonCall
+        private lateinit var parametersWithBoundaries: List<PythonParameter>
+
+        @BeforeEach
+        fun reset() {
+            callToOriginalAPI = PythonCall(
+                PythonReference(
+                    PythonFunction(name = "testModule.testFunction")
+                )
+            )
+            parametersWithBoundaries = listOf(
+                PythonParameter(
+                    name = "testParameter1",
+                    boundary = Boundary(
+                        isDiscrete = false,
+                        lowerIntervalLimit = 0.0,
+                        lowerLimitType = LESS_THAN_OR_EQUALS,
+                        upperIntervalLimit = 1.0,
+                        upperLimitType = LESS_THAN_OR_EQUALS
+                    )
+                ),
+                PythonParameter(
+                    name = "testParameter2",
+                    boundary = Boundary(
+                        isDiscrete = false,
+                        lowerIntervalLimit = 0.0,
+                        lowerLimitType = LESS_THAN,
+                        upperIntervalLimit = 1.0,
+                        upperLimitType = UNRESTRICTED
+                    )
+                )
+            )
+        }
+
+        @Test
+        fun `should create docstring if it is not blank`() {
+            val testFunction = PythonFunction(
+                name = "testFunction",
+                parameters = listOf(
+                    PythonParameter(
+                        name = "testParameter1",
+                        description = "Test parameter 1"
+                    ),
+                    PythonParameter(
+                        name = "testParameter2",
+                        type = PythonStringifiedType("int"),
+                        description = "Test parameter 2"
+                    ),
+                    PythonParameter(
+                        name = "testParameter3"
+                    ),
+                    PythonParameter(
+                        name = "testParameter4",
+                        type = PythonStringifiedType("str")
+                    )
+                ),
+                description = "Lorem ipsum"
+            )
+
+            testFunction.toPythonCode() shouldBe """
+                    |def testFunction(testParameter1, testParameter2: int, testParameter3, testParameter4: str):
+                    |    ${"\"\"\""}
+                    |    Lorem ipsum
+                    |
+                    |    Parameters
+                    |    ----------
+                    |    testParameter1
+                    |        Test parameter 1
+                    |    testParameter2 : int
+                    |        Test parameter 2
+                    |    testParameter3
+                    |    testParameter4 : str
+                    |    ${"\"\"\""}
+                    |
+                    |    pass
+            """.trimMargin()
+        }
+    }
+}

--- a/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonDocstringGeneratorTest.kt
+++ b/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonDocstringGeneratorTest.kt
@@ -1,24 +1,18 @@
 package com.larsreimann.api_editor.codegen
 
-import com.larsreimann.api_editor.model.Boundary
-import com.larsreimann.api_editor.model.ComparisonOperator.LESS_THAN
-import com.larsreimann.api_editor.model.ComparisonOperator.LESS_THAN_OR_EQUALS
-import com.larsreimann.api_editor.model.ComparisonOperator.UNRESTRICTED
 import com.larsreimann.api_editor.mutable_model.PythonAttribute
-import com.larsreimann.api_editor.mutable_model.PythonCall
 import com.larsreimann.api_editor.mutable_model.PythonClass
 import com.larsreimann.api_editor.mutable_model.PythonConstructor
 import com.larsreimann.api_editor.mutable_model.PythonFunction
 import com.larsreimann.api_editor.mutable_model.PythonInt
 import com.larsreimann.api_editor.mutable_model.PythonParameter
-import com.larsreimann.api_editor.mutable_model.PythonReference
 import com.larsreimann.api_editor.mutable_model.PythonStringifiedType
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-class PDocstringGeneratorTest {
+class PythonDocstringGeneratorTest {
 
     @Nested
     inner class ClassDocstring {
@@ -80,7 +74,7 @@ class PDocstringGeneratorTest {
             testClass.constructor = null
             testClass.attributes.clear()
 
-            testClass.toPythonCode() shouldBe ""
+            testClass.docstring() shouldBe ""
         }
 
         @Test
@@ -88,94 +82,57 @@ class PDocstringGeneratorTest {
             testClass.description = ""
             testClass.constructor = null
 
-            testClass.toPythonCode() shouldBe """
-                    |class TestClass:
-                    |    ${"\"\"\""}
-                    |    Attributes
-                    |    ----------
-                    |    testAttribute1
-                    |        Test attribute 1
-                    |    testAttribute2 : int
-                    |        Test attribute 2
-                    |    testAttribute3
-                    |    testAttribute4 : str
-                    |    ${"\"\"\""}
-                    |
-                    |    def __init__():
-                    |        self.testAttribute1 = 1
-                    |        self.testAttribute2: int = 2
-                    |        self.testAttribute3 = 3
-                    |        self.testAttribute4: str = 4
+            testClass.docstring() shouldBe """
+                    |Attributes
+                    |----------
+                    |testAttribute1
+                    |    Test attribute 1
+                    |testAttribute2 : int
+                    |    Test attribute 2
+                    |testAttribute3
+                    |testAttribute4 : str
             """.trimMargin()
         }
 
         @Test
         fun `should create docstring (no description, parameters, no attributes)`() {
+            testClass.description = ""
+            testClass.attributes.clear()
 
-            testClass.toPythonCode() shouldBe """
-                    |class TestClass:
-                    |    ${"\"\"\""}
-                    |    Lorem ipsum
-                    |
-                    |    Parameters
-                    |    ----------
-                    |    testParameter1
-                    |        Test parameter 1
-                    |    testParameter2 : int
-                    |        Test parameter 2
-                    |    testParameter3
-                    |    testParameter4 : str
-                    |
-                    |    Attributes
-                    |    ----------
-                    |    testAttribute1
-                    |        Test attribute 1
-                    |    testAttribute2 : int
-                    |        Test attribute 2
-                    |    testAttribute3
-                    |    testAttribute4 : str
-                    |    ${"\"\"\""}
-                    |
-                    |    def __init__(testParameter1, testParameter2: int, testParameter3, testParameter4: str):
-                    |        self.testAttribute1 = 1
-                    |        self.testAttribute2: int = 2
-                    |        self.testAttribute3 = 3
-                    |        self.testAttribute4: str = 4
+            testClass.docstring() shouldBe """
+                    |Parameters
+                    |----------
+                    |testParameter1
+                    |    Test parameter 1
+                    |testParameter2 : int
+                    |    Test parameter 2
+                    |testParameter3
+                    |testParameter4 : str
             """.trimMargin()
         }
 
         @Test
         fun `should create docstring (no description, parameters, attributes)`() {
+            testClass.description = ""
 
-            testClass.toPythonCode() shouldBe """
-                    |class TestClass:
-                    |    ${"\"\"\""}
-                    |    Lorem ipsum
+            testClass.docstring() shouldBe """
+                    |Parameters
+                    |----------
+                    |testParameter1
+                    |    Test parameter 1
+                    |testParameter2 : int
+                    |    Test parameter 2
+                    |testParameter3
+                    |testParameter4 : str
                     |
-                    |    Parameters
-                    |    ----------
-                    |    testParameter1
-                    |        Test parameter 1
-                    |    testParameter2 : int
-                    |        Test parameter 2
-                    |    testParameter3
-                    |    testParameter4 : str
-                    |
-                    |    Attributes
-                    |    ----------
-                    |    testAttribute1
-                    |        Test attribute 1
-                    |    testAttribute2 : int
-                    |        Test attribute 2
-                    |    testAttribute3
-                    |    testAttribute4 : str
-                    |    ${"\"\"\""}
-                    |
-                    |    def __init__(testParameter1, testParameter2: int, testParameter3, testParameter4: str):
-                    |        self.testAttribute1 = 1
-                    |        self.testAttribute2: int = 2
-                    |        self.testAttribute3 = 3
-                    |        self.testAttribute4: str = 4
+                    |Attributes
+                    |----------
+                    |testAttribute1
+                    |    Test attribute 1
+                    |testAttribute2 : int
+                    |    Test attribute 2
+                    |testAttribute3
+                    |testAttribute4 : str
             """.trimMargin()
         }
 
@@ -184,118 +141,70 @@ class PDocstringGeneratorTest {
             testClass.constructor = null
             testClass.attributes.clear()
 
-            testClass.toPythonCode() shouldBe """
-                    |class TestClass:
-                    |    ${"\"\"\""}
-                    |    Lorem ipsum
-                    |    ${"\"\"\""}
-                    |
-                    |    pass
+            testClass.docstring() shouldBe """
+                    |Lorem ipsum
             """.trimMargin()
         }
 
         @Test
         fun `should create docstring (description, no parameters, attributes)`() {
+            testClass.constructor = null
 
-            testClass.toPythonCode() shouldBe """
-                    |class TestClass:
-                    |    ${"\"\"\""}
-                    |    Lorem ipsum
+            testClass.docstring() shouldBe """
+                    |Lorem ipsum
                     |
-                    |    Parameters
-                    |    ----------
-                    |    testParameter1
-                    |        Test parameter 1
-                    |    testParameter2 : int
-                    |        Test parameter 2
-                    |    testParameter3
-                    |    testParameter4 : str
-                    |
-                    |    Attributes
-                    |    ----------
-                    |    testAttribute1
-                    |        Test attribute 1
-                    |    testAttribute2 : int
-                    |        Test attribute 2
-                    |    testAttribute3
-                    |    testAttribute4 : str
-                    |    ${"\"\"\""}
-                    |
-                    |    def __init__(testParameter1, testParameter2: int, testParameter3, testParameter4: str):
-                    |        self.testAttribute1 = 1
-                    |        self.testAttribute2: int = 2
-                    |        self.testAttribute3 = 3
-                    |        self.testAttribute4: str = 4
+                    |Attributes
+                    |----------
+                    |testAttribute1
+                    |    Test attribute 1
+                    |testAttribute2 : int
+                    |    Test attribute 2
+                    |testAttribute3
+                    |testAttribute4 : str
             """.trimMargin()
         }
 
         @Test
         fun `should create docstring (description, parameters, no attributes)`() {
+            testClass.attributes.clear()
 
-            testClass.toPythonCode() shouldBe """
-                    |class TestClass:
-                    |    ${"\"\"\""}
-                    |    Lorem ipsum
+            testClass.docstring() shouldBe """
+                    |Lorem ipsum
                     |
-                    |    Parameters
-                    |    ----------
-                    |    testParameter1
-                    |        Test parameter 1
-                    |    testParameter2 : int
-                    |        Test parameter 2
-                    |    testParameter3
-                    |    testParameter4 : str
-                    |
-                    |    Attributes
-                    |    ----------
-                    |    testAttribute1
-                    |        Test attribute 1
-                    |    testAttribute2 : int
-                    |        Test attribute 2
-                    |    testAttribute3
-                    |    testAttribute4 : str
-                    |    ${"\"\"\""}
-                    |
-                    |    def __init__(testParameter1, testParameter2: int, testParameter3, testParameter4: str):
-                    |        self.testAttribute1 = 1
-                    |        self.testAttribute2: int = 2
-                    |        self.testAttribute3 = 3
-                    |        self.testAttribute4: str = 4
+                    |Parameters
+                    |----------
+                    |testParameter1
+                    |    Test parameter 1
+                    |testParameter2 : int
+                    |    Test parameter 2
+                    |testParameter3
+                    |testParameter4 : str
             """.trimMargin()
         }
 
 
         @Test
         fun `should create docstring (description, parameters, attributes)`() {
-            testClass.toPythonCode() shouldBe """
-                    |class TestClass:
-                    |    ${"\"\"\""}
-                    |    Lorem ipsum
+            testClass.docstring() shouldBe """
+                    |Lorem ipsum
                     |
-                    |    Parameters
-                    |    ----------
-                    |    testParameter1
-                    |        Test parameter 1
-                    |    testParameter2 : int
-                    |        Test parameter 2
-                    |    testParameter3
-                    |    testParameter4 : str
+                    |Parameters
+                    |----------
+                    |testParameter1
+                    |    Test parameter 1
+                    |testParameter2 : int
+                    |    Test parameter 2
+                    |testParameter3
+                    |testParameter4 : str
                     |
-                    |    Attributes
-                    |    ----------
-                    |    testAttribute1
-                    |        Test attribute 1
-                    |    testAttribute2 : int
-                    |        Test attribute 2
-                    |    testAttribute3
-                    |    testAttribute4 : str
-                    |    ${"\"\"\""}
-                    |
-                    |    def __init__(testParameter1, testParameter2: int, testParameter3, testParameter4: str):
-                    |        self.testAttribute1 = 1
-                    |        self.testAttribute2: int = 2
-                    |        self.testAttribute3 = 3
-                    |        self.testAttribute4: str = 4
+                    |Attributes
+                    |----------
+                    |testAttribute1
+                    |    Test attribute 1
+                    |testAttribute2 : int
+                    |    Test attribute 2
+                    |testAttribute3
+                    |testAttribute4 : str
             """.trimMargin()
         }
     }
@@ -303,43 +212,11 @@ class PDocstringGeneratorTest {
     @Nested
     inner class FunctionToPythonCode {
 
-        private lateinit var callToOriginalAPI: PythonCall
-        private lateinit var parametersWithBoundaries: List<PythonParameter>
+        private lateinit var testFunction: PythonFunction
 
         @BeforeEach
         fun reset() {
-            callToOriginalAPI = PythonCall(
-                PythonReference(
-                    PythonFunction(name = "testModule.testFunction")
-                )
-            )
-            parametersWithBoundaries = listOf(
-                PythonParameter(
-                    name = "testParameter1",
-                    boundary = Boundary(
-                        isDiscrete = false,
-                        lowerIntervalLimit = 0.0,
-                        lowerLimitType = LESS_THAN_OR_EQUALS,
-                        upperIntervalLimit = 1.0,
-                        upperLimitType = LESS_THAN_OR_EQUALS
-                    )
-                ),
-                PythonParameter(
-                    name = "testParameter2",
-                    boundary = Boundary(
-                        isDiscrete = false,
-                        lowerIntervalLimit = 0.0,
-                        lowerLimitType = LESS_THAN,
-                        upperIntervalLimit = 1.0,
-                        upperLimitType = UNRESTRICTED
-                    )
-                )
-            )
-        }
-
-        @Test
-        fun `should create docstring if it is not blank`() {
-            val testFunction = PythonFunction(
+            testFunction = PythonFunction(
                 name = "testFunction",
                 parameters = listOf(
                     PythonParameter(
@@ -361,23 +238,54 @@ class PDocstringGeneratorTest {
                 ),
                 description = "Lorem ipsum"
             )
+        }
 
-            testFunction.toPythonCode() shouldBe """
-                    |def testFunction(testParameter1, testParameter2: int, testParameter3, testParameter4: str):
-                    |    ${"\"\"\""}
-                    |    Lorem ipsum
+        @Test
+        fun `should create docstring (no description, no parameters)`() {
+            testFunction.description = ""
+            testFunction.parameters.clear()
+
+            testFunction.docstring() shouldBe ""
+        }
+
+        @Test
+        fun `should create docstring (no description, parameters)`() {
+            testFunction.description = ""
+
+            testFunction.docstring() shouldBe """
+                    |Parameters
+                    |----------
+                    |testParameter1
+                    |    Test parameter 1
+                    |testParameter2 : int
+                    |    Test parameter 2
+                    |testParameter3
+                    |testParameter4 : str
+            """.trimMargin()
+        }
+
+        @Test
+        fun `should create docstring (description, no parameters)`() {
+            testFunction.parameters.clear()
+
+            testFunction.docstring() shouldBe """
+                    |Lorem ipsum
+            """.trimMargin()
+        }
+
+        @Test
+        fun `should create docstring (description, parameters)`() {
+            testFunction.docstring() shouldBe """
+                    |Lorem ipsum
                     |
-                    |    Parameters
-                    |    ----------
-                    |    testParameter1
-                    |        Test parameter 1
-                    |    testParameter2 : int
-                    |        Test parameter 2
-                    |    testParameter3
-                    |    testParameter4 : str
-                    |    ${"\"\"\""}
-                    |
-                    |    pass
+                    |Parameters
+                    |----------
+                    |testParameter1
+                    |    Test parameter 1
+                    |testParameter2 : int
+                    |    Test parameter 2
+                    |testParameter3
+                    |testParameter4 : str
             """.trimMargin()
         }
     }

--- a/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonDocstringGeneratorTest.kt
+++ b/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonDocstringGeneratorTest.kt
@@ -1,5 +1,6 @@
 package com.larsreimann.api_editor.codegen
 
+import com.larsreimann.api_editor.model.PythonParameterAssignment
 import com.larsreimann.api_editor.mutable_model.PythonAttribute
 import com.larsreimann.api_editor.mutable_model.PythonClass
 import com.larsreimann.api_editor.mutable_model.PythonConstructor
@@ -182,7 +183,6 @@ class PythonDocstringGeneratorTest {
             """.trimMargin()
         }
 
-
         @Test
         fun `should create docstring (description, parameters, attributes)`() {
             testClass.docstring() shouldBe """
@@ -205,6 +205,26 @@ class PythonDocstringGeneratorTest {
                     |    Test attribute 2
                     |testAttribute3
                     |testAttribute4 : str
+            """.trimMargin()
+        }
+
+        @Test
+        fun `should skip implicit parameters`() {
+            val testClass = PythonClass(
+                name = "TestClass",
+                constructor = PythonConstructor(
+                    parameters = listOf(
+                        PythonParameter(name = "self", assignedBy = PythonParameterAssignment.IMPLICIT),
+                        PythonParameter(name = "testParameter1", description = "Test parameter 1"),
+                    )
+                )
+            )
+
+            testClass.docstring() shouldBe """
+                    |Parameters
+                    |----------
+                    |testParameter1
+                    |    Test parameter 1
             """.trimMargin()
         }
     }
@@ -286,6 +306,24 @@ class PythonDocstringGeneratorTest {
                     |    Test parameter 2
                     |testParameter3
                     |testParameter4 : str
+            """.trimMargin()
+        }
+
+        @Test
+        fun `should skip implicit parameters`() {
+            val testFunction = PythonFunction(
+                name = "testFunction",
+                parameters = listOf(
+                    PythonParameter(name = "self", assignedBy = PythonParameterAssignment.IMPLICIT),
+                    PythonParameter(name = "testParameter1", description = "Test parameter 1"),
+                )
+            )
+
+            testFunction.docstring() shouldBe """
+                    |Parameters
+                    |----------
+                    |testParameter1
+                    |    Test parameter 1
             """.trimMargin()
         }
     }


### PR DESCRIPTION
Closes #514.

### Summary of Changes

Create docstrings for generate Python classes and functions if they contain any additional information.

### Testing Instructions

1. Launch the backend:
```sh
cd api-editor
./gradlew run
```
2. Open the browser at [localhost:4280](http://localhost:4280).
3. Load some API data into the editor
4. Click "Generate adapters" in the menu bar
5. Extract the downloaded `.zip` file
6. Check the create Python files (`adapters` folder)
