### PR TITLE
feat(gui): merge annotations on import

### DIFF
--- a/api-editor/gui/src/features/annotations/AnnotationImportDialog.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationImportDialog.tsx
@@ -17,7 +17,7 @@ import React, { useState } from 'react';
 import { useAppDispatch } from '../../app/hooks';
 import { StyledDropzone } from '../../common/StyledDropzone';
 import { isValidJsonFile } from '../../common/util/validation';
-import { AnnotationStore, initialState, setAnnotations } from './annotationSlice';
+import { AnnotationStore, initialState, mergeAnnotations, setAnnotations } from './annotationSlice';
 import { hideAnnotationImportDialog, toggleAnnotationImportDialog } from '../ui/uiSlice';
 
 export const AnnotationImportDialog: React.FC = function () {
@@ -25,7 +25,13 @@ export const AnnotationImportDialog: React.FC = function () {
     const [newAnnotationStore, setNewAnnotationStore] = useState<AnnotationStore>(initialState);
     const dispatch = useAppDispatch();
 
-    const submit = () => {
+    const merge = () => {
+        if (fileName) {
+            dispatch(mergeAnnotations(newAnnotationStore));
+        }
+        dispatch(hideAnnotationImportDialog());
+    };
+    const replace = () => {
         if (fileName) {
             dispatch(setAnnotations(newAnnotationStore));
         }
@@ -79,8 +85,11 @@ export const AnnotationImportDialog: React.FC = function () {
                 </ModalBody>
                 <ModalFooter>
                     <HStack spacing={4}>
-                        <Button colorScheme="blue" onClick={submit}>
-                            Submit
+                        <Button colorScheme="blue" onClick={merge}>
+                            Merge into existing
+                        </Button>
+                        <Button colorScheme="gray" onClick={replace}>
+                            Replace existing
                         </Button>
                         <Button colorScheme="red" onClick={close}>
                             Cancel

--- a/api-editor/gui/src/features/annotations/annotationSlice.ts
+++ b/api-editor/gui/src/features/annotations/annotationSlice.ts
@@ -10,7 +10,7 @@ export const maximumNumberOfClassAnnotations = 5;
 /**
  * How many annotations can be applied to a function at once.
  */
-export const maximumNumberOfFunctionAnnotations = 6;
+export const maximumNumberOfFunctionAnnotations = 7;
 
 /**
  * How many annotations can be applied to a parameter at once.
@@ -371,6 +371,29 @@ const annotationsSlice = createSlice({
                 ...action.payload,
             };
         },
+        mergeAnnotations(state, action: PayloadAction<AnnotationStore>) {
+            for (const annotationType of Object.keys(action.payload)) {
+                if (annotationType === 'calledAfters' || annotationType === 'groups') {
+                    for (const target of Object.keys(action.payload[annotationType])) {
+                        // @ts-ignore
+                        state[annotationType][target] = {
+                            // @ts-ignore
+                            ...(state[annotationType][target] ?? {}),
+                            // @ts-ignore
+                            ...action.payload[annotationType][target],
+                        };
+                    }
+                } else {
+                    // @ts-ignore
+                    state[annotationType] = {
+                        // @ts-ignore
+                        ...state[annotationType],
+                        // @ts-ignore
+                        ...action.payload[annotationType],
+                    };
+                }
+            }
+        },
         resetAnnotations() {
             return initialState;
         },
@@ -516,6 +539,7 @@ const annotationsSlice = createSlice({
 const { actions, reducer } = annotationsSlice;
 export const {
     setAnnotations,
+    mergeAnnotations,
     resetAnnotations,
 
     upsertAttribute,


### PR DESCRIPTION
Closes #636.

### Summary of Changes

Users can now decide to merge imported annotations into the existing ones or replace the existing ones completely.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/173532383-3401e3f8-6360-411b-b6d6-cf538d43cab6.png)
