### PR TITLE
fix(gui): add implicit usages of default values on import

### DIFF
--- a/api-editor/gui/src/features/usages/UsageImportDialog.tsx
+++ b/api-editor/gui/src/features/usages/UsageImportDialog.tsx
@@ -14,22 +14,24 @@ import {
     Text as ChakraText,
 } from '@chakra-ui/react';
 import React, { useState } from 'react';
-import { useAppDispatch } from '../../app/hooks';
+import {useAppDispatch, useAppSelector} from '../../app/hooks';
 import { StyledDropzone } from '../../common/StyledDropzone';
 import { isValidJsonFile } from '../../common/util/validation';
 import { UsageCountJson, UsageCountStore } from './model/UsageCountStore';
 import { toggleUsageImportDialog } from '../ui/uiSlice';
 import { setUsages } from './usageSlice';
+import {selectPythonPackage} from "../packageData/apiSlice";
 
 export const UsageImportDialog: React.FC = function () {
     const [fileName, setFileName] = useState('');
     const [newUsages, setNewUsages] = useState<string>();
     const dispatch = useAppDispatch();
+    const api = useAppSelector(selectPythonPackage);
 
     const submit = async () => {
         if (newUsages) {
             const parsedUsages = JSON.parse(newUsages) as UsageCountJson;
-            dispatch(setUsages(UsageCountStore.fromJson(parsedUsages)));
+            dispatch(setUsages(UsageCountStore.fromJson(parsedUsages, api)));
         }
         close();
     };

--- a/api-editor/gui/src/features/usages/UsageImportDialog.tsx
+++ b/api-editor/gui/src/features/usages/UsageImportDialog.tsx
@@ -14,13 +14,13 @@ import {
     Text as ChakraText,
 } from '@chakra-ui/react';
 import React, { useState } from 'react';
-import {useAppDispatch, useAppSelector} from '../../app/hooks';
+import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { StyledDropzone } from '../../common/StyledDropzone';
 import { isValidJsonFile } from '../../common/util/validation';
 import { UsageCountJson, UsageCountStore } from './model/UsageCountStore';
 import { toggleUsageImportDialog } from '../ui/uiSlice';
 import { setUsages } from './usageSlice';
-import {selectPythonPackage} from "../packageData/apiSlice";
+import { selectPythonPackage } from '../packageData/apiSlice';
 
 export const UsageImportDialog: React.FC = function () {
     const [fileName, setFileName] = useState('');

--- a/api-editor/gui/src/features/usages/model/UsageCountStore.ts
+++ b/api-editor/gui/src/features/usages/model/UsageCountStore.ts
@@ -1,5 +1,5 @@
 import { PythonPackage } from '../../packageData/model/PythonPackage';
-import {PythonParameter} from "../../packageData/model/PythonParameter";
+import { PythonParameter } from '../../packageData/model/PythonParameter';
 
 export interface UsageCountJson {
     class_counts: {
@@ -83,8 +83,9 @@ export class UsageCountStore {
                 continue;
             }
 
-            const defaultValue = parameter.defaultValue
-            if (defaultValue === undefined || defaultValue === null) { // defaultValue could be an empty string
+            const defaultValue = parameter.defaultValue;
+            if (defaultValue === undefined || defaultValue === null) {
+                // defaultValue could be an empty string
                 continue;
             }
 
@@ -99,7 +100,7 @@ export class UsageCountStore {
                 continue;
             }
 
-            const nExplicitUsage  = this.valueUsages.get(parameterId)?.get(defaultValue) ?? 0;
+            const nExplicitUsage = this.valueUsages.get(parameterId)?.get(defaultValue) ?? 0;
 
             if (!this.valueUsages.has(parameterId)) {
                 this.valueUsages.set(parameterId, new Map());

--- a/api-editor/gui/src/features/usages/model/UsageCountStore.ts
+++ b/api-editor/gui/src/features/usages/model/UsageCountStore.ts
@@ -1,3 +1,6 @@
+import { PythonPackage } from '../../packageData/model/PythonPackage';
+import {PythonParameter} from "../../packageData/model/PythonParameter";
+
 export interface UsageCountJson {
     class_counts: {
         [target: string]: number;
@@ -16,12 +19,13 @@ export interface UsageCountJson {
 }
 
 export class UsageCountStore {
-    static fromJson(json: UsageCountJson): UsageCountStore {
+    static fromJson(json: UsageCountJson, api?: PythonPackage): UsageCountStore {
         return new UsageCountStore(
             new Map(Object.entries(json.class_counts)),
             new Map(Object.entries(json.function_counts)),
             new Map(Object.entries(json.parameter_counts)),
             new Map(Object.entries(json.value_counts).map((entry) => [entry[0], new Map(Object.entries(entry[1]))])),
+            api,
         );
     }
 
@@ -37,7 +41,12 @@ export class UsageCountStore {
         readonly functionUsages: Map<string, number> = new Map(),
         readonly parameterUsages: Map<string, number> = new Map(),
         readonly valueUsages: Map<string, Map<string, number>> = new Map(),
+        api?: PythonPackage,
     ) {
+        if (api) {
+            this.addImplicitUsagesOfDefaultValues(api);
+        }
+
         this.classMaxUsages = classUsages.size === 0 ? 0 : Math.max(...classUsages.values());
         this.functionMaxUsages = functionUsages.size === 0 ? 0 : Math.max(...functionUsages.values());
         this.parameterMaxUsages = parameterUsages.size === 0 ? 0 : Math.max(...parameterUsages.values());
@@ -58,6 +67,48 @@ export class UsageCountStore {
                 [...this.valueUsages.entries()].map((entry) => [entry[0], Object.fromEntries(entry[1])]),
             ),
         };
+    }
+
+    /**
+     * Adds the implicit usages of a parameters default value. When a function is called and a parameter is used with
+     * its default value, that usage of a value is not part of the UsageStore, so  we need to add it.
+     *
+     * @param api Description of the API
+     * @private
+     */
+    private addImplicitUsagesOfDefaultValues(api: PythonPackage) {
+        for (const [parameterId, parameterUsageCount] of this.parameterUsages.entries()) {
+            const parameter = api.getByRelativePathAsString(parameterId);
+            if (!(parameter instanceof PythonParameter)) {
+                continue;
+            }
+
+            const defaultValue = parameter.defaultValue
+            if (defaultValue === undefined || defaultValue === null) { // defaultValue could be an empty string
+                continue;
+            }
+
+            const containingFunction = parameter.containingFunction;
+            if (!containingFunction) {
+                continue;
+            }
+
+            const functionUsageCount = this.functionUsages.get(containingFunction.id) ?? 0;
+            const nImplicitUsages = functionUsageCount - parameterUsageCount;
+            if (nImplicitUsages === 0) {
+                continue;
+            }
+
+            const nExplicitUsage  = this.valueUsages.get(parameterId)?.get(defaultValue) ?? 0;
+
+            if (!this.valueUsages.has(parameterId)) {
+                this.valueUsages.set(parameterId, new Map());
+            }
+            if (!this.valueUsages.get(parameterId)!.has(defaultValue)) {
+                this.valueUsages.get(parameterId)!.set(defaultValue, 0);
+            }
+            this.valueUsages.get(parameterId)!.set(defaultValue, nImplicitUsages + nExplicitUsage);
+        }
     }
 
     private computeParameterUsefulness(pythonParameterId: string): number {


### PR DESCRIPTION
Closes #612.

### Summary of Changes

The GUI did not take implicit usages of default value into account when computing the usefulness of parameters. This meant we would either get the usefulness correct if the default value was the most common value or estimate a too low value if it was not.

### Screenshots (if necessary)

#### Before

![image](https://user-images.githubusercontent.com/2501322/173539630-8964017a-8dc6-4304-bde1-da33afe71a94.png)

#### After

![image](https://user-images.githubusercontent.com/2501322/173540384-836dc603-c079-4245-8b45-57913bff34d1.png)

The remaining matches are correct and due to the fact that no `@constant` annotations are created if their default value is not a literal.