### PR TITLE
fix: NPE if `@Pure` annotation is combined with another annotation

### DIFF
--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/validation/AnnotationValidator.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/validation/AnnotationValidator.kt
@@ -183,13 +183,24 @@ class AnnotationValidator(private val annotatedPythonPackage: SerializablePython
         private var possibleCombinations = buildMap<String, Set<String>> {
             this["Attribute"] = mutableSetOf("Rename")
             this["Boundary"] = mutableSetOf("Group", "Optional", "Rename", "Required")
-            this["CalledAfter"] = mutableSetOf("CalledAfter", "Group", "Move", "Rename")
+            this["CalledAfter"] = mutableSetOf("CalledAfter", "Group", "Move", "Pure", "Rename")
             this["Constant"] = mutableSetOf()
             this["Enum"] = mutableSetOf("Group", "Rename", "Required")
             this["Group"] =
-                mutableSetOf("Boundary", "CalledAfter", "Enum", "Group", "Move", "Optional", "Rename", "Required")
-            this["Move"] = mutableSetOf("CalledAfter", "Group", "Rename")
+                mutableSetOf(
+                    "Boundary",
+                    "CalledAfter",
+                    "Enum",
+                    "Group",
+                    "Move",
+                    "Optional",
+                    "Pure",
+                    "Rename",
+                    "Required"
+                )
+            this["Move"] = mutableSetOf("CalledAfter", "Group", "Pure", "Rename")
             this["Optional"] = mutableSetOf("Boundary", "Group", "Rename")
+            this["Pure"] = mutableSetOf("CalledAfter", "Group", "Move", "Rename")
             this["Remove"] = mutableSetOf()
             this["Rename"] = mutableSetOf(
                 "Attribute",
@@ -199,6 +210,7 @@ class AnnotationValidator(private val annotatedPythonPackage: SerializablePython
                 "Group",
                 "Move",
                 "Optional",
+                "Pure",
                 "Required"
             )
             this["Required"] = mutableSetOf("Boundary", "Enum", "Group", "Rename")

--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/validation/AnnotationValidator.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/validation/AnnotationValidator.kt
@@ -165,7 +165,7 @@ class AnnotationValidator(private val annotatedPythonPackage: SerializablePython
     ) {
         val firstAnnotationName = firstAnnotation.type
         val secondAnnotationName = secondAnnotation.type
-        if (secondAnnotationName !in possibleCombinations[firstAnnotationName]!!) {
+        if (firstAnnotationName !in possibleCombinations || secondAnnotationName !in possibleCombinations[firstAnnotationName]!!) {
             validationErrors.add(AnnotationCombinationError(qualifiedName, firstAnnotationName, secondAnnotationName))
         }
     }
@@ -186,7 +186,8 @@ class AnnotationValidator(private val annotatedPythonPackage: SerializablePython
             this["CalledAfter"] = mutableSetOf("CalledAfter", "Group", "Move", "Rename")
             this["Constant"] = mutableSetOf()
             this["Enum"] = mutableSetOf("Group", "Rename", "Required")
-            this["Group"] = mutableSetOf("Boundary", "CalledAfter", "Enum", "Group", "Move", "Optional", "Rename", "Required")
+            this["Group"] =
+                mutableSetOf("Boundary", "CalledAfter", "Enum", "Group", "Move", "Optional", "Rename", "Required")
             this["Move"] = mutableSetOf("CalledAfter", "Group", "Rename")
             this["Optional"] = mutableSetOf("Boundary", "Group", "Rename")
             this["Remove"] = mutableSetOf()


### PR DESCRIPTION
Closes #520.

### Summary of Changes

* Don't throw an NPE if the map with possible combinations of annotations lacks an entry
* Add missing entries for `@Pure` annotation

### Testing Instructions

1. Run the backend
```
cd api-editor
./gradlew run
```
2. Open localhost:4280 in the browser.
3. Add `@Pure`, `@CalledAfter`, `@Group`, `@Move`, `@Rename` annotations to the same API element.
4. Click on `Generate adapters`.
5. Check that a Zip file is being downloaded.
