### PR TITLE
perf: improve performance of usage command

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 extend-ignore =
+    # whitespace before ':' (black handles that)
+    E203,
     # line too long (black handles that)
     E501,
     # Line break occurred before a binary operator (seems to conflict with the linter)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
         run: poetry run parse-package api -p package_parser -s package_parser -o out
 
       - name: Smoke test (usages)
-        run: poetry run parse-package usages -p package_parser -c package_parser -t out/tmp -o out
+        run: poetry run parse-package usages -p package_parser -c package_parser -o out
 
       - name: Smoke test (annotations)
         run: poetry run parse-package annotations -a tests/data/removes/api_data.json -u tests/data/removes/usage_data.json -o out/annotations.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,7 +101,7 @@ jobs:
         run: poetry run parse-package api -p package_parser -s package_parser -o out
 
       - name: Smoke test (usages)
-        run: poetry run parse-package usages -p package_parser -c package_parser -t out/tmp -o out
+        run: poetry run parse-package usages -p package_parser -c package_parser -o out
 
       - name: Smoke test (annotations)
         run: poetry run parse-package annotations -a tests/data/removes/api_data.json -u tests/data/removes/usage_data.json -o out/annotations.json

--- a/package-parser/README.md
+++ b/package-parser/README.md
@@ -24,7 +24,7 @@ A tool to analyze client and API code written in Python.
     ```
 2. Analyze client code of this API:
     ```shell
-    parse-package usages -p sklearn -s "Kaggle Kernels" -t tmp -o out
+    parse-package usages -p sklearn -s "Kaggle Kernels" -o out
     ```
 3. Generate annotations for the API:
    ```shell

--- a/package-parser/package_parser/cli/_cli.py
+++ b/package-parser/package_parser/cli/_cli.py
@@ -24,11 +24,11 @@ def cli() -> None:
     if args.command == _API_COMMAND:
         _run_api_command(args.package, args.src, args.out)
     elif args.command == _USAGES_COMMAND:
-        _run_usages_command(args.package, args.client, args.out, args.processes, args.batch_size)
+        _run_usages_command(args.package, args.client, args.out, args.processes, args.batchsize)
     elif args.command == _ANNOTATIONS_COMMAND:
         _run_annotations(args.api, args.usages, args.out)
     elif args.command == _ALL_COMMAND:
-        _run_all_command(args.package, args.src, args.client, args.out, args.processes, args.batch_size)
+        _run_all_command(args.package, args.src, args.client, args.out, args.processes, args.batchsize)
 
 
 def _get_args() -> argparse.Namespace:
@@ -96,7 +96,7 @@ def _add_usages_subparser(subparsers: _SubParsersAction) -> None:
         default=4
     ),
     usages_parser.add_argument(
-        "--batch_size",
+        "--batchsize",
         help="How many files to process in one go. Higher values lead to higher memory usage but better performance.",
         type=int,
         required=False,
@@ -169,7 +169,7 @@ def _add_all_subparser(subparsers: _SubParsersAction) -> None:
         default=4
     )
     all_parser.add_argument(
-        "--batch_size",
+        "--batchsize",
         help="How many files to process in one go. Higher values lead to higher memory usage but better performance.",
         type=int,
         required=False,

--- a/package-parser/package_parser/cli/_cli.py
+++ b/package-parser/package_parser/cli/_cli.py
@@ -24,11 +24,20 @@ def cli() -> None:
     if args.command == _API_COMMAND:
         _run_api_command(args.package, args.src, args.out)
     elif args.command == _USAGES_COMMAND:
-        _run_usages_command(args.package, args.client, args.out, args.processes, args.batchsize)
+        _run_usages_command(
+            args.package, args.client, args.out, args.processes, args.batchsize
+        )
     elif args.command == _ANNOTATIONS_COMMAND:
         _run_annotations(args.api, args.usages, args.out)
     elif args.command == _ALL_COMMAND:
-        _run_all_command(args.package, args.src, args.client, args.out, args.processes, args.batchsize)
+        _run_all_command(
+            args.package,
+            args.src,
+            args.client,
+            args.out,
+            args.processes,
+            args.batchsize,
+        )
 
 
 def _get_args() -> argparse.Namespace:
@@ -93,14 +102,14 @@ def _add_usages_subparser(subparsers: _SubParsersAction) -> None:
         help="How many processes should be spawned during processing.",
         type=int,
         required=False,
-        default=4
+        default=4,
     ),
     usages_parser.add_argument(
         "--batchsize",
         help="How many files to process in one go. Higher values lead to higher memory usage but better performance.",
         type=int,
         required=False,
-        default=100
+        default=100,
     )
     usages_parser.add_argument(
         "-o", "--out", help="Output directory.", type=Path, required=True
@@ -166,12 +175,12 @@ def _add_all_subparser(subparsers: _SubParsersAction) -> None:
         help="How many processes should be spawned during processing.",
         type=int,
         required=False,
-        default=4
+        default=4,
     )
     all_parser.add_argument(
         "--batchsize",
         help="How many files to process in one go. Higher values lead to higher memory usage but better performance.",
         type=int,
         required=False,
-        default=100
+        default=100,
     )

--- a/package-parser/package_parser/cli/_cli.py
+++ b/package-parser/package_parser/cli/_cli.py
@@ -24,11 +24,11 @@ def cli() -> None:
     if args.command == _API_COMMAND:
         _run_api_command(args.package, args.src, args.out)
     elif args.command == _USAGES_COMMAND:
-        _run_usages_command(args.package, args.client, args.out, args.processes)
+        _run_usages_command(args.package, args.client, args.out, args.processes, args.batch_size)
     elif args.command == _ANNOTATIONS_COMMAND:
         _run_annotations(args.api, args.usages, args.out)
     elif args.command == _ALL_COMMAND:
-        _run_all_command(args.package, args.src, args.client, args.out, args.processes)
+        _run_all_command(args.package, args.src, args.client, args.out, args.processes, args.batch_size)
 
 
 def _get_args() -> argparse.Namespace:
@@ -94,6 +94,13 @@ def _add_usages_subparser(subparsers: _SubParsersAction) -> None:
         type=int,
         required=False,
         default=4
+    ),
+    usages_parser.add_argument(
+        "--batch_size",
+        help="How many files to process in one go. Higher values lead to higher memory usage but better performance.",
+        type=int,
+        required=False,
+        default=100
     )
     usages_parser.add_argument(
         "-o", "--out", help="Output directory.", type=Path, required=True
@@ -160,4 +167,11 @@ def _add_all_subparser(subparsers: _SubParsersAction) -> None:
         type=int,
         required=False,
         default=4
+    )
+    all_parser.add_argument(
+        "--batch_size",
+        help="How many files to process in one go. Higher values lead to higher memory usage but better performance.",
+        type=int,
+        required=False,
+        default=100
     )

--- a/package-parser/package_parser/cli/_cli.py
+++ b/package-parser/package_parser/cli/_cli.py
@@ -24,7 +24,7 @@ def cli() -> None:
     if args.command == _API_COMMAND:
         _run_api_command(args.package, args.src, args.out)
     elif args.command == _USAGES_COMMAND:
-        _run_usages_command(args.package, args.client, args.tmp, args.out)
+        _run_usages_command(args.package, args.client, args.out)
     elif args.command == _ANNOTATIONS_COMMAND:
         _run_annotations(args.api, args.usages, args.out)
     elif args.command == _ALL_COMMAND:
@@ -89,18 +89,11 @@ def _add_usages_subparser(subparsers: _SubParsersAction) -> None:
         required=True,
     )
     usages_parser.add_argument(
-        "-t",
-        "--tmp",
-        help="Directory where temporary files can be stored (to save progress in case the program crashes).",
-        type=Path,
-        required=True,
-    )
-    usages_parser.add_argument(
         "-o", "--out", help="Output directory.", type=Path, required=True
     )
 
 
-def _add_annotations_subparser(subparsers):
+def _add_annotations_subparser(subparsers) -> None:
     generate_parser = subparsers.add_parser(
         _ANNOTATIONS_COMMAND, help="Generate Annotations automatically."
     )

--- a/package-parser/package_parser/cli/_cli.py
+++ b/package-parser/package_parser/cli/_cli.py
@@ -24,11 +24,11 @@ def cli() -> None:
     if args.command == _API_COMMAND:
         _run_api_command(args.package, args.src, args.out)
     elif args.command == _USAGES_COMMAND:
-        _run_usages_command(args.package, args.client, args.out)
+        _run_usages_command(args.package, args.client, args.out, args.processes)
     elif args.command == _ANNOTATIONS_COMMAND:
         _run_annotations(args.api, args.usages, args.out)
     elif args.command == _ALL_COMMAND:
-        _run_all_command(args)
+        _run_all_command(args.package, args.src, args.client, args.out, args.processes)
 
 
 def _get_args() -> argparse.Namespace:
@@ -89,6 +89,13 @@ def _add_usages_subparser(subparsers: _SubParsersAction) -> None:
         required=True,
     )
     usages_parser.add_argument(
+        "--processes",
+        help="How many processes should be spawned during processing.",
+        type=int,
+        required=False,
+        default=4
+    )
+    usages_parser.add_argument(
         "-o", "--out", help="Output directory.", type=Path, required=True
     )
 
@@ -146,4 +153,11 @@ def _add_all_subparser(subparsers: _SubParsersAction) -> None:
     )
     all_parser.add_argument(
         "-o", "--out", help="Output directory.", type=Path, required=True
+    )
+    all_parser.add_argument(
+        "--processes",
+        help="How many processes should be spawned during processing.",
+        type=int,
+        required=False,
+        default=4
     )

--- a/package-parser/package_parser/cli/_run_all.py
+++ b/package-parser/package_parser/cli/_run_all.py
@@ -14,12 +14,19 @@ def _run_all_command(
     client_dir_path: Path,
     out_dir_path: Path,
     n_processes: int,
-    batch_size: int
+    batch_size: int,
 ) -> None:
     out_file_annotations = out_dir_path.joinpath("annotations.json")
     results = _run_in_parallel(
         partial(_run_api_command, package, src_dir_path, out_dir_path),
-        partial(_run_usages_command, package, client_dir_path, out_dir_path, n_processes, batch_size),
+        partial(
+            _run_usages_command,
+            package,
+            client_dir_path,
+            out_dir_path,
+            n_processes,
+            batch_size,
+        ),
     )
     _run_annotations(results[_API_KEY], results[_USAGES_KEY], out_file_annotations)
 

--- a/package-parser/package_parser/cli/_run_all.py
+++ b/package-parser/package_parser/cli/_run_all.py
@@ -8,11 +8,18 @@ from package_parser.cli._run_usages import _run_usages_command
 from package_parser.cli._shared_constants import _API_KEY, _USAGES_KEY
 
 
-def _run_all_command(package: str, src_dir_path: Path, client_dir_path: Path, out_dir_path: Path, n_processes: int):
+def _run_all_command(
+    package: str,
+    src_dir_path: Path,
+    client_dir_path: Path,
+    out_dir_path: Path,
+    n_processes: int,
+    batch_size: int
+) -> None:
     out_file_annotations = out_dir_path.joinpath("annotations.json")
     results = _run_in_parallel(
         partial(_run_api_command, package, src_dir_path, out_dir_path),
-        partial(_run_usages_command, package, client_dir_path, out_dir_path, n_processes),
+        partial(_run_usages_command, package, client_dir_path, out_dir_path, n_processes, batch_size),
     )
     _run_annotations(results[_API_KEY], results[_USAGES_KEY], out_file_annotations)
 

--- a/package-parser/package_parser/cli/_run_all.py
+++ b/package-parser/package_parser/cli/_run_all.py
@@ -1,6 +1,6 @@
 import multiprocessing
 from functools import partial
-from typing import Any
+from pathlib import Path
 
 from package_parser.cli._run_annotations import _run_annotations
 from package_parser.cli._run_api import _run_api_command
@@ -8,13 +8,11 @@ from package_parser.cli._run_usages import _run_usages_command
 from package_parser.cli._shared_constants import _API_KEY, _USAGES_KEY
 
 
-def _run_all_command(args):
-    out = args.out
-    tmp = args.out.joinpath("tmp")
-    out_file_annotations = args.out.joinpath("annotations.json")
+def _run_all_command(package: str, src_dir_path: Path, client_dir_path: Path, out_dir_path: Path, n_processes: int):
+    out_file_annotations = out_dir_path.joinpath("annotations.json")
     results = _run_in_parallel(
-        partial(_run_api_command, args.package, args.src, out),
-        partial(_run_usages_command, args.package, args.client, tmp, out),
+        partial(_run_api_command, package, src_dir_path, out_dir_path),
+        partial(_run_usages_command, package, client_dir_path, out_dir_path, n_processes),
     )
     _run_annotations(results[_API_KEY], results[_USAGES_KEY], out_file_annotations)
 

--- a/package-parser/package_parser/cli/_run_usages.py
+++ b/package-parser/package_parser/cli/_run_usages.py
@@ -8,7 +8,12 @@ from package_parser.utils import ensure_file_exists
 
 
 def _run_usages_command(
-    package: str, client_dir_path: Path, out_dir_path: Path, n_processes: int, batch_size: int, result_dict: Optional[dict] = None
+    package: str,
+    client_dir_path: Path,
+    out_dir_path: Path,
+    n_processes: int,
+    batch_size: int,
+    result_dict: Optional[dict] = None,
 ) -> None:
     usages = find_usages(package, client_dir_path, n_processes, batch_size)
 

--- a/package-parser/package_parser/cli/_run_usages.py
+++ b/package-parser/package_parser/cli/_run_usages.py
@@ -8,9 +8,9 @@ from package_parser.utils import ensure_file_exists
 
 
 def _run_usages_command(
-    package: str, client_dir_path: Path, out_dir_path: Path, n_processes: int, result_dict: Optional[dict] = None
+    package: str, client_dir_path: Path, out_dir_path: Path, n_processes: int, batch_size: int, result_dict: Optional[dict] = None
 ) -> None:
-    usages = find_usages(package, client_dir_path, n_processes)
+    usages = find_usages(package, client_dir_path, n_processes, batch_size)
 
     out_file_usage_count = out_dir_path.joinpath(f"{package}__usages_counted.json")
     ensure_file_exists(out_file_usage_count)

--- a/package-parser/package_parser/cli/_run_usages.py
+++ b/package-parser/package_parser/cli/_run_usages.py
@@ -8,11 +8,11 @@ from package_parser.utils import ensure_file_exists
 
 
 def _run_usages_command(
-    package: str, client: Path, out: Path, result_dict: Optional[dict] = None
+    package: str, client_dir_path: Path, out_dir_path: Path, n_processes: int, result_dict: Optional[dict] = None
 ) -> None:
-    usages = find_usages(package, client)
+    usages = find_usages(package, client_dir_path, n_processes)
 
-    out_file_usage_count = out.joinpath(f"{package}__usages_counted.json")
+    out_file_usage_count = out_dir_path.joinpath(f"{package}__usages_counted.json")
     ensure_file_exists(out_file_usage_count)
     with out_file_usage_count.open("w") as f:
         json.dump(usages.to_json(), f, indent=2)

--- a/package-parser/package_parser/cli/_run_usages.py
+++ b/package-parser/package_parser/cli/_run_usages.py
@@ -8,9 +8,9 @@ from package_parser.utils import ensure_file_exists
 
 
 def _run_usages_command(
-    package: str, client: Path, tmp: Path, out: Path, result_dict: Optional[dict] = None
+    package: str, client: Path, out: Path, result_dict: Optional[dict] = None
 ) -> None:
-    usages = find_usages(package, client, tmp)
+    usages = find_usages(package, client)
 
     out_file_usage_count = out.joinpath(f"{package}__usages_counted.json")
     ensure_file_exists(out_file_usage_count)

--- a/package-parser/package_parser/processing/usages/_ast_visitor.py
+++ b/package-parser/package_parser/processing/usages/_ast_visitor.py
@@ -7,9 +7,8 @@ from package_parser.model.usages import UsageCountStore
 
 
 class _UsageFinder:
-    def __init__(self, package_name: str, python_file: str) -> None:
+    def __init__(self, package_name: str) -> None:
         self.package_name: str = package_name
-        self.python_file: str = python_file
         self.usages: UsageCountStore = UsageCountStore()
 
     def enter_call(self, node: astroid.Call):

--- a/package-parser/package_parser/processing/usages/_find_usages.py
+++ b/package-parser/package_parser/processing/usages/_find_usages.py
@@ -75,7 +75,7 @@ def _find_usages_in_single_file(
 
     # noinspection PyBroadException
     try:
-        with open(python_file, "r") as f:
+        with open(python_file, "r", encoding="UTF-8") as f:
             source = f.read()
 
         if __is_relevant_python_file(package_name, source):

--- a/package-parser/package_parser/processing/usages/_find_usages.py
+++ b/package-parser/package_parser/processing/usages/_find_usages.py
@@ -12,9 +12,9 @@ from ._ast_visitor import _UsageFinder
 from ...model.usages import UsageCountStore
 
 
-def find_usages(package_name: str, src_dir: Path, n_processes: int) -> UsageCountStore:
+def find_usages(package_name: str, src_dir: Path, n_processes: int, batch_size: int) -> UsageCountStore:
     python_files = list_files(src_dir, ".py")
-    python_file_batches = _split_into_batches(python_files, 100)
+    python_file_batches = _split_into_batches(python_files, batch_size)
 
     aggregated_counts = UsageCountStore()
 

--- a/package-parser/package_parser/processing/usages/_find_usages.py
+++ b/package-parser/package_parser/processing/usages/_find_usages.py
@@ -1,7 +1,7 @@
 import logging
 from multiprocessing import Pool
 from pathlib import Path
-from typing import Optional
+from typing import TypeVar
 
 import astroid
 
@@ -12,25 +12,65 @@ from ...model.usages import UsageCountStore
 
 def find_usages(package_name: str, src_dir: Path, n_processes: int) -> UsageCountStore:
     python_files = list_files(src_dir, ".py")
+    python_file_batches = _split_into_batches(python_files, 1000)
+
     aggregated_counts = UsageCountStore()
 
     with Pool(processes=n_processes) as pool:
         for counts_in_file in pool.starmap(
-            __find_usages_in_single_file,
-            [[package_name, it] for it in python_files],
+            _find_usages_in_batch,
+            [[package_name, it] for it in python_file_batches]
         ):
-            if counts_in_file is not None:
-                aggregated_counts.merge_other_into_self(counts_in_file)
+            aggregated_counts.merge_other_into_self(counts_in_file)
     pool.join()
     pool.close()
 
     return aggregated_counts
 
 
-def __find_usages_in_single_file(
+T = TypeVar('T')
+
+
+def _split_into_batches(
+    list_: list[T],
+    batch_size: int
+) -> list[list[T]]:
+    """
+    Splits a list into batches of size batch_size.
+    """
+
+    batches = []
+    batch = []
+
+    for python_file in list_:
+        batch.append(python_file)
+        if len(batch) >= batch_size:
+            batches.append(batch)
+            batch = []
+
+    if len(batch) > 0:
+        batches.append(batch)
+
+    return batches
+
+
+def _find_usages_in_batch(
     package_name: str,
-    python_file: str
-) -> Optional[UsageCountStore]:
+    python_files: list[str]
+) -> UsageCountStore:
+    usage_finder = _UsageFinder(package_name)
+
+    for python_file in python_files:
+        _find_usages_in_single_file(package_name, python_file, usage_finder)
+
+    return usage_finder.usages
+
+
+def _find_usages_in_single_file(
+    package_name: str,
+    python_file: str,
+    usage_finder: _UsageFinder,
+) -> None:
     logging.info(f"Working on {python_file}")
 
     # noinspection PyBroadException
@@ -39,10 +79,7 @@ def __find_usages_in_single_file(
             source = f.read()
 
         if __is_relevant_python_file(package_name, source):
-            usage_finder = _UsageFinder(package_name, python_file)
             ASTWalker(usage_finder).walk(astroid.parse(source))
-
-            return usage_finder.usages
         else:
             logging.info(f"Skipping {python_file} (irrelevant file)")
 
@@ -54,8 +91,6 @@ def __find_usages_in_single_file(
         logging.warning(f"Skipping {python_file} (infinite recursion)")
     except Exception:
         logging.error(f"Skipping {python_file} (unknown error)")
-
-    return None
 
 
 def __is_relevant_python_file(package_name: str, source_code: str) -> bool:

--- a/package-parser/package_parser/processing/usages/_find_usages.py
+++ b/package-parser/package_parser/processing/usages/_find_usages.py
@@ -7,7 +7,7 @@ from typing import TypeVar
 import astroid
 from astroid.builder import AstroidBuilder
 
-from package_parser.utils import ASTWalker, list_files, NonCachingAstBuilder, parse_python_code
+from package_parser.utils import ASTWalker, list_files, parse_python_code
 from ._ast_visitor import _UsageFinder
 from ...model.usages import UsageCountStore
 
@@ -68,7 +68,7 @@ def _find_usages_in_batch(
     package_name: str,
     python_files: list[str]
 ) -> UsageCountStore:
-    ast_builder = NonCachingAstBuilder()
+    ast_builder = AstroidBuilder()
     usage_finder = _UsageFinder(package_name)
     ast_walker = ASTWalker(usage_finder)
 

--- a/package-parser/package_parser/processing/usages/_find_usages.py
+++ b/package-parser/package_parser/processing/usages/_find_usages.py
@@ -75,6 +75,8 @@ def _find_usages_in_batch(
     for python_file in python_files:
         _find_usages_in_single_file(package_name, python_file, ast_builder, ast_walker)
 
+    astroid.MANAGER.clear_cache()
+
     return usage_finder.usages
 
 

--- a/package-parser/package_parser/processing/usages/_find_usages.py
+++ b/package-parser/package_parser/processing/usages/_find_usages.py
@@ -1,60 +1,30 @@
-import json
 import logging
-import multiprocessing
-from multiprocessing import synchronize
 from pathlib import Path
+from typing import Optional
 
 import astroid
-from package_parser.utils import ASTWalker, initialize_and_read_exclude_file, list_files
 
-from ...model.usages import UsageCountStore
+from package_parser.utils import ASTWalker, list_files
 from ._ast_visitor import _UsageFinder
-
-__N_PROCESSES = 12
-
-
-def find_usages(package_name: str, src_dir: Path, tmp_dir: Path):
-    candidate_python_files = list_files(src_dir, ".py")
-
-    exclude_file = tmp_dir.joinpath("$$$$$exclude$$$$$.txt")
-    excluded_python_files = set(initialize_and_read_exclude_file(exclude_file))
-
-    python_files = [
-        it for it in candidate_python_files if it not in excluded_python_files
-    ]
-
-    tmp_dir.mkdir(parents=True, exist_ok=True)
-
-    lock = multiprocessing.Lock()
-    with multiprocessing.Pool(
-        processes=__N_PROCESSES,
-        initializer=__initialize_process_environment,
-        initargs=(lock,),
-    ) as pool:
-        pool.starmap(
-            __find_usages_in_single_file,
-            [[package_name, it, exclude_file, tmp_dir] for it in python_files],
-        )
-    pool.join()
-    pool.close()
-
-    return _merge_results(tmp_dir)
+from ...model.usages import UsageCountStore
 
 
-_lock: synchronize.Lock = multiprocessing.Lock()
+def find_usages(package_name: str, src_dir: Path) -> UsageCountStore:
+    python_files = list_files(src_dir, ".py")
 
+    aggregated_counts = UsageCountStore()
+    for python_file in python_files:
+        counts_in_file = __find_usages_in_single_file(package_name, python_file)
+        if counts_in_file is not None:
+            aggregated_counts.merge_other_into_self(counts_in_file)
 
-def __initialize_process_environment(lock: synchronize.Lock):
-    global _lock
-    _lock = lock
+    return aggregated_counts
 
 
 def __find_usages_in_single_file(
     package_name: str,
-    python_file: str,
-    exclude_file: Path,
-    tmp_dir: Path,
-):
+    python_file: str
+) -> Optional[UsageCountStore]:
     logging.info(f"Working on {python_file}")
 
     try:
@@ -65,13 +35,7 @@ def __find_usages_in_single_file(
             usage_finder = _UsageFinder(package_name, python_file)
             ASTWalker(usage_finder).walk(astroid.parse(source))
 
-            tmp_file = tmp_dir.joinpath(
-                python_file.replace("/", "__")
-                .replace("\\", "__")
-                .replace(".py", ".json")
-            )
-            with tmp_file.open("w") as f:
-                json.dump(usage_finder.usages.to_json(), f, indent=2)
+            return usage_finder.usages
         else:
             logging.info(f"Skipping {python_file} (irrelevant file)")
 
@@ -82,24 +46,8 @@ def __find_usages_in_single_file(
     except RecursionError:
         logging.warning(f"Skipping {python_file} (infinite recursion)")
 
-    with _lock:
-        with exclude_file.open("a") as f:
-            f.write(f"{python_file}\n")
+    return None
 
 
 def __is_relevant_python_file(package_name: str, source_code: str) -> bool:
     return package_name in source_code
-
-
-def _merge_results(tmp_dir: Path) -> UsageCountStore:
-    result = UsageCountStore()
-
-    files = list_files(tmp_dir, extension=".json")
-    for index, file in enumerate(files):
-        logging.info(f"Merging {file} ({index + 1}/{len(files)})")
-
-        with open(file, "r") as f:
-            other_usage_store = UsageCountStore.from_json(json.load(f))
-            result.merge_other_into_self(other_usage_store)
-
-    return result

--- a/package-parser/package_parser/utils/__init__.py
+++ b/package-parser/package_parser/utils/__init__.py
@@ -1,3 +1,4 @@
 from ._ASTWalker import ASTWalker
 from ._files import ensure_file_exists, initialize_and_read_exclude_file, list_files
+from ._parsing import NonCachingAstBuilder, parse_python_code
 from ._qnames import declaration_qname_to_name, parent_qname

--- a/package-parser/package_parser/utils/__init__.py
+++ b/package-parser/package_parser/utils/__init__.py
@@ -1,4 +1,4 @@
 from ._ASTWalker import ASTWalker
 from ._files import ensure_file_exists, initialize_and_read_exclude_file, list_files
-from ._parsing import NonCachingAstBuilder, parse_python_code
+from ._parsing import parse_python_code
 from ._qnames import declaration_qname_to_name, parent_qname

--- a/package-parser/package_parser/utils/_parsing.py
+++ b/package-parser/package_parser/utils/_parsing.py
@@ -1,7 +1,6 @@
 import textwrap
 
 import astroid
-from astroid import nodes, rebuilder
 from astroid.builder import AstroidBuilder
 
 
@@ -20,33 +19,7 @@ def parse_python_code(
     """
 
     if ast_builder is None:
-        ast_builder = NonCachingAstBuilder()
+        ast_builder = AstroidBuilder()
 
     code = textwrap.dedent(code)
     return ast_builder.string_build(code, modname=module_name, path=path)
-
-
-class NonCachingAstBuilder(AstroidBuilder):
-    def _post_build(
-        self,
-        module: nodes.Module,
-        builder: rebuilder.TreeRebuilder,
-        encoding: str
-    ) -> nodes.Module:
-        """Handles encoding and delayed nodes after a module has been built"""
-        module.file_encoding = encoding
-        # self._manager.cache_module(module)
-        # post tree building steps after we stored the module in the cache:
-        for from_node in builder._import_from_nodes:
-            if from_node.modname == "__future__":
-                for symbol, _ in from_node.names:
-                    module.future_imports.add(symbol)
-            self.add_from_names_to_locals(from_node)
-        # handle delayed assattr nodes
-        for delayed in builder._delayed_assattr:
-            self.delayed_assattr(delayed)  # memory leak
-
-        # Visit the transforms
-        if self._apply_transforms:
-            module = self._manager.visit_transforms(module)
-        return module

--- a/package-parser/package_parser/utils/_parsing.py
+++ b/package-parser/package_parser/utils/_parsing.py
@@ -8,7 +8,7 @@ def parse_python_code(
     code: str,
     module_name: str = "",
     path: str = None,
-    ast_builder: AstroidBuilder = None
+    ast_builder: AstroidBuilder = None,
 ) -> astroid.Module:
     """Parses a source string in order to obtain an astroid AST from it
 

--- a/package-parser/package_parser/utils/_parsing.py
+++ b/package-parser/package_parser/utils/_parsing.py
@@ -1,39 +1,41 @@
 import textwrap
 
+import astroid
 from astroid import nodes, rebuilder
 from astroid.builder import AstroidBuilder
-from astroid.manager import AstroidManager
 
 
-def parse_without_caching(code: str, module_name: str = "", path=None, apply_transforms=True):
+def parse_python_code(
+    code: str,
+    module_name: str = "",
+    path: str = None,
+    ast_builder: AstroidBuilder = None
+) -> astroid.Module:
     """Parses a source string in order to obtain an astroid AST from it
 
     :param str code: The code for the module.
     :param str module_name: The name for the module, if any
     :param str path: The path for the module
-    :param bool apply_transforms:
-        Apply the transforms for the give code. Use it if you
-        don't want the default transforms to be applied.
+    :param ast_builder: The Astroid builder to use
     """
+
+    if ast_builder is None:
+        ast_builder = NonCachingAstBuilder()
+
     code = textwrap.dedent(code)
-    builder = AstroidBuilder(
-        manager=AstroidManager(), apply_transforms=apply_transforms
-    )
-    return builder.string_build(code, modname=module_name, path=path)  # causes memory leak
+    return ast_builder.string_build(code, modname=module_name, path=path)
 
 
-class MyAstroidBuild(AstroidBuilder):
-    def string_build(self, data: str, modname: str = "", path: str = None):
-        """Build astroid from source code string."""
-        module, builder = self._data_build(data, modname, path)
-        module.file_bytes = data.encode("utf-8")
-        return self._post_build(module, builder, "utf-8")
-
+class NonCachingAstBuilder(AstroidBuilder):
     def _post_build(
-        self, module: nodes.Module, builder: rebuilder.TreeRebuilder, encoding: str
+        self,
+        module: nodes.Module,
+        builder: rebuilder.TreeRebuilder,
+        encoding: str
     ) -> nodes.Module:
         """Handles encoding and delayed nodes after a module has been built"""
         module.file_encoding = encoding
+        # self._manager.cache_module(module)
         # post tree building steps after we stored the module in the cache:
         for from_node in builder._import_from_nodes:
             if from_node.modname == "__future__":
@@ -42,7 +44,7 @@ class MyAstroidBuild(AstroidBuilder):
             self.add_from_names_to_locals(from_node)
         # handle delayed assattr nodes
         for delayed in builder._delayed_assattr:
-            self.delayed_assattr(delayed)
+            self.delayed_assattr(delayed)  # memory leak
 
         # Visit the transforms
         if self._apply_transforms:

--- a/package-parser/package_parser/utils/_parsing.py
+++ b/package-parser/package_parser/utils/_parsing.py
@@ -19,10 +19,16 @@ def parse_without_caching(code: str, module_name: str = "", path=None, apply_tra
     builder = AstroidBuilder(
         manager=AstroidManager(), apply_transforms=apply_transforms
     )
-    return builder.string_build(code, modname=module_name, path=path)
+    return builder.string_build(code, modname=module_name, path=path)  # causes memory leak
 
 
 class MyAstroidBuild(AstroidBuilder):
+    def string_build(self, data: str, modname: str = "", path: str = None):
+        """Build astroid from source code string."""
+        module, builder = self._data_build(data, modname, path)
+        module.file_bytes = data.encode("utf-8")
+        return self._post_build(module, builder, "utf-8")
+
     def _post_build(
         self, module: nodes.Module, builder: rebuilder.TreeRebuilder, encoding: str
     ) -> nodes.Module:

--- a/package-parser/package_parser/utils/_parsing.py
+++ b/package-parser/package_parser/utils/_parsing.py
@@ -1,0 +1,44 @@
+import textwrap
+
+from astroid import nodes, rebuilder
+from astroid.builder import AstroidBuilder
+from astroid.manager import AstroidManager
+
+
+def parse_without_caching(code: str, module_name: str = "", path=None, apply_transforms=True):
+    """Parses a source string in order to obtain an astroid AST from it
+
+    :param str code: The code for the module.
+    :param str module_name: The name for the module, if any
+    :param str path: The path for the module
+    :param bool apply_transforms:
+        Apply the transforms for the give code. Use it if you
+        don't want the default transforms to be applied.
+    """
+    code = textwrap.dedent(code)
+    builder = AstroidBuilder(
+        manager=AstroidManager(), apply_transforms=apply_transforms
+    )
+    return builder.string_build(code, modname=module_name, path=path)
+
+
+class MyAstroidBuild(AstroidBuilder):
+    def _post_build(
+        self, module: nodes.Module, builder: rebuilder.TreeRebuilder, encoding: str
+    ) -> nodes.Module:
+        """Handles encoding and delayed nodes after a module has been built"""
+        module.file_encoding = encoding
+        # post tree building steps after we stored the module in the cache:
+        for from_node in builder._import_from_nodes:
+            if from_node.modname == "__future__":
+                for symbol, _ in from_node.names:
+                    module.future_imports.add(symbol)
+            self.add_from_names_to_locals(from_node)
+        # handle delayed assattr nodes
+        for delayed in builder._delayed_assattr:
+            self.delayed_assattr(delayed)
+
+        # Visit the transforms
+        if self._apply_transforms:
+            module = self._manager.visit_transforms(module)
+        return module


### PR DESCRIPTION
Closes #607.

### Summary of Changes

* We no longer create another file to hold the usage counts for each file with client code. The reading and writing was time intensive and it was hard to get rid of the 30k+ files afterwards.
* Workaround a memory leak caused by the internal caching of `astroid`. Previously, the memory usage would continually increase until all RAM was used, heavily slowing down the system. In many cases, a PC restart was necessary. Unfortunately, there is no satisfactory way to disable/clear the caches. Therefore, we kill the Python processes once they are done with their batch and start new ones. This leads to the jigsaw pattern regarding memory usage shown in the second screenshot below.
* Add CLI argument `--processes` and `--batchsize` to control the tradeoff between performance and memory usage of the `usage` and `all` commands.

**Note:** This solution is still far from ideal since all processes always have to wait for the slowest one. But at least the command can be run again without crashing.

**Note 2:** On my machine analyzing all Kaggle kernels took 28min 19s.

### Screenshots (if necessary)

Memory usage before (would increase up to maximum if not forced to close):

![Screenshot 2022-06-12 120010](https://user-images.githubusercontent.com/2501322/173237685-8424c1e4-6f06-489d-b0d4-b41bfe131f9b.png)

Memory usage after:

![Screenshot 2022-06-12 161002](https://user-images.githubusercontent.com/2501322/173237694-ea327027-9cd1-42da-9d20-ef4d7dcb6012.png)
