### PR TITLE
feat: configure name of generated package

### DIFF
--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/server/Routing.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/server/Routing.kt
@@ -58,7 +58,7 @@ fun Route.echo() {
 }
 
 fun Route.infer() {
-    post("/infer/{newPackageName}") {
+    post("/generate-adapters/{newPackageName}") {
         val pythonPackage = call.receive<SerializablePythonPackage>()
         when (val doInferResult = doInfer(pythonPackage, call.parameters.getOrFail("newPackageName"))) {
             is DoInferResult.ValidationFailure -> {

--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/transformation/TransformationPlan.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/transformation/TransformationPlan.kt
@@ -5,7 +5,7 @@ import com.larsreimann.api_editor.mutable_model.PythonPackage
 /**
  * Processes all annotations and updates the AST to create adapters.
  */
-fun PythonPackage.transform(newPackageName: String) {
+fun PythonPackage.transform(newPackageName: String = "new_package") {
     preprocess(newPackageName)
     processAnnotations()
     postprocess()

--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/transformation/TransformationPlan.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/transformation/TransformationPlan.kt
@@ -5,8 +5,8 @@ import com.larsreimann.api_editor.mutable_model.PythonPackage
 /**
  * Processes all annotations and updates the AST to create adapters.
  */
-fun PythonPackage.transform() {
-    preprocess()
+fun PythonPackage.transform(newPackageName: String) {
+    preprocess(newPackageName)
     processAnnotations()
     postprocess()
 }
@@ -14,10 +14,10 @@ fun PythonPackage.transform() {
 /**
  * Transformation steps that have to be run before annotations can be processed.
  */
-private fun PythonPackage.preprocess() {
+private fun PythonPackage.preprocess(newPackageName: String) {
     removePrivateDeclarations()
     addOriginalDeclarations()
-    changeModulePrefix(newPrefix = "simpleml")
+    changeModulePrefix(newPackageName)
     replaceClassMethodsWithStaticMethods()
     updateParameterAssignment()
     normalizeNamesOfImplicitParameters()

--- a/api-editor/gui/src/app/App.tsx
+++ b/api-editor/gui/src/app/App.tsx
@@ -75,7 +75,7 @@ export const App: React.FC = function () {
                 h="100vh"
             >
                 <GridItem gridArea="menu" colSpan={2}>
-                    <MenuBar pythonPackage={pythonPackage} displayInferErrors={displayInferErrors} />
+                    <MenuBar displayInferErrors={displayInferErrors} />
                 </GridItem>
                 <GridItem
                     gridArea="leftPane"

--- a/api-editor/gui/src/common/DeleteAllAnnotations.tsx
+++ b/api-editor/gui/src/common/DeleteAllAnnotations.tsx
@@ -1,0 +1,66 @@
+import {
+    AlertDialog,
+    AlertDialogBody,
+    AlertDialogContent,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogOverlay,
+    Button,
+    Heading,
+    Text as ChakraText,
+    VStack,
+} from '@chakra-ui/react';
+import React, { useRef, useState } from 'react';
+import { useAppDispatch } from '../app/hooks';
+import { resetAnnotations } from '../features/annotations/annotationSlice';
+
+export const DeleteAllAnnotations = function () {
+    const dispatch = useAppDispatch();
+    const [isOpen, setIsOpen] = useState(false);
+    const cancelRef = useRef(null);
+
+    // Event handlers ----------------------------------------------------------
+
+    const handleConfirm = () => {
+        dispatch(resetAnnotations());
+        setIsOpen(false);
+    };
+    const handleCancel = () => setIsOpen(false);
+
+    // Render ------------------------------------------------------------------
+
+    return (
+        <>
+            <Button onClick={() => setIsOpen(true)}>Delete all annotations</Button>
+
+            <AlertDialog isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={handleCancel}>
+                <AlertDialogOverlay>
+                    <AlertDialogContent>
+                        <AlertDialogHeader>
+                            <Heading>Delete all annotations</Heading>
+                        </AlertDialogHeader>
+
+                        <AlertDialogBody>
+                            <VStack alignItems="flexStart">
+                                <ChakraText>Are you sure? You can't undo this action afterwards.</ChakraText>
+                                <ChakraText>
+                                    Hint: Consider exporting your work first by clicking on the "Export" button in the
+                                    menu bar.
+                                </ChakraText>
+                            </VStack>
+                        </AlertDialogBody>
+
+                        <AlertDialogFooter>
+                            <Button ref={cancelRef} onClick={handleCancel}>
+                                Cancel
+                            </Button>
+                            <Button colorScheme="red" onClick={handleConfirm} ml={3}>
+                                Delete
+                            </Button>
+                        </AlertDialogFooter>
+                    </AlertDialogContent>
+                </AlertDialogOverlay>
+            </AlertDialog>
+        </>
+    );
+};

--- a/api-editor/gui/src/common/GenerateAdapters.tsx
+++ b/api-editor/gui/src/common/GenerateAdapters.tsx
@@ -1,0 +1,125 @@
+import {
+    AlertDialog,
+    AlertDialogBody,
+    AlertDialogContent,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogOverlay,
+    Button,
+    FormControl,
+    FormErrorMessage,
+    FormHelperText,
+    FormLabel,
+    Heading,
+    Input,
+    VStack,
+} from '@chakra-ui/react';
+import React, { useRef, useState } from 'react';
+import { useAppSelector } from '../app/hooks';
+import { selectAnnotations } from '../features/annotations/annotationSlice';
+import { AnnotatedPythonPackageBuilder } from '../features/annotatedPackageData/model/AnnotatedPythonPackageBuilder';
+import { selectPythonPackage } from '../features/packageData/apiSlice';
+
+interface GenerateAdaptersProps {
+    displayInferErrors: (errors: string[]) => void;
+}
+
+export const GenerateAdapters: React.FC<GenerateAdaptersProps> = function ({ displayInferErrors }) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [newPackageName, setNewPackageName] = useState('');
+    const [shouldValidate, setShouldValidate] = useState(false);
+    const cancelRef = useRef(null);
+
+    const annotationStore = useAppSelector(selectAnnotations);
+    const pythonPackage = useAppSelector(selectPythonPackage);
+
+    const packageNameIsValid = !shouldValidate || newPackageName !== '';
+
+    // Event handlers ----------------------------------------------------------
+
+    const handleConfirm = () => {
+        if (newPackageName !== '') {
+            generateAdapters();
+            setIsOpen(false);
+            setShouldValidate(false);
+        } else {
+            setShouldValidate(true);
+        }
+    };
+    const handleCancel = () => {
+        setIsOpen(false);
+        setShouldValidate(false);
+    };
+
+    const generateAdapters = () => {
+        const annotatedPythonPackageBuilder = new AnnotatedPythonPackageBuilder(pythonPackage, annotationStore);
+        const annotatedPythonPackage = annotatedPythonPackageBuilder.generateAnnotatedPythonPackage();
+
+        const requestOptions = {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(annotatedPythonPackage),
+        };
+        fetch(`/api-editor/generate-adapters/${newPackageName}`, requestOptions).then(async (response) => {
+            if (!response.ok) {
+                const jsonResponse = await response.json();
+                displayInferErrors(jsonResponse);
+            } else {
+                const jsonBlob = await response.blob();
+                const a = document.createElement('a');
+                a.href = URL.createObjectURL(jsonBlob);
+                a.download = `${newPackageName}.zip`;
+                a.click();
+            }
+        });
+    };
+
+    // Render ------------------------------------------------------------------
+
+    return (
+        <>
+            <Button onClick={() => setIsOpen(true)}>Generate adapters</Button>
+
+            <AlertDialog isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={handleCancel}>
+                <AlertDialogOverlay>
+                    <AlertDialogContent>
+                        <AlertDialogHeader>
+                            <Heading>Generate adapters</Heading>
+                        </AlertDialogHeader>
+
+                        <AlertDialogBody>
+                            <VStack alignItems="flexStart">
+                                <FormControl isInvalid={!packageNameIsValid}>
+                                    <FormLabel htmlFor="newPackageName">New package name:</FormLabel>
+                                    <Input
+                                        type="text"
+                                        id="newPackageName"
+                                        value={newPackageName}
+                                        onChange={(event) => setNewPackageName(event.target.value)}
+                                        spellCheck={false}
+                                    />
+                                    {packageNameIsValid ? (
+                                        <FormHelperText>
+                                            Enter the package name for the generated adapters.
+                                        </FormHelperText>
+                                    ) : (
+                                        <FormErrorMessage>Package name is required.</FormErrorMessage>
+                                    )}
+                                </FormControl>
+                            </VStack>
+                        </AlertDialogBody>
+
+                        <AlertDialogFooter>
+                            <Button colorScheme="blue" onClick={handleConfirm}>
+                                Confirm
+                            </Button>
+                            <Button colorScheme="red" ref={cancelRef} onClick={handleCancel} ml={3}>
+                                Cancel
+                            </Button>
+                        </AlertDialogFooter>
+                    </AlertDialogContent>
+                </AlertDialogOverlay>
+            </AlertDialog>
+        </>
+    );
+};

--- a/api-editor/gui/src/common/MenuBar.tsx
+++ b/api-editor/gui/src/common/MenuBar.tsx
@@ -125,7 +125,7 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ pythonPackage, displa
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(annotatedPythonPackage),
         };
-        fetch('/api-editor/infer', requestOptions).then(async (response) => {
+        fetch('/api-editor/infer/simpleml', requestOptions).then(async (response) => {
             if (!response.ok) {
                 const jsonResponse = await response.json();
                 displayInferErrors(jsonResponse);

--- a/api-editor/gui/src/common/MenuBar.tsx
+++ b/api-editor/gui/src/common/MenuBar.tsx
@@ -1,14 +1,7 @@
 import {
-    AlertDialog,
-    AlertDialogBody,
-    AlertDialogContent,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogOverlay,
     Box,
     Button,
     Flex,
-    Heading,
     HStack,
     Icon,
     Input,
@@ -21,16 +14,12 @@ import {
     MenuList,
     MenuOptionGroup,
     Spacer,
-    Text as ChakraText,
     useColorMode,
-    VStack,
 } from '@chakra-ui/react';
-import React, { useRef, useState } from 'react';
+import React from 'react';
 import { FaChevronDown } from 'react-icons/fa';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
-import { resetAnnotations, selectAnnotations } from '../features/annotations/annotationSlice';
-import { AnnotatedPythonPackageBuilder } from '../features/annotatedPackageData/model/AnnotatedPythonPackageBuilder';
-import { PythonPackage } from '../features/packageData/model/PythonPackage';
+import { selectAnnotations } from '../features/annotations/annotationSlice';
 import { FilterHelpButton } from './FilterHelpButton';
 import {
     HeatMapMode,
@@ -42,64 +31,14 @@ import {
     toggleAPIImportDialog,
     toggleUsageImportDialog,
 } from '../features/ui/uiSlice';
+import { DeleteAllAnnotations } from './DeleteAllAnnotations';
+import { GenerateAdapters } from './GenerateAdapters';
 
 interface MenuBarProps {
-    pythonPackage: PythonPackage;
     displayInferErrors: (errors: string[]) => void;
 }
 
-const DeleteAllAnnotations = function () {
-    const dispatch = useAppDispatch();
-    const [isOpen, setIsOpen] = useState(false);
-    const cancelRef = useRef(null);
-
-    // Event handlers ----------------------------------------------------------
-
-    const handleConfirm = () => {
-        dispatch(resetAnnotations());
-        setIsOpen(false);
-    };
-    const handleCancel = () => setIsOpen(false);
-
-    // Render ------------------------------------------------------------------
-
-    return (
-        <>
-            <Button onClick={() => setIsOpen(true)}>Delete all annotations</Button>
-
-            <AlertDialog isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={handleCancel}>
-                <AlertDialogOverlay>
-                    <AlertDialogContent>
-                        <AlertDialogHeader>
-                            <Heading>Delete all annotations</Heading>
-                        </AlertDialogHeader>
-
-                        <AlertDialogBody>
-                            <VStack alignItems="flexStart">
-                                <ChakraText>Are you sure? You can't undo this action afterwards.</ChakraText>
-                                <ChakraText>
-                                    Hint: Consider exporting your work first by clicking on the "Export" button in the
-                                    menu bar.
-                                </ChakraText>
-                            </VStack>
-                        </AlertDialogBody>
-
-                        <AlertDialogFooter>
-                            <Button ref={cancelRef} onClick={handleCancel}>
-                                Cancel
-                            </Button>
-                            <Button colorScheme="red" onClick={handleConfirm} ml={3}>
-                                Delete
-                            </Button>
-                        </AlertDialogFooter>
-                    </AlertDialogContent>
-                </AlertDialogOverlay>
-            </AlertDialog>
-        </>
-    );
-};
-
-export const MenuBar: React.FC<MenuBarProps> = function ({ pythonPackage, displayInferErrors }) {
+export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors }) {
     const { colorMode, toggleColorMode } = useColorMode();
     const dispatch = useAppDispatch();
 
@@ -114,30 +53,6 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ pythonPackage, displa
         a.href = URL.createObjectURL(file);
         a.download = 'annotations.json';
         a.click();
-    };
-
-    const generateAdapters = () => {
-        const annotatedPythonPackageBuilder = new AnnotatedPythonPackageBuilder(pythonPackage, annotationStore);
-        const annotatedPythonPackage = annotatedPythonPackageBuilder.generateAnnotatedPythonPackage();
-        const packageName = "safeds"
-
-        const requestOptions = {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(annotatedPythonPackage),
-        };
-        fetch(`/api-editor/generate-adapters/${packageName}`, requestOptions).then(async (response) => {
-            if (!response.ok) {
-                const jsonResponse = await response.json();
-                displayInferErrors(jsonResponse);
-            } else {
-                const jsonBlob = await response.blob();
-                const a = document.createElement('a');
-                a.href = URL.createObjectURL(jsonBlob);
-                a.download = `${packageName}.zip`;
-                a.click();
-            }
-        });
     };
 
     const colorModeArray: string[] = [];
@@ -187,7 +102,7 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ pythonPackage, displa
                     </Menu>
                 </Box>
 
-                <Button onClick={generateAdapters}>Generate adapters</Button>
+                <GenerateAdapters displayInferErrors={displayInferErrors} />
                 <DeleteAllAnnotations />
 
                 <Box>

--- a/api-editor/gui/src/common/MenuBar.tsx
+++ b/api-editor/gui/src/common/MenuBar.tsx
@@ -119,13 +119,14 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ pythonPackage, displa
     const infer = () => {
         const annotatedPythonPackageBuilder = new AnnotatedPythonPackageBuilder(pythonPackage, annotationStore);
         const annotatedPythonPackage = annotatedPythonPackageBuilder.generateAnnotatedPythonPackage();
+        const packageName = "safeds"
 
         const requestOptions = {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(annotatedPythonPackage),
         };
-        fetch('/api-editor/infer/simpleml', requestOptions).then(async (response) => {
+        fetch(`/api-editor/infer/${packageName}`, requestOptions).then(async (response) => {
             if (!response.ok) {
                 const jsonResponse = await response.json();
                 displayInferErrors(jsonResponse);
@@ -133,7 +134,7 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ pythonPackage, displa
                 const jsonBlob = await response.blob();
                 const a = document.createElement('a');
                 a.href = URL.createObjectURL(jsonBlob);
-                a.download = 'simpleml.zip';
+                a.download = `${packageName}.zip`;
                 a.click();
             }
         });

--- a/api-editor/gui/src/common/MenuBar.tsx
+++ b/api-editor/gui/src/common/MenuBar.tsx
@@ -126,7 +126,7 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ pythonPackage, displa
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(annotatedPythonPackage),
         };
-        fetch(`/api-editor/infer/${packageName}`, requestOptions).then(async (response) => {
+        fetch(`/api-editor/generate-adapters/${packageName}`, requestOptions).then(async (response) => {
             if (!response.ok) {
                 const jsonResponse = await response.json();
                 displayInferErrors(jsonResponse);

--- a/api-editor/gui/src/common/MenuBar.tsx
+++ b/api-editor/gui/src/common/MenuBar.tsx
@@ -116,7 +116,7 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ pythonPackage, displa
         a.click();
     };
 
-    const infer = () => {
+    const generateAdapters = () => {
         const annotatedPythonPackageBuilder = new AnnotatedPythonPackageBuilder(pythonPackage, annotationStore);
         const annotatedPythonPackage = annotatedPythonPackageBuilder.generateAnnotatedPythonPackage();
         const packageName = "safeds"
@@ -187,7 +187,7 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ pythonPackage, displa
                     </Menu>
                 </Box>
 
-                <Button onClick={infer}>Generate adapters</Button>
+                <Button onClick={generateAdapters}>Generate adapters</Button>
                 <DeleteAllAnnotations />
 
                 <Box>


### PR DESCRIPTION
Closes #581.

### Summary of Changes

When user clicks on "Generate Adapters" a dialog will appear where the user can enter the name of the generated package.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/173252066-031b9308-b9cf-4ba2-998d-353a83a9495f.png)