### PR TITLE
fix: set filter to "is:public" after API data import

### DIFF
--- a/api-editor/gui/src/features/packageData/PackageDataImportDialog.tsx
+++ b/api-editor/gui/src/features/packageData/PackageDataImportDialog.tsx
@@ -40,7 +40,7 @@ const PackageDataImportDialog: React.FC<ImportPythonPackageDialogProps> = functi
         if (newPythonPackage) {
             const parsedPythonPackage = JSON.parse(newPythonPackage) as PythonPackageJson;
             setPythonPackage(parsePythonPackageJson(parsedPythonPackage));
-            setFilter('');
+            setFilter('is:public');
             navigate('/');
 
             await idb.set('package', parsedPythonPackage);


### PR DESCRIPTION
### Summary of Changes

When importing new API data the filter input field was previously set to "". Now it's set to "is:public".

### Testing Instructions

1. Run the backend:
```sh
cd api-editor
./gradlew run
```
2. Open localhost:4280 in the browser.
3. Import new API data
4. Check the content of the filter input field.
