### PR TITLE
feat(gui): add `is:done` filter

### DIFF
--- a/api-editor/gui/src/common/FilterHelpButton.tsx
+++ b/api-editor/gui/src/common/FilterHelpButton.tsx
@@ -17,8 +17,8 @@ import React from 'react';
 
 export const FilterHelpButton = function () {
     return (
-        <Box>
-            <Popover>
+        <Box zIndex={100}>
+            <Popover isLazy={true}>
                 <PopoverTrigger>
                     <IconButton variant="ghost" icon={<Icon name="help" />} aria-label="help" />
                 </PopoverTrigger>
@@ -45,6 +45,12 @@ export const FilterHelpButton = function () {
                                     Displays only elements that have the given visibility. Replace [visibility] with one
                                     of <em>public, internal</em>.
                                 </ChakraText>
+                            </ListItem>
+                            <ListItem>
+                                <ChakraText>
+                                    <strong>is:done</strong>
+                                </ChakraText>
+                                <ChakraText>Displays only elements that are marked as done.</ChakraText>
                             </ListItem>
                             <ListItem>
                                 <ChakraText>

--- a/api-editor/gui/src/common/FilterInput.tsx
+++ b/api-editor/gui/src/common/FilterInput.tsx
@@ -24,7 +24,7 @@ export const FilterInput: React.FC = function () {
     const filterIsValid = invalidTokens.length === 0;
 
     return (
-        <Box>
+        <Box zIndex={50}>
             <Popover
                 returnFocusOnClose={false}
                 isOpen={!filterIsValid}

--- a/api-editor/gui/src/features/packageData/model/filters/AnnotationFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/AnnotationFilter.ts
@@ -54,6 +54,7 @@ export class AnnotationFilter extends AbstractPythonFilter {
                     id in annotations.calledAfters ||
                     id in annotations.constants ||
                     id in annotations.descriptions ||
+                    // Deliberately not checking annotations.done. It should be transparent to users it's an annotation.
                     id in annotations.enums ||
                     id in annotations.groups ||
                     id in annotations.moves ||
@@ -74,6 +75,8 @@ export class AnnotationFilter extends AbstractPythonFilter {
                 return id in annotations.constants;
             case AnnotationType.Description:
                 return id in annotations.descriptions;
+            case AnnotationType.Done:
+                return id in annotations.dones;
             case AnnotationType.Enum:
                 return id in annotations.enums;
             case AnnotationType.Group:
@@ -105,6 +108,7 @@ export enum AnnotationType {
     CalledAfter,
     Constant,
     Description,
+    Done,
     Enum,
     Group,
     Move,

--- a/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
@@ -101,6 +101,8 @@ const parsePositiveToken = function (token: string): Optional<AbstractPythonFilt
             return new AnnotationFilter(AnnotationType.Constant);
         case 'annotation:@description':
             return new AnnotationFilter(AnnotationType.Description);
+        case 'is:done': // Deliberate special case. It should be transparent to users it's an annotation.
+            return new AnnotationFilter(AnnotationType.Done);
         case 'annotation:@enum':
             return new AnnotationFilter(AnnotationType.Enum);
         case 'annotation:@group':


### PR DESCRIPTION
Closes #589.

### Summary of Changes

Add new filter `is:done`. Even though the "done" marker is implemented as an annotation, we use a special token for it, since we want to hide this implementation detail from the user.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/173418070-b0f16abe-d40a-4849-8e0a-0d5479b29b2d.png)

