### PR TITLE
fix(backend): syntax of multi-line todo comment

### DIFF
--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGenerator.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGenerator.kt
@@ -375,12 +375,16 @@ fun todoComment(message: String) = buildString {
         return ""
     }
 
-    val lines = message.lines()
+    val lines = message.trim().lines()
     val firstLine = lines.first()
     val remainingLines = lines.drop(1)
 
-    appendLine("# TODO: $firstLine")
-    remainingLines.forEach {
-        appendIndented(it, indent = " ".repeat(8))
+    appendLine("# TODO: ${firstLine.trim()}")
+    remainingLines.forEachIndexed { index, line ->
+        val indentedLine = "#       $line"
+        append(indentedLine.trim())
+        if (index < remainingLines.size - 1) {
+            appendLine()
+        }
     }
 }

--- a/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGeneratorTest.kt
+++ b/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/codegen/PythonCodeGeneratorTest.kt
@@ -243,12 +243,14 @@ class PythonCodeGeneratorTest {
         fun `should store todo if it is not blank`() {
             val testClass = PythonClass(
                 name = "TestClass",
-                todo = "Lorem ipsum\n\nDolor sit amet"
+                todo = "    Lorem ipsum\n\n    Dolor sit\namet\n"
             )
 
             testClass.toPythonCode() shouldBe """
                     |# TODO: Lorem ipsum
-                    |        Dolor sit amet
+                    |#
+                    |#           Dolor sit
+                    |#       amet
                     |class TestClass:
                     |    pass
             """.trimMargin()
@@ -460,12 +462,14 @@ class PythonCodeGeneratorTest {
         @Test
         fun `should store todo if it is not blank`() {
             val testConstructor = PythonConstructor(
-                todo = "Lorem ipsum\n\nDolor sit amet"
+                todo = "    Lorem ipsum\n\n    Dolor sit\namet\n"
             )
 
             testConstructor.toPythonCode() shouldBe """
                     |# TODO: Lorem ipsum
-                    |        Dolor sit amet
+                    |#
+                    |#           Dolor sit
+                    |#       amet
                     |def __init__():
                     |    pass
             """.trimMargin()
@@ -721,12 +725,14 @@ class PythonCodeGeneratorTest {
         fun `should store todo if it is not blank`() {
             val testFunction = PythonFunction(
                 name = "testFunction",
-                todo = "Lorem ipsum\n\nDolor sit amet"
+                todo = "    Lorem ipsum\n\n    Dolor sit\namet\n"
             )
 
             testFunction.toPythonCode() shouldBe """
                     |# TODO: Lorem ipsum
-                    |        Dolor sit amet
+                    |#
+                    |#           Dolor sit
+                    |#       amet
                     |def testFunction():
                     |    pass
             """.trimMargin()


### PR DESCRIPTION
### Summary of Changes

Previously, a multi-line TODO comment would lead to erroneous Python code. This is fixed now.