### PR TITLE
fix: crash when some annotation forms were opened

### DIFF
--- a/api-editor/gui/src/features/annotations/forms/CalledAfterForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/CalledAfterForm.tsx
@@ -39,7 +39,11 @@ export const CalledAfterForm: React.FC<CalledAfterFormProps> = function ({ targe
     });
 
     useEffect(() => {
-        setFocus('calledAfterName');
+        try {
+            setFocus('calledAfterName');
+        } catch (e) {
+            // ignore
+        }
     }, [setFocus]);
 
     useEffect(() => {

--- a/api-editor/gui/src/features/annotations/forms/EnumForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/EnumForm.tsx
@@ -60,7 +60,11 @@ export const EnumForm: React.FC<EnumFormProps> = function ({ target }) {
     });
 
     useEffect(() => {
-        setFocus('enumName');
+        try {
+            setFocus('enumName');
+        } catch (e) {
+            // ignore
+        }
     }, [setFocus]);
 
     useEffect(() => {

--- a/api-editor/gui/src/features/annotations/forms/GroupForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/GroupForm.tsx
@@ -84,7 +84,11 @@ export const GroupForm: React.FC<GroupFormProps> = function ({ target, groupName
     });
 
     useEffect(() => {
-        setFocus('groupName');
+        try {
+            setFocus('groupName');
+        } catch (e) {
+            // ignore
+        }
     }, [setFocus]);
 
     useEffect(() => {

--- a/api-editor/gui/src/features/annotations/forms/MoveForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/MoveForm.tsx
@@ -36,7 +36,11 @@ export const MoveForm: React.FC<MoveFormProps> = function ({ target }) {
     });
 
     useEffect(() => {
-        setFocus('destination');
+        try {
+            setFocus('destination');
+        } catch (e) {
+            // ignore
+        }
     }, [setFocus]);
 
     useEffect(() => {

--- a/api-editor/gui/src/features/annotations/forms/RenameForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/RenameForm.tsx
@@ -36,7 +36,11 @@ export const RenameForm: React.FC<RenameFormProps> = function ({ target }) {
     });
 
     useEffect(() => {
-        setFocus('newName');
+        try {
+            setFocus('newName');
+        } catch (e) {
+            // ignore
+        }
     }, [setFocus]);
 
     useEffect(() => {


### PR DESCRIPTION
Closes #593.

### Summary of Changes

Opening an annotation form that sets the focus to some input element could crash the application. This  happens due to a possible race condition between calling `reset` and `setFocus`.

### Testing Instructions

1. Add a `@calledAfter` annotation to a function
2. Add a `@group` annotation to a function
3. Add a `@rename` annotation to an API element
4. Add a `@move` annotation to a global API element
5. Add a `@enum` annotation to a parameter.

The app should no longer crash in these cases.