### PR TITLE
feat(gui): sort classes/functions by usages

### DIFF
--- a/api-editor/gui/src/common/MenuBar.tsx
+++ b/api-editor/gui/src/common/MenuBar.tsx
@@ -23,8 +23,8 @@ import { selectAnnotations } from '../features/annotations/annotationSlice';
 import { FilterHelpButton } from './FilterHelpButton';
 import {
     HeatMapMode,
-    selectHeatMapMode,
-    setHeatMapMode,
+    selectHeatMapMode, selectSortingMode,
+    setHeatMapMode, setSortingMode, SortingMode,
     toggleAnnotationImportDialog,
     toggleAPIImportDialog,
     toggleUsageImportDialog,
@@ -43,6 +43,7 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
     const dispatch = useAppDispatch();
 
     const annotationStore = useAppSelector(selectAnnotations);
+    const sortingMode = useAppSelector(selectSortingMode);
     const heatMapMode = useAppSelector(selectHeatMapMode);
 
     const exportAnnotations = () => {
@@ -58,17 +59,6 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
     const colorModeArray: string[] = [];
     if (colorMode === 'dark') {
         colorModeArray.push('darkMode');
-    }
-
-    let heatMapModeString: string = '';
-    if (heatMapMode === HeatMapMode.None) {
-        heatMapModeString = 'none';
-    } else if (heatMapMode === HeatMapMode.Usages) {
-        heatMapModeString = 'usages';
-    } else if (heatMapMode === HeatMapMode.Usefulness) {
-        heatMapModeString = 'usefulness';
-    } else if (heatMapMode === HeatMapMode.Annotations) {
-        heatMapModeString = 'annotations';
     }
 
     return (
@@ -117,32 +107,51 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
                                 </MenuItemOption>
                             </MenuOptionGroup>
                             <MenuDivider />
-                            <MenuGroup title="Heat Map Mode">
-                                <MenuOptionGroup type="radio" defaultValue="none" value={heatMapModeString}>
+                            <MenuGroup title="Class/Function Sorting">
+                                <MenuOptionGroup type="radio" defaultValue={SortingMode.Alphabetical} value={sortingMode}>
                                     <MenuItemOption
                                         paddingLeft={8}
-                                        value={'none'}
+                                        value={SortingMode.Alphabetical}
+                                        onClick={() => dispatch(setSortingMode(SortingMode.Alphabetical))}
+                                    >
+                                        Alphabetical
+                                    </MenuItemOption>
+                                    <MenuItemOption
+                                        paddingLeft={8}
+                                        value={SortingMode.Usages}
+                                        onClick={() => dispatch(setSortingMode(SortingMode.Usages))}
+                                    >
+                                        Usages (Descending)
+                                    </MenuItemOption>
+                                </MenuOptionGroup>
+                            </MenuGroup>
+                            <MenuDivider />
+                            <MenuGroup title="Heat Map Mode">
+                                <MenuOptionGroup type="radio" defaultValue={HeatMapMode.None} value={heatMapMode}>
+                                    <MenuItemOption
+                                        paddingLeft={8}
+                                        value={HeatMapMode.None}
                                         onClick={() => dispatch(setHeatMapMode(HeatMapMode.None))}
                                     >
                                         None
                                     </MenuItemOption>
                                     <MenuItemOption
                                         paddingLeft={8}
-                                        value={'usages'}
+                                        value={HeatMapMode.Usages}
                                         onClick={() => dispatch(setHeatMapMode(HeatMapMode.Usages))}
                                     >
                                         Usages
                                     </MenuItemOption>
                                     <MenuItemOption
                                         paddingLeft={8}
-                                        value={'usefulness'}
+                                        value={HeatMapMode.Usefulness}
                                         onClick={() => dispatch(setHeatMapMode(HeatMapMode.Usefulness))}
                                     >
                                         Usefulness
                                     </MenuItemOption>
                                     <MenuItemOption
                                         paddingLeft={8}
-                                        value={'annotations'}
+                                        value={HeatMapMode.Annotations}
                                         onClick={() => dispatch(setHeatMapMode(HeatMapMode.Annotations))}
                                     >
                                         Annotations

--- a/api-editor/gui/src/common/MenuBar.tsx
+++ b/api-editor/gui/src/common/MenuBar.tsx
@@ -23,8 +23,11 @@ import { selectAnnotations } from '../features/annotations/annotationSlice';
 import { FilterHelpButton } from './FilterHelpButton';
 import {
     HeatMapMode,
-    selectHeatMapMode, selectSortingMode,
-    setHeatMapMode, setSortingMode, SortingMode,
+    selectHeatMapMode,
+    selectSortingMode,
+    setHeatMapMode,
+    setSortingMode,
+    SortingMode,
     toggleAnnotationImportDialog,
     toggleAPIImportDialog,
     toggleUsageImportDialog,
@@ -108,7 +111,11 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
                             </MenuOptionGroup>
                             <MenuDivider />
                             <MenuGroup title="Class/Function Sorting">
-                                <MenuOptionGroup type="radio" defaultValue={SortingMode.Alphabetical} value={sortingMode}>
+                                <MenuOptionGroup
+                                    type="radio"
+                                    defaultValue={SortingMode.Alphabetical}
+                                    value={sortingMode}
+                                >
                                     <MenuItemOption
                                         paddingLeft={8}
                                         value={SortingMode.Alphabetical}

--- a/api-editor/gui/src/features/packageData/treeView/HeatMapTag.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/HeatMapTag.tsx
@@ -26,6 +26,8 @@ export const HeatMapTag: React.FC<HeatMapTagProps> = function ({ actualValue, ma
             size="sm"
             variant="solid"
             width={boxWidth}
+            border="1px solid white"
+            boxSizing="border-box"
         >
             {actualValue}
         </Tag>

--- a/api-editor/gui/src/features/ui/uiSlice.ts
+++ b/api-editor/gui/src/features/ui/uiSlice.ts
@@ -17,6 +17,7 @@ export interface UIState {
     treeViewScrollOffset: number;
     heatMapMode: HeatMapMode;
     filterString: string;
+    sortingMode: SortingMode;
 }
 
 type UserAction =
@@ -95,10 +96,15 @@ interface TodoUserAction {
 }
 
 export enum HeatMapMode {
-    None,
-    Usages,
-    Usefulness,
-    Annotations,
+    None = 'none',
+    Usages = 'usages',
+    Usefulness = 'usefulness',
+    Annotations = 'annotations',
+}
+
+export enum SortingMode {
+    Alphabetical = 'alphabetical',
+    Usages = 'usages',
 }
 
 // Initial state -------------------------------------------------------------------------------------------------------
@@ -113,6 +119,7 @@ export const initialState: UIState = {
     treeViewScrollOffset: 0,
     heatMapMode: HeatMapMode.None,
     filterString: 'is:public',
+    sortingMode: SortingMode.Alphabetical,
 };
 
 // Thunks --------------------------------------------------------------------------------------------------------------
@@ -273,6 +280,9 @@ const uiSlice = createSlice({
         setFilterString(state, action: PayloadAction<string>) {
             state.filterString = action.payload;
         },
+        setSortingMode(state, action: PayloadAction<SortingMode>) {
+            state.sortingMode = action.payload;
+        },
     },
     extraReducers(builder) {
         builder.addCase(initializeUI.fulfilled, (state, action) => action.payload);
@@ -310,6 +320,7 @@ export const {
     setHeatMapMode,
 
     setFilterString,
+    setSortingMode,
 } = actions;
 export const uiReducer = reducer;
 
@@ -341,3 +352,4 @@ export const selectFilter = createSelector(
         return createFilterFromString(filterString);
     },
 );
+export const selectSortingMode = (state: RootState): SortingMode => selectUI(state).sortingMode;


### PR DESCRIPTION
Closes #587.

### Summary of Changes

Allow sorting of the tree view by usages in descending order.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/173550599-934bfb8f-9b26-44cc-bf84-1c7a70a76b8f.png)
