### PR TITLE
fix: incorrect pnames

### DIFF
--- a/package-parser/package_parser/commands/get_api/_ast_visitor.py
+++ b/package-parser/package_parser/commands/get_api/_ast_visitor.py
@@ -26,12 +26,11 @@ class _AstVisitor:
         self.__declaration_stack: list[Union[Module, Class, Function]] = []
 
     def __get_pname(self, name: str) -> str:
-        return (
-            self.api.package
-            + "/"
-            + "/".join([it.name for it in self.__declaration_stack])
-            + name
-        )
+        segments = [self.api.package]
+        segments += [it.name for it in self.__declaration_stack]
+        segments += [name]
+
+        return "/".join(segments)
 
     def enter_module(self, module_node: astroid.Module):
         imports: list[Import] = []


### PR DESCRIPTION
Closes #525.

### Summary of Changes

Add missing slashes to the created `pname` properties.

### Testing Instructions

1. Run
```sh
cd package-parser
poetry run parse-package api -p package_parser -s package_parser -o out
```
2. Check the `pname` properties.
