### PR TITLE
fix: NPE when generating adapters with multiple annotations with default value `None`

### DIFF
--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/mutable_model/PythonAst.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/mutable_model/PythonAst.kt
@@ -245,7 +245,7 @@ data class PythonBoolean(val value: Boolean) : PythonLiteral()
 data class PythonFloat(val value: Double) : PythonLiteral()
 data class PythonInt(val value: Int) : PythonLiteral()
 data class PythonString(val value: String) : PythonLiteral()
-object PythonNone : PythonLiteral()
+class PythonNone : PythonLiteral() // Cannot use object because each instance needs unique parent links
 
 class PythonMemberAccess(
     receiver: PythonExpression,

--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/server/Routing.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/server/Routing.kt
@@ -3,6 +3,8 @@ package com.larsreimann.api_editor.backend
 import com.larsreimann.api_editor.codegen.generateCode
 import com.larsreimann.api_editor.model.SerializablePythonPackage
 import com.larsreimann.api_editor.mutable_model.convertPackage
+import com.larsreimann.api_editor.transformation.processing_exceptions.ConflictingEnumException
+import com.larsreimann.api_editor.transformation.processing_exceptions.ConflictingGroupException
 import com.larsreimann.api_editor.transformation.transform
 import com.larsreimann.api_editor.validation.AnnotationValidator
 import io.ktor.http.ContentDisposition
@@ -93,7 +95,14 @@ fun doInfer(originalPythonPackage: SerializablePythonPackage): DoInferResult {
 
     // Process package
     val mutablePackage = convertPackage(originalPythonPackage)
-    mutablePackage.transform()
+
+    try {
+        mutablePackage.transform()
+    } catch (e: ConflictingEnumException) {
+        return DoInferResult.ValidationFailure(listOf(e.message!!))
+    } catch (e: ConflictingGroupException) {
+        return DoInferResult.ValidationFailure(listOf(e.message!!))
+    }
 
     // Build files
     val path = mutablePackage.generateCode()

--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/transformation/ParameterAnnotationProcessor.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/transformation/ParameterAnnotationProcessor.kt
@@ -120,6 +120,6 @@ private fun DefaultValue.toPythonLiteral(): PythonLiteral {
             }
         }
         is DefaultString -> PythonString(this.value)
-        is DefaultNone -> PythonNone
+        is DefaultNone -> PythonNone()
     }
 }

--- a/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGeneratorTest.kt
+++ b/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGeneratorTest.kt
@@ -1160,7 +1160,7 @@ class PythonCodeGeneratorTest {
 
         @Test
         fun `should handle None`() {
-            val expression = PythonNone
+            val expression = PythonNone()
             expression.toPythonCode() shouldBe "None"
         }
 

--- a/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/transformation/ParameterAnnotationProcessorTest.kt
+++ b/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/transformation/ParameterAnnotationProcessorTest.kt
@@ -204,7 +204,7 @@ class ParameterAnnotationProcessorTest {
 
         val testParameter2 = PythonParameter(name = "testParameter2")
         testMethod.parameters += testParameter2
-       callToOriginalAPI.arguments += PythonArgument(
+        callToOriginalAPI.arguments += PythonArgument(
             value = PythonReference(testParameter2)
         )
 
@@ -213,8 +213,8 @@ class ParameterAnnotationProcessorTest {
 
         testPackage.processParameterAnnotations()
 
-       callToOriginalAPI.arguments.shouldHaveSize(2)
-       callToOriginalAPI.arguments[0].value.shouldBeInstanceOf<PythonNone>()
-       callToOriginalAPI.arguments[1].value.shouldBeInstanceOf<PythonNone>()
+        callToOriginalAPI.arguments.shouldHaveSize(2)
+        callToOriginalAPI.arguments[0].value.shouldBeInstanceOf<PythonNone>()
+        callToOriginalAPI.arguments[1].value.shouldBeInstanceOf<PythonNone>()
     }
 }

--- a/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/transformation/ParameterAnnotationProcessorTest.kt
+++ b/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/transformation/ParameterAnnotationProcessorTest.kt
@@ -3,6 +3,7 @@ package com.larsreimann.api_editor.transformation
 import com.larsreimann.api_editor.model.AttributeAnnotation
 import com.larsreimann.api_editor.model.ConstantAnnotation
 import com.larsreimann.api_editor.model.DefaultBoolean
+import com.larsreimann.api_editor.model.DefaultNone
 import com.larsreimann.api_editor.model.OptionalAnnotation
 import com.larsreimann.api_editor.model.PythonParameterAssignment
 import com.larsreimann.api_editor.model.RequiredAnnotation
@@ -12,6 +13,7 @@ import com.larsreimann.api_editor.mutable_model.PythonCall
 import com.larsreimann.api_editor.mutable_model.PythonClass
 import com.larsreimann.api_editor.mutable_model.PythonFunction
 import com.larsreimann.api_editor.mutable_model.PythonModule
+import com.larsreimann.api_editor.mutable_model.PythonNone
 import com.larsreimann.api_editor.mutable_model.PythonPackage
 import com.larsreimann.api_editor.mutable_model.PythonParameter
 import com.larsreimann.api_editor.mutable_model.PythonReference
@@ -194,5 +196,25 @@ class ParameterAnnotationProcessorTest {
         testPackage.annotations
             .filterIsInstance<RequiredAnnotation>()
             .shouldBeEmpty()
+    }
+
+    @Test // https://github.com/lars-reimann/api-editor/issues/616
+    fun `should work when multiple parameters are set to constant null`() {
+        val callToOriginalAPI = testMethod.callToOriginalAPI.shouldNotBeNull()
+
+        val testParameter2 = PythonParameter(name = "testParameter2")
+        testMethod.parameters += testParameter2
+       callToOriginalAPI.arguments += PythonArgument(
+            value = PythonReference(testParameter2)
+        )
+
+        testParameter.annotations += ConstantAnnotation(DefaultNone)
+        testParameter2.annotations += ConstantAnnotation(DefaultNone)
+
+        testPackage.processParameterAnnotations()
+
+       callToOriginalAPI.arguments.shouldHaveSize(2)
+       callToOriginalAPI.arguments[0].value.shouldBeInstanceOf<PythonNone>()
+       callToOriginalAPI.arguments[1].value.shouldBeInstanceOf<PythonNone>()
     }
 }


### PR DESCRIPTION
Closes #616.

### Summary of Changes

Adding the `@Constant` (or `@Optional`/`@Attribute`) annotations with value `None` to multiple parameters caused a NPE in the backend when generating adapters. This was caused because the AST node `PythonNone` was a singleton and was, therefore, always moved to the last place were it was needed. The previous places were set to `null`. 

**Note for the future:** Do not create singleton `PythonAstNode`s!