### PR TITLE
fix: create boundary type for negative bound

### DIFF
--- a/package-parser/package_parser/commands/get_api/_refined_types.py
+++ b/package-parser/package_parser/commands/get_api/_refined_types.py
@@ -94,8 +94,8 @@ class BoundaryType(AbstractType):
     def from_string(cls, string: str) -> Optional[BoundaryType]:
         pattern = r"""(?P<base_type>float|int)?[ ]  # optional base type of either float or int
                     (in|of)[ ](the[ ])?(range|interval)[ ](of[ ])?  # 'in' or 'of', optional 'the', 'range' or 'interval', optional 'of'
-                    `?(?P<min_bracket>\[|\()(?P<min>\d+.?\d*|negative_infinity),[ ]  # left side of the range
-                    (?P<max>\d+.?\d*|infinity)(?P<max_bracket>\]|\))`?"""  # right side of the range
+                    `?(?P<min_bracket>[\[(])(?P<min>[-+]?\d+(.\d*)?|negative_infinity),[ ]  # left side of the range
+                    (?P<max>[-+]?\d+(.\d*)?|infinity)(?P<max_bracket>[\])])`?"""  # right side of the range
         match = re.search(pattern, string, re.VERBOSE)
 
         if match is not None:

--- a/package-parser/tests/commands/get_api/test_boundaries.py
+++ b/package-parser/tests/commands/get_api/test_boundaries.py
@@ -14,7 +14,7 @@ from package_parser.commands.get_api._refined_types import BoundaryType
         (
             """If bootstrap is True, the number of samples to draw from X\nto train each base estimator.\n\n
             - If None (default), then draw `X.shape[0]` samples.\n- If int, then draw `max_samples` samples.\n
-            - If float, then draw `max_samples * X.shape[0]` samples. Thus,\n  `max_samples` should be in the interval `(0.0, 1.0]`.\n\n.. 
+            - If float, then draw `max_samples * X.shape[0]` samples. Thus,\n  `max_samples` should be in the interval `(0.0, 1.0]`.\n\n..
             versionadded:: 0.22""",
             BoundaryType("float", 0, 1, False, True),
         ),
@@ -30,6 +30,19 @@ from package_parser.commands.get_api._refined_types import BoundaryType
             absolute counts.\nThis parameter is ignored if vocabulary is not None.""",
             BoundaryType("float", 0, 1, True, True),
         ),
+        (
+            "Tolerance for singular values computed by svd_solver == 'arpack'.\nMust be of range [-2, -1].\n\n.. versionadded:: 0.18.0",
+            BoundaryType("float", -2, -1, True, True)
+        ),
+        (
+            "Damping factor in the range (-1, -0.5)",
+            BoundaryType("float", -1, -0.5, False, False)
+        ),
+        (
+            "'max_samples' should be in the interval (-1.0, -0.5]",
+            BoundaryType("float", -1.0, -0.5, False, True)
+        ),
+
     ],
 )
 def test_boundaries_from_string(string: str, expected: BoundaryType):

--- a/package-parser/tests/commands/get_api/test_boundaries.py
+++ b/package-parser/tests/commands/get_api/test_boundaries.py
@@ -32,17 +32,16 @@ from package_parser.commands.get_api._refined_types import BoundaryType
         ),
         (
             "Tolerance for singular values computed by svd_solver == 'arpack'.\nMust be of range [-2, -1].\n\n.. versionadded:: 0.18.0",
-            BoundaryType("float", -2, -1, True, True)
+            BoundaryType("float", -2, -1, True, True),
         ),
         (
             "Damping factor in the range (-1, -0.5)",
-            BoundaryType("float", -1, -0.5, False, False)
+            BoundaryType("float", -1, -0.5, False, False),
         ),
         (
             "'max_samples' should be in the interval (-1.0, -0.5]",
-            BoundaryType("float", -1.0, -0.5, False, True)
+            BoundaryType("float", -1.0, -0.5, False, True),
         ),
-
     ],
 )
 def test_boundaries_from_string(string: str, expected: BoundaryType):


### PR DESCRIPTION
### Summary of Changes

Create boundary types even if one of the bounds was negative.

### Testing Instructions

1. Create API data for scikit-learn
```sh
poetry run parse-package api -p sklearn -o out
```
2. Ensure that boundary types are created even if the bounds are negative
