### PR TITLE
feat(gui): select but don't expand/collapse in tree view

### DIFF
--- a/api-editor/gui/src/features/packageData/treeView/TreeNode.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/TreeNode.tsx
@@ -1,21 +1,21 @@
-import { HStack, Icon, Text as ChakraText } from '@chakra-ui/react';
-import React, { MouseEvent } from 'react';
-import { IconType } from 'react-icons/lib';
-import { useLocation } from 'react-router';
-import { useNavigate } from 'react-router-dom';
-import { useAppDispatch, useAppSelector } from '../../../app/hooks';
-import { PythonDeclaration } from '../model/PythonDeclaration';
+import {HStack, Icon, Text as ChakraText} from '@chakra-ui/react';
+import React, {MouseEvent} from 'react';
+import {IconType} from 'react-icons/lib';
+import {useLocation} from 'react-router';
+import {useNavigate} from 'react-router-dom';
+import {useAppDispatch, useAppSelector} from '../../../app/hooks';
+import {PythonDeclaration} from '../model/PythonDeclaration';
 import {
     HeatMapMode,
     selectHeatMapMode,
     selectIsExpandedInTreeView,
     toggleIsExpandedInTreeView,
 } from '../../ui/uiSlice';
-import { VisibilityIndicator } from './VisibilityIndicator';
-import { AbstractPythonFilter } from '../model/filters/AbstractPythonFilter';
-import { selectAnnotations } from '../../annotations/annotationSlice';
-import { HeatMapInterpolation, HeatMapTag } from './HeatMapTag';
-import { UsageCountStore } from '../../usages/model/UsageCountStore';
+import {VisibilityIndicator} from './VisibilityIndicator';
+import {AbstractPythonFilter} from '../model/filters/AbstractPythonFilter';
+import {selectAnnotations} from '../../annotations/annotationSlice';
+import {HeatMapInterpolation, HeatMapTag} from './HeatMapTag';
+import {UsageCountStore} from '../../usages/model/UsageCountStore';
 
 interface TreeNodeProps {
     declaration: PythonDeclaration;
@@ -38,14 +38,14 @@ export class ValuePair {
 }
 
 export const TreeNode: React.FC<TreeNodeProps> = function ({
-    declaration,
-    icon,
-    isExpandable,
-    filter,
-    usages,
-    maxValue,
-    specificValue = 0,
-}) {
+                                                               declaration,
+                                                               icon,
+                                                               isExpandable,
+                                                               filter,
+                                                               usages,
+                                                               maxValue,
+                                                               specificValue = 0,
+                                                           }) {
     const currentPathname = useLocation().pathname;
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
@@ -60,13 +60,18 @@ export const TreeNode: React.FC<TreeNodeProps> = function ({
 
     const fontWeight = filter.shouldKeepDeclaration(declaration, annotations, usages) ? 'bold' : undefined;
 
-    const handleClick = (event: MouseEvent) => {
-        if (!event.shiftKey) {
+    const handleNodeClick = (event: MouseEvent) => {
+        if (event.shiftKey) {
             dispatch(toggleIsExpandedInTreeView(declaration.pathAsString()));
+        } else {
+            navigate(`/${declaration.pathAsString()}`);
         }
+    }
 
-        navigate(`/${declaration.pathAsString()}`);
-    };
+    const handleVisibilityIndicatorClick = (event: MouseEvent) => {
+        dispatch(toggleIsExpandedInTreeView(declaration.pathAsString()));
+        event.stopPropagation();
+    }
 
     const interpolation =
         useAppSelector(selectHeatMapMode) === HeatMapMode.Annotations
@@ -81,16 +86,17 @@ export const TreeNode: React.FC<TreeNodeProps> = function ({
             color={color}
             backgroundColor={backgroundColor}
             paddingLeft={paddingLeft}
-            onClick={handleClick}
+            onClick={handleNodeClick}
         >
             <VisibilityIndicator
                 hasChildren={isExpandable}
                 showChildren={showChildren}
                 isSelected={isSelected(declaration, currentPathname)}
+                onClick={handleVisibilityIndicatorClick}
             />
-            <Icon as={icon} />
+            <Icon as={icon}/>
             {displayHeatMap && (
-                <HeatMapTag actualValue={specificValue} maxValue={maxValue} interpolation={interpolation} />
+                <HeatMapTag actualValue={specificValue} maxValue={maxValue} interpolation={interpolation}/>
             )}
             <ChakraText fontWeight={fontWeight}>{declaration.getUniqueName()}</ChakraText>
         </HStack>

--- a/api-editor/gui/src/features/packageData/treeView/TreeNode.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/TreeNode.tsx
@@ -1,5 +1,5 @@
 import { HStack, Icon, Text as ChakraText } from '@chakra-ui/react';
-import React from 'react';
+import React, { MouseEvent } from 'react';
 import { IconType } from 'react-icons/lib';
 import { useLocation } from 'react-router';
 import { useNavigate } from 'react-router-dom';
@@ -60,8 +60,11 @@ export const TreeNode: React.FC<TreeNodeProps> = function ({
 
     const fontWeight = filter.shouldKeepDeclaration(declaration, annotations, usages) ? 'bold' : undefined;
 
-    const handleClick = () => {
-        dispatch(toggleIsExpandedInTreeView(declaration.pathAsString()));
+    const handleClick = (event: MouseEvent) => {
+        if (!event.shiftKey) {
+            dispatch(toggleIsExpandedInTreeView(declaration.pathAsString()));
+        }
+
         navigate(`/${declaration.pathAsString()}`);
     };
 

--- a/api-editor/gui/src/features/packageData/treeView/TreeNode.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/TreeNode.tsx
@@ -1,21 +1,21 @@
-import {HStack, Icon, Text as ChakraText} from '@chakra-ui/react';
-import React, {MouseEvent} from 'react';
-import {IconType} from 'react-icons/lib';
-import {useLocation} from 'react-router';
-import {useNavigate} from 'react-router-dom';
-import {useAppDispatch, useAppSelector} from '../../../app/hooks';
-import {PythonDeclaration} from '../model/PythonDeclaration';
+import { HStack, Icon, Text as ChakraText } from '@chakra-ui/react';
+import React, { MouseEvent } from 'react';
+import { IconType } from 'react-icons/lib';
+import { useLocation } from 'react-router';
+import { useNavigate } from 'react-router-dom';
+import { useAppDispatch, useAppSelector } from '../../../app/hooks';
+import { PythonDeclaration } from '../model/PythonDeclaration';
 import {
     HeatMapMode,
     selectHeatMapMode,
     selectIsExpandedInTreeView,
     toggleIsExpandedInTreeView,
 } from '../../ui/uiSlice';
-import {VisibilityIndicator} from './VisibilityIndicator';
-import {AbstractPythonFilter} from '../model/filters/AbstractPythonFilter';
-import {selectAnnotations} from '../../annotations/annotationSlice';
-import {HeatMapInterpolation, HeatMapTag} from './HeatMapTag';
-import {UsageCountStore} from '../../usages/model/UsageCountStore';
+import { VisibilityIndicator } from './VisibilityIndicator';
+import { AbstractPythonFilter } from '../model/filters/AbstractPythonFilter';
+import { selectAnnotations } from '../../annotations/annotationSlice';
+import { HeatMapInterpolation, HeatMapTag } from './HeatMapTag';
+import { UsageCountStore } from '../../usages/model/UsageCountStore';
 
 interface TreeNodeProps {
     declaration: PythonDeclaration;
@@ -38,14 +38,14 @@ export class ValuePair {
 }
 
 export const TreeNode: React.FC<TreeNodeProps> = function ({
-                                                               declaration,
-                                                               icon,
-                                                               isExpandable,
-                                                               filter,
-                                                               usages,
-                                                               maxValue,
-                                                               specificValue = 0,
-                                                           }) {
+    declaration,
+    icon,
+    isExpandable,
+    filter,
+    usages,
+    maxValue,
+    specificValue = 0,
+}) {
     const currentPathname = useLocation().pathname;
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
@@ -66,12 +66,12 @@ export const TreeNode: React.FC<TreeNodeProps> = function ({
         } else {
             navigate(`/${declaration.pathAsString()}`);
         }
-    }
+    };
 
     const handleVisibilityIndicatorClick = (event: MouseEvent) => {
         dispatch(toggleIsExpandedInTreeView(declaration.pathAsString()));
         event.stopPropagation();
-    }
+    };
 
     const interpolation =
         useAppSelector(selectHeatMapMode) === HeatMapMode.Annotations
@@ -94,9 +94,9 @@ export const TreeNode: React.FC<TreeNodeProps> = function ({
                 isSelected={isSelected(declaration, currentPathname)}
                 onClick={handleVisibilityIndicatorClick}
             />
-            <Icon as={icon}/>
+            <Icon as={icon} />
             {displayHeatMap && (
-                <HeatMapTag actualValue={specificValue} maxValue={maxValue} interpolation={interpolation}/>
+                <HeatMapTag actualValue={specificValue} maxValue={maxValue} interpolation={interpolation} />
             )}
             <ChakraText fontWeight={fontWeight}>{declaration.getUniqueName()}</ChakraText>
         </HStack>

--- a/api-editor/gui/src/features/packageData/treeView/VisibilityIndicator.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/VisibilityIndicator.tsx
@@ -1,17 +1,19 @@
 import { Icon, useColorModeValue } from '@chakra-ui/react';
-import React from 'react';
+import React, { MouseEvent } from 'react';
 import { FaChevronDown, FaChevronRight } from 'react-icons/fa';
 
 interface VisibilityIndicatorProps {
     hasChildren: boolean;
     showChildren: boolean;
     isSelected?: boolean;
+    onClick: (event: MouseEvent) => void;
 }
 
 export const VisibilityIndicator: React.FC<VisibilityIndicatorProps> = function ({
     hasChildren,
     showChildren,
     isSelected = false,
+    onClick = () => {},
 }) {
     const isClosed = !isSelected && !showChildren;
     const closedColor = useColorModeValue('gray.200', 'gray.700');
@@ -21,6 +23,7 @@ export const VisibilityIndicator: React.FC<VisibilityIndicatorProps> = function 
             as={showChildren ? FaChevronDown : FaChevronRight}
             color={isClosed ? closedColor : undefined}
             opacity={hasChildren ? 1 : 0}
+            onClick={onClick}
         />
     );
 };


### PR DESCRIPTION
Closes #624.

### Summary of Changes

Change the user interaction with nodes in the tree view:
1. If the user clicks on the visibility indicator (down/right arrow), the node is only expanded/collapsed but not selected.
2. If the user clicks on another part of the node with `Shift` pressed, the node is also only expanded/collapsed but not selected.
3. Otherwise, the node is selected but not expanded.
