### PR TITLE
feat: verbose flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ report/
 build/
 dist/
 dist-ssr/
+out/
+tmp/
 
 api-editor/backend/src/main/resources/static/
 

--- a/package-parser/README.md
+++ b/package-parser/README.md
@@ -2,101 +2,31 @@
 
 A tool to analyze client and API code written in Python.
 
-## Usage
-
-```text
-usage: parse-package [-h] {api,usages,improve,annotations,all} ...
-
-Analyze Python code.
-
-positional arguments:
-  {api,usages,improve,annotations,all}
-    api                 List the API of a package.
-    usages              Find usages of API elements.
-    improve             Suggest how to improve an existing API.
-    annotations         Generate Annotations automatically.
-    all                 Run api and usages command in parallel and then run annotations command.
-
-optional arguments:
-  -h, --help            show this help message and exit
-```
-
-### api command
-
-```text
-usage: parse-package api [-h] -p PACKAGE [-s SRC] -o OUT
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -p PACKAGE, --package PACKAGE
-                        The name of the package.
-  -s SRC, --src SRC     Directory containing the Python code of the package. If this is omitted, we try to locate the package with the given name in the current Python interpreter.
-  -o OUT, --out OUT     Output directory.
-```
-
-### usages command
-
-```text
-usage: parse-package usages [-h] -p PACKAGE -c CLIENT -t TMP -o OUT
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -p PACKAGE, --package PACKAGE
-                        The name of the package. It must be installed in the current interpreter.
-  -c CLIENT, --client CLIENT
-                        Directory containing Python code that uses the package.
-  -t TMP, --tmp TMP     Directory where temporary files can be stored (to save progress in case the program crashes).
-  -o OUT, --out OUT     Output directory.
-```
-
-### annotations command
-
-```text
-usage: parse-package annotations [-h] -a API -u USAGES -o OUT
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -a API, --api API     File created by the 'api' command.
-  -u USAGES, --usages USAGES
-                        File created by the 'usages' command that contains usage counts.
-  -o OUT, --out OUT     Output directory.
-```
-
-### all command
-
-```text
-usage: parse-package all [-h] -p PACKAGE [-s SRC] -c CLIENT -o OUT
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -p PACKAGE, --package PACKAGE
-                        The name of the package.
-  -s SRC, --src SRC     Directory containing the Python code of the package. If this is omitted, we try to locate the package with the given name in the current Python interpreter.
-  -c CLIENT, --client CLIENT
-                        Directory containing Python code that uses the package.
-  -o OUT, --out OUT     Output directory.
-```
-
-### Example usage
+### Installation
 
 1. Install Python 3.10.
-1. Install [poetry](https://python-poetry.org/docs/master/#installation).
-1. **Only the first time**, install dependencies:
+2. Install [poetry](https://python-poetry.org/docs/master/#installation).
+3. **Only the first time**, install dependencies:
     ```shell
     poetry install
     ```
-1. Create a shell with poetry:
+4. Create a shell with poetry:
     ```shell
     poetry shell
     ```
-1. Run the commands described above:
+
+### Example usage
+
+1. Analyze an API:
     ```shell
     # Step 1:
     parse-package api -p sklearn -o out
-
-    # Step 2:
-    parse-package usages -p sklearn -s "Kaggle Kernels" -t tmp -o out
-
-    # Step 3:
-    parse-package annotations -a "out/scikit-learn__sklearn__1.0__api.json" -u "out/scikit-learn__sklearn__1.0__usages.json" -o out/annotations.json
     ```
+2. Analyze client code of this API:
+    ```shell
+    parse-package usages -p sklearn -s "Kaggle Kernels" -t tmp -o out
+    ```
+3. Generate annotations for the API:
+   ```shell
+   parse-package annotations -a out/scikit-learn__sklearn__1.0__api.json -u out/scikit-learn__sklearn__1.0__usages.json -o out/annotations.json
+   ```

--- a/package-parser/package_parser/cli/_cli.py
+++ b/package-parser/package_parser/cli/_cli.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+
 # noinspection PyUnresolvedReferences,PyProtectedMember
 from argparse import _SubParsersAction
 from pathlib import Path
@@ -32,7 +33,9 @@ def cli() -> None:
 
 def _get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Analyze Python code.")
-    parser.add_argument("-v", "--verbose", help="show info messages", action="store_true")
+    parser.add_argument(
+        "-v", "--verbose", help="show info messages", action="store_true"
+    )
 
     # Commands
     subparsers = parser.add_subparsers(dest="command")
@@ -57,7 +60,7 @@ def _add_api_subparser(subparsers: _SubParsersAction) -> None:
         "-s",
         "--src",
         help="Directory containing the Python code of the package. If this is omitted, we try to locate the package "
-             "with the given name in the current Python interpreter.",
+        "with the given name in the current Python interpreter.",
         type=Path,
         required=False,
         default=None,
@@ -136,7 +139,7 @@ def _add_all_subparser(subparsers: _SubParsersAction) -> None:
         "-s",
         "--src",
         help="Directory containing the Python code of the package. If this is omitted, we try to locate the package "
-             "with the given name in the current Python interpreter.",
+        "with the given name in the current Python interpreter.",
         type=Path,
         required=False,
         default=None,

--- a/package-parser/package_parser/cli/_cli.py
+++ b/package-parser/package_parser/cli/_cli.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 # noinspection PyUnresolvedReferences,PyProtectedMember
 from argparse import _SubParsersAction
 from pathlib import Path
@@ -16,6 +17,9 @@ _ALL_COMMAND = "all"
 
 def cli() -> None:
     args = _get_args()
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO)
+
     if args.command == _API_COMMAND:
         _run_api_command(args.package, args.src, args.out)
     elif args.command == _USAGES_COMMAND:
@@ -28,6 +32,7 @@ def cli() -> None:
 
 def _get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Analyze Python code.")
+    parser.add_argument("-v", "--verbose", help="show info messages", action="store_true")
 
     # Commands
     subparsers = parser.add_subparsers(dest="command")
@@ -52,7 +57,7 @@ def _add_api_subparser(subparsers: _SubParsersAction) -> None:
         "-s",
         "--src",
         help="Directory containing the Python code of the package. If this is omitted, we try to locate the package "
-        "with the given name in the current Python interpreter.",
+             "with the given name in the current Python interpreter.",
         type=Path,
         required=False,
         default=None,
@@ -131,7 +136,7 @@ def _add_all_subparser(subparsers: _SubParsersAction) -> None:
         "-s",
         "--src",
         help="Directory containing the Python code of the package. If this is omitted, we try to locate the package "
-        "with the given name in the current Python interpreter.",
+             "with the given name in the current Python interpreter.",
         type=Path,
         required=False,
         default=None,


### PR DESCRIPTION
Closes #608.

### Summary of Changes

Verbose output can now be enable in the Python CLI commands like so:
```sh
parse-package -v api ...
```

Note that the `-v` flag must be between `parse-package` and any subcommand like `api`.