### PR TITLE
feat(gui): button to expand tree view up to matched nodes

### DIFF
--- a/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
@@ -16,7 +16,7 @@ interface ActionBarProps {
     usages: UsageCountStore;
 }
 
-export const ActionBar: React.FC<ActionBarProps> = function ({declaration, pythonPackage, pythonFilter, usages}) {
+export const ActionBar: React.FC<ActionBarProps> = function ({ declaration, pythonPackage, pythonFilter, usages }) {
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
 
@@ -217,14 +217,14 @@ const doGetMatchedNodesAndParents = function (
     current: PythonDeclaration,
     isMatched: (declaration: PythonDeclaration) => boolean,
 ): DoGetMatchedNodesAndParentsResult {
-    const nodesToExpand: string[] = []
+    const nodesToExpand: string[] = [];
     let shouldExpandThisNode = false;
 
     for (const child of current.children()) {
-        const {
-            nodesToExpand: childrenNodesToExpand,
-            subtreeShouldBeExpanded
-        } = doGetMatchedNodesAndParents(child, isMatched);
+        const { nodesToExpand: childrenNodesToExpand, subtreeShouldBeExpanded } = doGetMatchedNodesAndParents(
+            child,
+            isMatched,
+        );
 
         nodesToExpand.push(...childrenNodesToExpand);
         shouldExpandThisNode ||= subtreeShouldBeExpanded;
@@ -236,6 +236,6 @@ const doGetMatchedNodesAndParents = function (
 
     return {
         nodesToExpand,
-        subtreeShouldBeExpanded: isMatched(current) || shouldExpandThisNode
+        subtreeShouldBeExpanded: isMatched(current) || shouldExpandThisNode,
     };
 };

--- a/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
@@ -7,7 +7,7 @@ import { AnnotationStore, selectAnnotations } from '../../annotations/annotation
 import { useNavigate } from 'react-router';
 import { useAppDispatch, useAppSelector } from '../../../app/hooks';
 import { UsageCountStore } from '../../usages/model/UsageCountStore';
-import { setAllCollapsedInTreeView, setAllExpandedInTreeView } from '../../ui/uiSlice';
+import { setAllCollapsedInTreeView, setAllExpandedInTreeView, setExactlyExpandedInTreeView } from '../../ui/uiSlice';
 
 interface ActionBarProps {
     declaration: PythonDeclaration;
@@ -16,11 +16,13 @@ interface ActionBarProps {
     usages: UsageCountStore;
 }
 
-export const ActionBar: React.FC<ActionBarProps> = function ({ declaration, pythonPackage, pythonFilter, usages }) {
+export const ActionBar: React.FC<ActionBarProps> = function ({declaration, pythonPackage, pythonFilter, usages}) {
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
 
     const annotations = useAppSelector(selectAnnotations);
+    const isMatched = (node: PythonDeclaration): boolean =>
+        pythonFilter.shouldKeepDeclaration(node, annotations, usages);
 
     return (
         <HStack borderTop={1} layerStyle="subtleBorder" padding="0.5em 1em" marginTop={0} w="100%">
@@ -85,6 +87,14 @@ export const ActionBar: React.FC<ActionBarProps> = function ({ declaration, pyth
                 }}
             >
                 Collapse Selected
+            </Button>
+            <Button
+                accessKey="m"
+                onClick={() => {
+                    dispatch(setExactlyExpandedInTreeView(getMatchedNodesAndParents(pythonPackage, isMatched)));
+                }}
+            >
+                Expand Matched
             </Button>
         </HStack>
     );
@@ -189,4 +199,43 @@ const getDescendants = function (current: PythonDeclaration): string[] {
         childrenList = [...childrenList, ...list];
     }
     return childrenList;
+};
+
+const getMatchedNodesAndParents = function (
+    pythonPackage: PythonPackage,
+    isMatched: (declaration: PythonDeclaration) => boolean,
+): string[] {
+    return doGetMatchedNodesAndParents(pythonPackage, isMatched).nodesToExpand;
+};
+
+interface DoGetMatchedNodesAndParentsResult {
+    nodesToExpand: string[];
+    subtreeShouldBeExpanded: boolean;
+}
+
+const doGetMatchedNodesAndParents = function (
+    current: PythonDeclaration,
+    isMatched: (declaration: PythonDeclaration) => boolean,
+): DoGetMatchedNodesAndParentsResult {
+    const nodesToExpand: string[] = []
+    let shouldExpandThisNode = false;
+
+    for (const child of current.children()) {
+        const {
+            nodesToExpand: childrenNodesToExpand,
+            subtreeShouldBeExpanded
+        } = doGetMatchedNodesAndParents(child, isMatched);
+
+        nodesToExpand.push(...childrenNodesToExpand);
+        shouldExpandThisNode ||= subtreeShouldBeExpanded;
+    }
+
+    if (shouldExpandThisNode) {
+        nodesToExpand.push(current.pathAsString());
+    }
+
+    return {
+        nodesToExpand,
+        subtreeShouldBeExpanded: isMatched(current) || shouldExpandThisNode
+    };
 };

--- a/api-editor/gui/src/features/packageData/selectionView/SelectionView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/SelectionView.tsx
@@ -29,7 +29,7 @@ export const SelectionView: React.FC<SelectionViewProps> = function ({ pythonPac
 
     return (
         <VStack h="100%" spacing={0}>
-            <Box flexGrow={1} overflowY="auto">
+            <Box flexGrow={1} overflowY="auto" width="100%">
                 <Box padding={4}>
                     {declaration instanceof PythonFunction && <FunctionView pythonFunction={declaration} />}
                     {declaration instanceof PythonClass && <ClassView pythonClass={declaration} />}

--- a/api-editor/gui/src/features/ui/uiSlice.ts
+++ b/api-editor/gui/src/features/ui/uiSlice.ts
@@ -228,6 +228,13 @@ const uiSlice = createSlice({
                 delete state.expandedInTreeView[item];
             }
         },
+        setExactlyExpandedInTreeView(state, action: PayloadAction<string[]>) {
+            const all = action.payload;
+            state.expandedInTreeView = {};
+            for (const item of all) {
+                state.expandedInTreeView[item] = true;
+            }
+        },
         setTreeViewScrollOffset(state, action: PayloadAction<number>) {
             state.treeViewScrollOffset = action.payload;
         },
@@ -267,6 +274,7 @@ export const {
     toggleIsExpandedInTreeView,
     setAllExpandedInTreeView,
     setAllCollapsedInTreeView,
+    setExactlyExpandedInTreeView,
     setTreeViewScrollOffset,
     setHeatMapMode,
 


### PR DESCRIPTION
Closes #588.

### Summary of Changes

The button "Expand Matched" expands/collapses nodes in the tree view so that as few nodes as possible but all matched nodes are visible.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/173340731-3b086f8b-7f8f-47fa-9016-a877d17006c4.png)

