### PR TITLE
feat(gui): module usages/usefulness

### DIFF
--- a/api-editor/gui/src/common/MenuBar.tsx
+++ b/api-editor/gui/src/common/MenuBar.tsx
@@ -110,7 +110,7 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
                                 </MenuItemOption>
                             </MenuOptionGroup>
                             <MenuDivider />
-                            <MenuGroup title="Class/Function Sorting">
+                            <MenuGroup title="Module/Class/Function Sorting">
                                 <MenuOptionGroup
                                     type="radio"
                                     defaultValue={SortingMode.Alphabetical}

--- a/api-editor/gui/src/features/packageData/apiSlice.ts
+++ b/api-editor/gui/src/features/packageData/apiSlice.ts
@@ -75,45 +75,46 @@ const selectSortedPythonPackages = createSelector(
                     pythonPackage.distribution,
                     pythonPackage.name,
                     pythonPackage.version,
-                    pythonPackage.modules.map(
-                        (module) =>
-                            new PythonModule(
-                                module.id,
-                                module.name,
-                                module.imports,
-                                module.fromImports,
-                                module.classes
-                                    .map(
-                                        (cls) =>
-                                            new PythonClass(
-                                                cls.id,
-                                                cls.name,
-                                                cls.qualifiedName,
-                                                cls.decorators,
-                                                cls.superclasses,
-                                                cls.methods.sort(
-                                                    (a, b) =>
-                                                        (usages.functionUsages.get(b.id) ?? 0) -
-                                                        (usages.functionUsages.get(a.id) ?? 0),
+                    pythonPackage.modules
+                        .map(
+                            (module) =>
+                                new PythonModule(
+                                    module.id,
+                                    module.name,
+                                    module.imports,
+                                    module.fromImports,
+                                    module.classes
+                                        .map(
+                                            (cls) =>
+                                                new PythonClass(
+                                                    cls.id,
+                                                    cls.name,
+                                                    cls.qualifiedName,
+                                                    cls.decorators,
+                                                    cls.superclasses,
+                                                    cls.methods.sort(
+                                                        (a, b) =>
+                                                            (usages.functionUsages.get(b.id) ?? 0) -
+                                                            (usages.functionUsages.get(a.id) ?? 0),
+                                                    ),
+                                                    cls.isPublic,
+                                                    cls.description,
+                                                    cls.fullDocstring,
                                                 ),
-                                                cls.isPublic,
-                                                cls.description,
-                                                cls.fullDocstring,
-                                            ),
-                                    )
-                                    .sort(
+                                        )
+                                        .sort(
+                                            (a, b) =>
+                                                (usages.classUsages.get(b.id) ?? 0) -
+                                                (usages.classUsages.get(a.id) ?? 0),
+                                        ),
+                                    [...module.functions].sort(
                                         (a, b) =>
-                                            (usages.classUsages.get(b.id) ?? 0) - (usages.classUsages.get(a.id) ?? 0),
+                                            (usages.functionUsages.get(b.id) ?? 0) -
+                                            (usages.functionUsages.get(a.id) ?? 0),
                                     ),
-                                [...module.functions].sort(
-                                    (a, b) =>
-                                        (usages.functionUsages.get(b.id) ?? 0) - (usages.functionUsages.get(a.id) ?? 0),
                                 ),
-                            ),
-                    ).sort(
-                        (a, b) =>
-                            (usages.moduleUsages.get(b.id) ?? 0) - (usages.moduleUsages.get(a.id) ?? 0),
-                    ),
+                        )
+                        .sort((a, b) => (usages.moduleUsages.get(b.id) ?? 0) - (usages.moduleUsages.get(a.id) ?? 0)),
                 );
         }
     },

--- a/api-editor/gui/src/features/packageData/apiSlice.ts
+++ b/api-editor/gui/src/features/packageData/apiSlice.ts
@@ -110,6 +110,9 @@ const selectSortedPythonPackages = createSelector(
                                         (usages.functionUsages.get(b.id) ?? 0) - (usages.functionUsages.get(a.id) ?? 0),
                                 ),
                             ),
+                    ).sort(
+                        (a, b) =>
+                            (usages.moduleUsages.get(b.id) ?? 0) - (usages.moduleUsages.get(a.id) ?? 0),
                     ),
                 );
         }

--- a/api-editor/gui/src/features/packageData/model/filters/UsageFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/UsageFilter.ts
@@ -21,8 +21,9 @@ export class UsageFilter extends AbstractPythonFilter {
         super();
     }
 
-    shouldKeepModule(_pythonModule: PythonModule, _annotations: AnnotationStore, _usages: UsageCountStore): boolean {
-        return false;
+    shouldKeepModule(pythonModule: PythonModule, annotations: AnnotationStore, usages: UsageCountStore): boolean {
+        const moduleUsages = usages.moduleUsages.get(pythonModule.id);
+        return this.shouldKeepWithUsages(moduleUsages);
     }
 
     shouldKeepClass(pythonClass: PythonClass, annotations: AnnotationStore, usages: UsageCountStore): boolean {

--- a/api-editor/gui/src/features/packageData/model/filters/UsefulnessFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/UsefulnessFilter.ts
@@ -21,8 +21,9 @@ export class UsefulnessFilter extends AbstractPythonFilter {
         super();
     }
 
-    shouldKeepModule(_pythonModule: PythonModule, _annotations: AnnotationStore, _usages: UsageCountStore): boolean {
-        return false;
+    shouldKeepModule(pythonModule: PythonModule, annotations: AnnotationStore, usages: UsageCountStore): boolean {
+        const moduleUsefulness = usages.moduleUsages.get(pythonModule.id);
+        return this.shouldKeepWithUsefulness(moduleUsefulness);
     }
 
     shouldKeepClass(pythonClass: PythonClass, annotations: AnnotationStore, usages: UsageCountStore): boolean {

--- a/api-editor/gui/src/features/packageData/treeView/ClassNode.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/ClassNode.tsx
@@ -20,7 +20,7 @@ export const ClassNode: React.FC<ClassNodeProps> = function ({ pythonClass, filt
     const annotationCounts = useAnnotationCounts(pythonClass);
     const heatMapMode = useAppSelector(selectHeatMapMode);
 
-    let valuePair: ValuePair = new ValuePair(0, 1);
+    let valuePair: ValuePair = new ValuePair(undefined, undefined);
     if (heatMapMode === HeatMapMode.Annotations) {
         valuePair = annotationCounts;
     } else if (heatMapMode === HeatMapMode.Usages || heatMapMode === HeatMapMode.Usefulness) {

--- a/api-editor/gui/src/features/packageData/treeView/FunctionNode.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/FunctionNode.tsx
@@ -20,7 +20,7 @@ export const FunctionNode: React.FC<FunctionNodeProps> = function ({ pythonFunct
     const annotationCounts = useAnnotationCounts(pythonFunction);
     const heatMapMode = useAppSelector(selectHeatMapMode);
 
-    let valuePair: ValuePair = new ValuePair(0, 1);
+    let valuePair: ValuePair = new ValuePair(undefined, undefined);
     if (heatMapMode === HeatMapMode.Annotations) {
         valuePair = annotationCounts;
     } else if (heatMapMode === HeatMapMode.Usages || heatMapMode === HeatMapMode.Usefulness) {

--- a/api-editor/gui/src/features/packageData/treeView/HeatMapTag.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/HeatMapTag.tsx
@@ -15,7 +15,7 @@ export enum HeatMapInterpolation {
 export const HeatMapTag: React.FC<HeatMapTagProps> = function ({ actualValue, maxValue, interpolation }) {
     const bg = backgroundColor(actualValue, maxValue ?? 0, interpolation);
     const opacity = maxValue === undefined ? 0 : 1;
-    const boxWidth = maxValue === undefined ? 0 : maxValue.toString().length * 6.7;
+    const boxWidth = maxValue === undefined ? 0 : 16 + maxValue.toString().length * 5;
 
     return (
         <Tag
@@ -28,6 +28,7 @@ export const HeatMapTag: React.FC<HeatMapTagProps> = function ({ actualValue, ma
             width={boxWidth}
             border="1px solid white"
             boxSizing="border-box"
+            fontFamily="monospace"
         >
             {actualValue}
         </Tag>

--- a/api-editor/gui/src/features/packageData/treeView/ModuleNode.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/ModuleNode.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { FaArchive } from 'react-icons/fa';
 import { isEmptyList } from '../../../common/util/listOperations';
 import { PythonModule } from '../model/PythonModule';
-import { TreeNode } from './TreeNode';
+import { TreeNode, ValuePair } from './TreeNode';
 import { AbstractPythonFilter } from '../model/filters/AbstractPythonFilter';
 import { UsageCountStore } from '../../usages/model/UsageCountStore';
+import { useAppSelector } from '../../../app/hooks';
+import { HeatMapMode, selectHeatMapMode } from '../../ui/uiSlice';
 
 interface ModuleNodeProps {
     pythonModule: PythonModule;
@@ -17,6 +19,12 @@ export const ModuleNode: React.FC<ModuleNodeProps> = function ({ pythonModule, f
     const hasFunctions = !isEmptyList(pythonModule.functions);
     const hasChildren = hasClasses || hasFunctions;
 
+    const heatMapMode = useAppSelector(selectHeatMapMode);
+    let valuePair: ValuePair = new ValuePair(undefined, undefined);
+    if (heatMapMode === HeatMapMode.Usages || heatMapMode === HeatMapMode.Usefulness) {
+        valuePair = getMapWithUsages(usages, pythonModule);
+    }
+
     return (
         <TreeNode
             declaration={pythonModule}
@@ -24,6 +32,15 @@ export const ModuleNode: React.FC<ModuleNodeProps> = function ({ pythonModule, f
             isExpandable={hasChildren}
             filter={filter}
             usages={usages}
+            maxValue={valuePair.maxValue}
+            specificValue={valuePair.specificValue}
         />
     );
+};
+
+const getMapWithUsages = function (usages: UsageCountStore, pythonModule: PythonModule): ValuePair {
+    const maxValue = usages.moduleMaxUsages;
+    const specificValue = usages.moduleUsages.get(pythonModule.id) ?? 0;
+
+    return new ValuePair(specificValue, maxValue);
 };

--- a/api-editor/gui/src/features/packageData/treeView/ParameterNode.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/ParameterNode.tsx
@@ -18,7 +18,7 @@ export const ParameterNode: React.FC<ParameterNodeProps> = function ({ pythonPar
     const annotationCounts = useAnnotationCounts(pythonParameter);
     const heatMapMode = useAppSelector(selectHeatMapMode);
 
-    let valuePair: ValuePair = new ValuePair(0, 1);
+    let valuePair: ValuePair = new ValuePair(undefined, undefined);
     if (heatMapMode === HeatMapMode.Annotations) {
         valuePair = annotationCounts;
     } else if (heatMapMode === HeatMapMode.Usages) {

--- a/api-editor/gui/src/features/usages/model/UsageCountStore.ts
+++ b/api-editor/gui/src/features/usages/model/UsageCountStore.ts
@@ -2,6 +2,9 @@ import { PythonPackage } from '../../packageData/model/PythonPackage';
 import { PythonParameter } from '../../packageData/model/PythonParameter';
 
 export interface UsageCountJson {
+    module_counts?: {
+        [target: string]: number;
+    };
     class_counts: {
         [target: string]: number;
     };
@@ -21,6 +24,7 @@ export interface UsageCountJson {
 export class UsageCountStore {
     static fromJson(json: UsageCountJson, api?: PythonPackage): UsageCountStore {
         return new UsageCountStore(
+            new Map(Object.entries(json.module_counts ?? {})),
             new Map(Object.entries(json.class_counts)),
             new Map(Object.entries(json.function_counts)),
             new Map(Object.entries(json.parameter_counts)),
@@ -37,6 +41,7 @@ export class UsageCountStore {
     readonly parameterMaxUsefulness: number;
 
     constructor(
+        readonly moduleUsages: Map<string, number> = new Map(),
         readonly classUsages: Map<string, number> = new Map(),
         readonly functionUsages: Map<string, number> = new Map(),
         readonly parameterUsages: Map<string, number> = new Map(),
@@ -45,6 +50,7 @@ export class UsageCountStore {
     ) {
         if (api) {
             this.addImplicitUsagesOfDefaultValues(api);
+            this.computeModuleUsages(api);
         }
 
         this.classMaxUsages = classUsages.size === 0 ? 0 : Math.max(...classUsages.values());
@@ -60,6 +66,7 @@ export class UsageCountStore {
 
     toJson(): UsageCountJson {
         return {
+            module_counts: Object.fromEntries(this.moduleUsages),
             class_counts: Object.fromEntries(this.classUsages),
             function_counts: Object.fromEntries(this.functionUsages),
             parameter_counts: Object.fromEntries(this.parameterUsages),
@@ -109,6 +116,19 @@ export class UsageCountStore {
                 this.valueUsages.get(parameterId)!.set(defaultValue, 0);
             }
             this.valueUsages.get(parameterId)!.set(defaultValue, nImplicitUsages + nExplicitUsage);
+        }
+    }
+
+    private computeModuleUsages(api: PythonPackage) {
+        for (const module of api.modules) {
+            let moduleUsageCount = 0;
+            for (const cls of module.classes) {
+                moduleUsageCount += this.classUsages.get(cls.id) ?? 0;
+            }
+            for (const func of module.functions) {
+                moduleUsageCount += this.functionUsages.get(func.id) ?? 0;
+            }
+            this.moduleUsages.set(module.id, moduleUsageCount);
         }
     }
 

--- a/api-editor/gui/src/features/usages/model/UsageCountStore.ts
+++ b/api-editor/gui/src/features/usages/model/UsageCountStore.ts
@@ -33,6 +33,7 @@ export class UsageCountStore {
         );
     }
 
+    readonly moduleMaxUsages: number;
     readonly classMaxUsages: number;
     readonly functionMaxUsages: number;
     readonly parameterMaxUsages: number;
@@ -53,6 +54,7 @@ export class UsageCountStore {
             this.computeModuleUsages(api);
         }
 
+        this.moduleMaxUsages = moduleUsages.size === 0 ? 0 : Math.max(...moduleUsages.values());
         this.classMaxUsages = classUsages.size === 0 ? 0 : Math.max(...classUsages.values());
         this.functionMaxUsages = functionUsages.size === 0 ? 0 : Math.max(...functionUsages.values());
         this.parameterMaxUsages = parameterUsages.size === 0 ? 0 : Math.max(...parameterUsages.values());


### PR DESCRIPTION
Closes #640.

### Summary of Changes

* Define module usages as the sum of usages of classes/functions in the module
* Define module usefulness as equal to module usages
* Display heat map tags for module usages/usefulness
* Filters `usages:...` and `usefulness:...` now affect modules
* Sorting by usages now also affects modules

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/173556742-8723ffe2-4357-4feb-b3b5-631f03b0aeb8.png)

