### PR TITLE
feat(gui): mark entire API elements as done

### DIFF
--- a/api-editor/gui/src/features/annotations/AnnotationDropdown.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationDropdown.tsx
@@ -1,8 +1,8 @@
 import { Box, Button, Icon, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
 import React from 'react';
 import { FaChevronDown } from 'react-icons/fa';
-import { useAppDispatch } from '../../app/hooks';
-import { addPure, addRemove, addRequired } from './annotationSlice';
+import { useAppDispatch, useAppSelector } from '../../app/hooks';
+import { addPure, addRemove, addRequired, selectDone } from './annotationSlice';
 import {
     showAttributeAnnotationForm,
     showBoundaryAnnotationForm,
@@ -53,12 +53,19 @@ export const AnnotationDropdown: React.FC<AnnotationDropdownProps> = function ({
     target,
 }) {
     const dispatch = useAppDispatch();
+    const isDone = Boolean(useAppSelector(selectDone(target)));
 
     return (
         // Box gets rid of popper.js warning "CSS margin styles cannot be used"
         <Box>
             <Menu>
-                <MenuButton as={Button} size="sm" variant="outline" rightIcon={<Icon as={FaChevronDown} />}>
+                <MenuButton
+                    as={Button}
+                    size="sm"
+                    variant="outline"
+                    rightIcon={<Icon as={FaChevronDown} />}
+                    disabled={isDone}
+                >
                     Annotations
                 </MenuButton>
                 <MenuList>

--- a/api-editor/gui/src/features/annotations/AnnotationImportDialog.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationImportDialog.tsx
@@ -17,27 +17,12 @@ import React, { useState } from 'react';
 import { useAppDispatch } from '../../app/hooks';
 import { StyledDropzone } from '../../common/StyledDropzone';
 import { isValidJsonFile } from '../../common/util/validation';
-import { AnnotationStore, setAnnotations } from './annotationSlice';
+import {AnnotationStore, initialState, setAnnotations} from './annotationSlice';
 import { hideAnnotationImportDialog, toggleAnnotationImportDialog } from '../ui/uiSlice';
 
 export const AnnotationImportDialog: React.FC = function () {
     const [fileName, setFileName] = useState('');
-    const [newAnnotationStore, setNewAnnotationStore] = useState<AnnotationStore>({
-        attributes: {},
-        boundaries: {},
-        constants: {},
-        calledAfters: {},
-        descriptions: {},
-        enums: {},
-        groups: {},
-        moves: {},
-        optionals: {},
-        pures: {},
-        renamings: {},
-        requireds: {},
-        removes: {},
-        todos: {},
-    });
+    const [newAnnotationStore, setNewAnnotationStore] = useState<AnnotationStore>(initialState);
     const dispatch = useAppDispatch();
 
     const submit = () => {

--- a/api-editor/gui/src/features/annotations/AnnotationImportDialog.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationImportDialog.tsx
@@ -17,7 +17,7 @@ import React, { useState } from 'react';
 import { useAppDispatch } from '../../app/hooks';
 import { StyledDropzone } from '../../common/StyledDropzone';
 import { isValidJsonFile } from '../../common/util/validation';
-import {AnnotationStore, initialState, setAnnotations} from './annotationSlice';
+import { AnnotationStore, initialState, setAnnotations } from './annotationSlice';
 import { hideAnnotationImportDialog, toggleAnnotationImportDialog } from '../ui/uiSlice';
 
 export const AnnotationImportDialog: React.FC = function () {

--- a/api-editor/gui/src/features/annotations/AnnotationView.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationView.tsx
@@ -35,6 +35,7 @@ import {
     selectRequired,
     selectRemove,
     selectTodo,
+    selectDone,
 } from './annotationSlice';
 import {
     showAttributeAnnotationForm,
@@ -95,6 +96,7 @@ export const AnnotationView: React.FC<AnnotationViewProps> = function ({ target 
         <Stack maxW="fit-content">
             {attributeAnnotation && (
                 <Annotation
+                    target={target}
                     type="attribute"
                     name={valueToString(attributeAnnotation.defaultValue, attributeAnnotation.defaultType)}
                     onEdit={() => dispatch(showAttributeAnnotationForm(target))}
@@ -103,6 +105,7 @@ export const AnnotationView: React.FC<AnnotationViewProps> = function ({ target 
             )}
             {boundaryAnnotation && (
                 <Annotation
+                    target={target}
                     type="boundary"
                     name={boundaryToString(boundaryAnnotation)}
                     onEdit={() => dispatch(showBoundaryAnnotationForm(target))}
@@ -111,6 +114,7 @@ export const AnnotationView: React.FC<AnnotationViewProps> = function ({ target 
             )}
             {Object.keys(calledAfterAnnotation).map((calledAfterName) => (
                 <Annotation
+                    target={target}
                     type="calledAfter"
                     name={calledAfterName}
                     key={calledAfterName}
@@ -119,6 +123,7 @@ export const AnnotationView: React.FC<AnnotationViewProps> = function ({ target 
             ))}
             {constantAnnotation && (
                 <Annotation
+                    target={target}
                     type="constant"
                     name={valueToString(constantAnnotation.defaultValue, constantAnnotation.defaultType)}
                     onEdit={() => dispatch(showConstantAnnotationForm(target))}
@@ -127,6 +132,7 @@ export const AnnotationView: React.FC<AnnotationViewProps> = function ({ target 
             )}
             {descriptionAnnotation && (
                 <Annotation
+                    target={target}
                     type="description"
                     onEdit={() => dispatch(showDescriptionAnnotationForm(target))}
                     onDelete={() => dispatch(removeDescription(target))}
@@ -134,6 +140,7 @@ export const AnnotationView: React.FC<AnnotationViewProps> = function ({ target 
             )}
             {enumAnnotation && (
                 <Annotation
+                    target={target}
                     type="enum"
                     name={enumAnnotation.enumName}
                     onEdit={() => dispatch(showEnumAnnotationForm(target))}
@@ -143,6 +150,7 @@ export const AnnotationView: React.FC<AnnotationViewProps> = function ({ target 
             {Object.keys(groupAnnotations).map((groupName) => (
                 <Annotation
                     key={groupName}
+                    target={target}
                     type="group"
                     name={groupName}
                     onEdit={() => dispatch(showGroupAnnotationForm({ target, groupName }))}
@@ -151,6 +159,7 @@ export const AnnotationView: React.FC<AnnotationViewProps> = function ({ target 
             ))}
             {moveAnnotation && (
                 <Annotation
+                    target={target}
                     type="move"
                     name={moveAnnotation.destination}
                     onEdit={() => dispatch(showMoveAnnotationForm(target))}
@@ -159,25 +168,32 @@ export const AnnotationView: React.FC<AnnotationViewProps> = function ({ target 
             )}
             {optionalAnnotation && (
                 <Annotation
+                    target={target}
                     type="optional"
                     name={valueToString(optionalAnnotation.defaultValue, optionalAnnotation.defaultType)}
                     onEdit={() => dispatch(showOptionalAnnotationForm(target))}
                     onDelete={() => dispatch(removeOptional(target))}
                 />
             )}
-            {pureAnnotation && <Annotation type="pure" onDelete={() => dispatch(removePure(target))} />}
-            {removeAnnotation && <Annotation type="remove" onDelete={() => dispatch(removeRemove(target))} />}
+            {pureAnnotation && <Annotation target={target} type="pure" onDelete={() => dispatch(removePure(target))} />}
+            {removeAnnotation && (
+                <Annotation target={target} type="remove" onDelete={() => dispatch(removeRemove(target))} />
+            )}
             {renameAnnotation && (
                 <Annotation
+                    target={target}
                     type="rename"
                     name={renameAnnotation.newName}
                     onEdit={() => dispatch(showRenameAnnotationForm(target))}
                     onDelete={() => dispatch(removeRenaming(target))}
                 />
             )}
-            {requiredAnnotation && <Annotation type="required" onDelete={() => dispatch(removeRequired(target))} />}
+            {requiredAnnotation && (
+                <Annotation target={target} type="required" onDelete={() => dispatch(removeRequired(target))} />
+            )}
             {todoAnnotation && (
                 <Annotation
+                    target={target}
                     type="todo"
                     onEdit={() => dispatch(showTodoAnnotationForm(target))}
                     onDelete={() => dispatch(removeTodo(target))}
@@ -226,20 +242,23 @@ const boundaryToString = (boundary: BoundaryAnnotation) => {
 };
 
 interface AnnotationProps {
+    target: string;
     type: string;
     name?: string;
     onEdit?: () => void;
     onDelete: () => void;
 }
 
-const Annotation: React.FC<AnnotationProps> = function ({ name, onDelete, onEdit, type }) {
+const Annotation: React.FC<AnnotationProps> = function ({ target, name, onDelete, onEdit, type }) {
+    const isDone = Boolean(useAppSelector(selectDone(target)));
+
     return (
         <ButtonGroup size="sm" variant="outline" isAttached>
             <Button
                 leftIcon={<FaWrench />}
                 flexGrow={1}
                 justifyContent="flex-start"
-                disabled={!onEdit}
+                disabled={!onEdit || isDone}
                 onClick={onEdit}
             >
                 @{type}
@@ -249,7 +268,13 @@ const Annotation: React.FC<AnnotationProps> = function ({ name, onDelete, onEdit
                     </ChakraText>
                 )}
             </Button>
-            <IconButton icon={<FaTrash />} aria-label="Delete annotation" colorScheme="red" onClick={onDelete} />
+            <IconButton
+                icon={<FaTrash />}
+                aria-label="Delete annotation"
+                colorScheme="red"
+                disabled={isDone}
+                onClick={onDelete}
+            />
         </ButtonGroup>
     );
 };

--- a/api-editor/gui/src/features/annotations/DoneButton.tsx
+++ b/api-editor/gui/src/features/annotations/DoneButton.tsx
@@ -1,30 +1,32 @@
-import {Button, Icon} from '@chakra-ui/react';
+import { Button, Icon } from '@chakra-ui/react';
 import React from 'react';
-import {FaCheck} from 'react-icons/fa';
-import {useAppDispatch, useAppSelector} from '../../app/hooks';
-import {addDone, removeDone, selectDone} from './annotationSlice';
+import { FaCheck } from 'react-icons/fa';
+import { useAppDispatch, useAppSelector } from '../../app/hooks';
+import { addDone, removeDone, selectDone } from './annotationSlice';
 
 interface DoneButtonProps {
     target: string;
 }
 
-export const DoneButton: React.FC<DoneButtonProps> = function ({target}) {
+export const DoneButton: React.FC<DoneButtonProps> = function ({ target }) {
     const dispatch = useAppDispatch();
     const isDone = useAppSelector(selectDone(target));
 
     if (isDone) {
         return (
-            <Button size="sm"
-                    variant="solid"
-                    colorScheme="green"
-                    rightIcon={<Icon as={FaCheck}/>}
-                    onClick={() => dispatch(removeDone(target))}>
+            <Button
+                size="sm"
+                variant="solid"
+                colorScheme="green"
+                rightIcon={<Icon as={FaCheck} />}
+                onClick={() => dispatch(removeDone(target))}
+            >
                 Done
             </Button>
         );
     } else {
         return (
-            <Button size="sm" variant="outline" onClick={() => dispatch(addDone({target}))}>
+            <Button size="sm" variant="outline" onClick={() => dispatch(addDone({ target }))}>
                 Mark as done
             </Button>
         );

--- a/api-editor/gui/src/features/annotations/DoneButton.tsx
+++ b/api-editor/gui/src/features/annotations/DoneButton.tsx
@@ -1,0 +1,32 @@
+import {Button, Icon} from '@chakra-ui/react';
+import React from 'react';
+import {FaCheck} from 'react-icons/fa';
+import {useAppDispatch, useAppSelector} from '../../app/hooks';
+import {addDone, removeDone, selectDone} from './annotationSlice';
+
+interface DoneButtonProps {
+    target: string;
+}
+
+export const DoneButton: React.FC<DoneButtonProps> = function ({target}) {
+    const dispatch = useAppDispatch();
+    const isDone = useAppSelector(selectDone(target));
+
+    if (isDone) {
+        return (
+            <Button size="sm"
+                    variant="solid"
+                    colorScheme="green"
+                    rightIcon={<Icon as={FaCheck}/>}
+                    onClick={() => dispatch(removeDone(target))}>
+                Done
+            </Button>
+        );
+    } else {
+        return (
+            <Button size="sm" variant="outline" onClick={() => dispatch(addDone({target}))}>
+                Mark as done
+            </Button>
+        );
+    }
+};

--- a/api-editor/gui/src/features/annotations/annotationSlice.ts
+++ b/api-editor/gui/src/features/annotations/annotationSlice.ts
@@ -18,6 +18,9 @@ export interface AnnotationStore {
     descriptions: {
         [target: string]: DescriptionAnnotation;
     };
+    dones: {
+        [target: string]: DoneAnnotation;
+    }
     enums: {
         [target: string]: EnumAnnotation;
     };
@@ -165,6 +168,19 @@ export interface DescriptionAnnotation {
     readonly newDescription: string;
 }
 
+/**
+ * The element is fully annotated and all annotations are checked.
+ *
+ * **Important:** While this is implemented as an annotation it should **not** be counted in the heat map or the
+ * statistics.
+ */
+export interface DoneAnnotation {
+    /**
+     * ID of the annotated Python declaration.
+     */
+    readonly target: string;
+}
+
 export interface EnumAnnotation {
     /**
      * ID of the annotated Python declaration.
@@ -294,6 +310,7 @@ export const initialState: AnnotationStore = {
     calledAfters: {},
     constants: {},
     descriptions: {},
+    dones: {},
     enums: {},
     groups: {},
     moves: {},
@@ -377,6 +394,12 @@ const annotationsSlice = createSlice({
         },
         removeDescription(state, action: PayloadAction<string>) {
             delete state.descriptions[action.payload];
+        },
+        addDone(state, action: PayloadAction<DoneAnnotation>) {
+            state.dones[action.payload.target] = action.payload;
+        },
+        removeDone(state, action: PayloadAction<string>) {
+            delete state.dones[action.payload];
         },
         upsertEnum(state, action: PayloadAction<EnumAnnotation>) {
             state.enums[action.payload.target] = action.payload;
@@ -490,6 +513,8 @@ export const {
     removeConstant,
     upsertDescription,
     removeDescription,
+    addDone,
+    removeDone,
     upsertEnum,
     removeEnum,
     upsertGroup,
@@ -532,6 +557,10 @@ export const selectDescription =
     (target: string) =>
     (state: RootState): DescriptionAnnotation | undefined =>
         selectAnnotations(state).descriptions[target];
+export const selectDone =
+    (target: string) =>
+        (state: RootState): DoneAnnotation | undefined =>
+            selectAnnotations(state).dones[target];
 export const selectEnum =
     (target: string) =>
     (state: RootState): EnumAnnotation | undefined =>

--- a/api-editor/gui/src/features/annotations/annotationSlice.ts
+++ b/api-editor/gui/src/features/annotations/annotationSlice.ts
@@ -20,7 +20,7 @@ export interface AnnotationStore {
     };
     dones: {
         [target: string]: DoneAnnotation;
-    }
+    };
     enums: {
         [target: string]: EnumAnnotation;
     };
@@ -559,8 +559,8 @@ export const selectDescription =
         selectAnnotations(state).descriptions[target];
 export const selectDone =
     (target: string) =>
-        (state: RootState): DoneAnnotation | undefined =>
-            selectAnnotations(state).dones[target];
+    (state: RootState): DoneAnnotation | undefined =>
+        selectAnnotations(state).dones[target];
 export const selectEnum =
     (target: string) =>
     (state: RootState): EnumAnnotation | undefined =>

--- a/api-editor/gui/src/features/packageData/selectionView/ClassView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ClassView.tsx
@@ -5,6 +5,7 @@ import { AnnotationView } from '../../annotations/AnnotationView';
 import { PythonClass } from '../model/PythonClass';
 import { DocumentationText } from './DocumentationText';
 import { SectionListViewItem } from './SectionListViewItem';
+import { DoneButton } from '../../annotations/DoneButton';
 
 interface ClassViewProps {
     pythonClass: PythonClass;
@@ -21,7 +22,10 @@ export const ClassView: React.FC<ClassViewProps> = function ({ pythonClass }) {
                         {pythonClass.name} {!pythonClass.isPublic && '(private)'}
                     </Heading>
                     {pythonClass.isPublic && (
-                        <AnnotationDropdown target={id} showDescription showMove showRemove showRename showTodo />
+                        <>
+                            <AnnotationDropdown target={id} showDescription showMove showRemove showRename showTodo />
+                            <DoneButton target={id} />
+                        </>
                     )}
                 </HStack>
 

--- a/api-editor/gui/src/features/packageData/selectionView/FunctionView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/FunctionView.tsx
@@ -9,6 +9,7 @@ import { DocumentationText } from './DocumentationText';
 import { ParameterNode } from './ParameterNode';
 import { useAppSelector } from '../../../app/hooks';
 import { selectCalledAfters } from '../../annotations/annotationSlice';
+import {DoneButton} from "../../annotations/DoneButton";
 
 interface FunctionViewProps {
     pythonFunction: PythonFunction;
@@ -31,17 +32,20 @@ export const FunctionView: React.FC<FunctionViewProps> = function ({ pythonFunct
                         {pythonFunction.name} {!pythonFunction.isPublic && '(private)'}
                     </Heading>
                     {pythonFunction.isPublic && (
-                        <AnnotationDropdown
-                            target={id}
-                            showCalledAfter={hasRemainingCalledAfters}
-                            showDescription
-                            showGroup={pythonFunction.explicitParameters().length >= 2}
-                            showMove={pythonFunction.containingModuleOrClass instanceof PythonModule}
-                            showPure
-                            showRemove
-                            showRename
-                            showTodo
-                        />
+                        <>
+                            <AnnotationDropdown
+                                target={id}
+                                showCalledAfter={hasRemainingCalledAfters}
+                                showDescription
+                                showGroup={pythonFunction.explicitParameters().length >= 2}
+                                showMove={pythonFunction.containingModuleOrClass instanceof PythonModule}
+                                showPure
+                                showRemove
+                                showRename
+                                showTodo
+                            />
+                            <DoneButton target={id} />
+                        </>
                     )}
                 </HStack>
 

--- a/api-editor/gui/src/features/packageData/selectionView/FunctionView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/FunctionView.tsx
@@ -9,7 +9,7 @@ import { DocumentationText } from './DocumentationText';
 import { ParameterNode } from './ParameterNode';
 import { useAppSelector } from '../../../app/hooks';
 import { selectCalledAfters } from '../../annotations/annotationSlice';
-import {DoneButton} from "../../annotations/DoneButton";
+import { DoneButton } from '../../annotations/DoneButton';
 
 interface FunctionViewProps {
     pythonFunction: PythonFunction;

--- a/api-editor/gui/src/features/packageData/selectionView/ParameterNode.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ParameterNode.tsx
@@ -4,6 +4,7 @@ import { AnnotationDropdown } from '../../annotations/AnnotationDropdown';
 import { AnnotationView } from '../../annotations/AnnotationView';
 import { PythonParameter } from '../model/PythonParameter';
 import { DocumentationText } from './DocumentationText';
+import {DoneButton} from "../../annotations/DoneButton";
 
 interface ParameterNodeProps {
     pythonParameter: PythonParameter;
@@ -29,17 +30,20 @@ export const ParameterNode: React.FC<ParameterNodeProps> = function ({ isTitle, 
                     </Heading>
                 )}
                 {pythonParameter.isPublic && isExplicitParameter && (
-                    <AnnotationDropdown
-                        target={id}
-                        showAttribute={isConstructorParameter}
-                        showBoundary
-                        showConstant
-                        showDescription
-                        showEnum
-                        showOptional
-                        showRename
-                        showRequired
-                    />
+                    <>
+                        <AnnotationDropdown
+                            target={id}
+                            showAttribute={isConstructorParameter}
+                            showBoundary
+                            showConstant
+                            showDescription
+                            showEnum
+                            showOptional
+                            showRename
+                            showRequired
+                        />
+                        <DoneButton target={id} />
+                    </>
                 )}
             </HStack>
 

--- a/api-editor/gui/src/features/packageData/selectionView/ParameterNode.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ParameterNode.tsx
@@ -4,7 +4,7 @@ import { AnnotationDropdown } from '../../annotations/AnnotationDropdown';
 import { AnnotationView } from '../../annotations/AnnotationView';
 import { PythonParameter } from '../model/PythonParameter';
 import { DocumentationText } from './DocumentationText';
-import {DoneButton} from "../../annotations/DoneButton";
+import { DoneButton } from '../../annotations/DoneButton';
 
 interface ParameterNodeProps {
     pythonParameter: PythonParameter;


### PR DESCRIPTION
Closes #591.

### Summary of Changes

* Add new meta-annotation "done". This can be used to express that an API element is completely annotated and all annotations are checked.
* Disable annotation dropdown when an element is done.
* Disable annotation view when an element is done.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/173413862-241e9985-ca64-4ef2-967e-c95c5b889332.png)

![image](https://user-images.githubusercontent.com/2501322/173413894-d01356bb-d9b5-472c-bb35-97d094737b56.png)

