### PR TITLE
fix(gui): remove gap between info and action bar in selection view

### DIFF
--- a/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
@@ -23,7 +23,7 @@ export const ActionBar: React.FC<ActionBarProps> = function ({ declaration, pyth
     const annotations = useAppSelector(selectAnnotations);
 
     return (
-        <HStack borderTop={1} layerStyle="subtleBorder" padding="0.5em 1em" w="100%">
+        <HStack borderTop={1} layerStyle="subtleBorder" padding="0.5em 1em" marginTop={0} w="100%">
             <Button
                 onClick={() => {
                     let navStr = getPreviousElementPath(declaration, pythonFilter, annotations, usages);

--- a/api-editor/gui/src/features/packageData/selectionView/SelectionView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/SelectionView.tsx
@@ -1,4 +1,4 @@
-import { Box, Spacer, VStack } from '@chakra-ui/react';
+import { Box, VStack } from '@chakra-ui/react';
 import React from 'react';
 import { useLocation } from 'react-router';
 import { PythonClass } from '../model/PythonClass';
@@ -28,8 +28,8 @@ export const SelectionView: React.FC<SelectionViewProps> = function ({ pythonPac
     }
 
     return (
-        <VStack h="100%">
-            <Box w="100%" flexGrow={1} overflowY="auto">
+        <VStack h="100%" spacing={0}>
+            <Box flexGrow={1} overflowY="auto">
                 <Box padding={4}>
                     {declaration instanceof PythonFunction && <FunctionView pythonFunction={declaration} />}
                     {declaration instanceof PythonClass && <ClassView pythonClass={declaration} />}
@@ -37,8 +37,6 @@ export const SelectionView: React.FC<SelectionViewProps> = function ({ pythonPac
                     {declaration instanceof PythonParameter && <ParameterView pythonParameter={declaration} />}
                 </Box>
             </Box>
-
-            <Spacer />
 
             <ActionBar
                 declaration={declaration}


### PR DESCRIPTION
### Summary of Changes

Remove the gap between the info about the selected declaration and the action bar in the selection view. Notice how the scroll bar in the screenshot below now touches the border of the action bar.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/173323305-344d97f3-65ec-4193-aa43-a72bd43ce6d9.png)
