### PR TITLE
feat: list declarations under a public module if applicable

### DIFF
--- a/api-editor/gui/src/app/App.tsx
+++ b/api-editor/gui/src/app/App.tsx
@@ -126,7 +126,7 @@ export const App: React.FC = function () {
                     )}
                     {currentUserAction.type === 'move' && <MoveForm target={userActionTarget || pythonPackage} />}
                     {currentUserAction.type === 'none' && (
-                        <TreeView pythonPackage={filteredPythonPackage} filter={pythonFilter} usages={usages} />
+                        <TreeView />
                     )}
                     {currentUserAction.type === 'optional' && (
                         <OptionalForm target={userActionTarget || pythonPackage} />

--- a/api-editor/gui/src/app/App.tsx
+++ b/api-editor/gui/src/app/App.tsx
@@ -68,7 +68,7 @@ export const App: React.FC = function () {
     };
 
     const currentUserAction = useAppSelector(selectCurrentUserAction);
-    const userActionTarget = pythonPackage.getByRelativePathAsString(currentUserAction.target);
+    const userActionTarget = pythonPackage.getDeclarationById(currentUserAction.target);
     const showAnnotationImportDialog = useAppSelector(selectShowAnnotationImportDialog);
     const showAPIImportDialog = useAppSelector(selectShowAPIImportDialog);
     const showUsagesImportDialog = useAppSelector(selectShowUsageImportDialog);

--- a/api-editor/gui/src/app/App.tsx
+++ b/api-editor/gui/src/app/App.tsx
@@ -47,7 +47,7 @@ import { initializeUsages, persistUsages, selectUsages } from '../features/usage
 import {
     initializePythonPackage,
     selectFilteredPythonPackage,
-    selectPythonPackage,
+    selectRawPythonPackage,
 } from '../features/packageData/apiSlice';
 import { PythonClass } from '../features/packageData/model/PythonClass';
 import { PythonParameter } from '../features/packageData/model/PythonParameter';
@@ -55,7 +55,7 @@ import { PythonParameter } from '../features/packageData/model/PythonParameter';
 export const App: React.FC = function () {
     useIndexedDB();
 
-    const pythonPackage = useAppSelector(selectPythonPackage);
+    const pythonPackage = useAppSelector(selectRawPythonPackage);
     const usages = useAppSelector(selectUsages);
     const pythonFilter = useAppSelector(selectFilter);
     const filteredPythonPackage = useAppSelector(selectFilteredPythonPackage);
@@ -135,7 +135,7 @@ export const App: React.FC = function () {
                     {currentUserAction.type === 'todo' && <TodoForm target={userActionTarget || pythonPackage} />}
                 </GridItem>
                 <GridItem gridArea="rightPane" overflow="auto">
-                    <SelectionView pythonPackage={pythonPackage} pythonFilter={pythonFilter} usages={usages} />
+                    <SelectionView />
                 </GridItem>
 
                 {showAnnotationImportDialog && <AnnotationImportDialog />}

--- a/api-editor/gui/src/app/App.tsx
+++ b/api-editor/gui/src/app/App.tsx
@@ -36,7 +36,6 @@ import {
     initializeUI,
     persistUI,
     selectCurrentUserAction,
-    selectFilter,
     selectShowAnnotationImportDialog,
     selectShowAPIImportDialog,
     selectShowUsageImportDialog,
@@ -44,11 +43,7 @@ import {
     setFilterString,
 } from '../features/ui/uiSlice';
 import { initializeUsages, persistUsages, selectUsages } from '../features/usages/usageSlice';
-import {
-    initializePythonPackage,
-    selectFilteredPythonPackage,
-    selectRawPythonPackage,
-} from '../features/packageData/apiSlice';
+import { initializePythonPackage, selectRawPythonPackage } from '../features/packageData/apiSlice';
 import { PythonClass } from '../features/packageData/model/PythonClass';
 import { PythonParameter } from '../features/packageData/model/PythonParameter';
 
@@ -122,9 +117,7 @@ export const App: React.FC = function () {
                         />
                     )}
                     {currentUserAction.type === 'move' && <MoveForm target={userActionTarget || pythonPackage} />}
-                    {currentUserAction.type === 'none' && (
-                        <TreeView />
-                    )}
+                    {currentUserAction.type === 'none' && <TreeView />}
                     {currentUserAction.type === 'optional' && (
                         <OptionalForm target={userActionTarget || pythonPackage} />
                     )}

--- a/api-editor/gui/src/app/App.tsx
+++ b/api-editor/gui/src/app/App.tsx
@@ -56,9 +56,6 @@ export const App: React.FC = function () {
     useIndexedDB();
 
     const pythonPackage = useAppSelector(selectRawPythonPackage);
-    const usages = useAppSelector(selectUsages);
-    const pythonFilter = useAppSelector(selectFilter);
-    const filteredPythonPackage = useAppSelector(selectFilteredPythonPackage);
 
     const [showInferErrorDialog, setShowInferErrorDialog] = useState(false);
     const [inferErrors, setInferErrors] = useState<string[]>([]);

--- a/api-editor/gui/src/common/GenerateAdapters.tsx
+++ b/api-editor/gui/src/common/GenerateAdapters.tsx
@@ -18,7 +18,7 @@ import React, { useRef, useState } from 'react';
 import { useAppSelector } from '../app/hooks';
 import { selectAnnotations } from '../features/annotations/annotationSlice';
 import { AnnotatedPythonPackageBuilder } from '../features/annotatedPackageData/model/AnnotatedPythonPackageBuilder';
-import { selectPythonPackage } from '../features/packageData/apiSlice';
+import { selectRawPythonPackage } from '../features/packageData/apiSlice';
 
 interface GenerateAdaptersProps {
     displayInferErrors: (errors: string[]) => void;
@@ -31,7 +31,7 @@ export const GenerateAdapters: React.FC<GenerateAdaptersProps> = function ({ dis
     const cancelRef = useRef(null);
 
     const annotationStore = useAppSelector(selectAnnotations);
-    const pythonPackage = useAppSelector(selectPythonPackage);
+    const pythonPackage = useAppSelector(selectRawPythonPackage);
 
     const packageNameIsValid = !shouldValidate || newPackageName !== '';
 

--- a/api-editor/gui/src/features/annotatedPackageData/model/AnnotatedPythonPackageBuilder.ts
+++ b/api-editor/gui/src/features/annotatedPackageData/model/AnnotatedPythonPackageBuilder.ts
@@ -17,6 +17,7 @@ import {
     InferableBoundaryAnnotation,
     InferableCalledAfterAnnotation,
     InferableConstantAnnotation,
+    InferableDescriptionAnnotation,
     InferableEnumAnnotation,
     InferableGroupAnnotation,
     InferableMoveAnnotation,
@@ -25,7 +26,6 @@ import {
     InferableRemoveAnnotation,
     InferableRenameAnnotation,
     InferableRequiredAnnotation,
-    InferableDescriptionAnnotation,
     InferableTodoAnnotation,
 } from './InferableAnnotation';
 
@@ -44,7 +44,7 @@ export class AnnotatedPythonPackageBuilder {
             this.pythonPackage.distribution,
             this.pythonPackage.version,
             this.#buildAnnotatedPythonModules(this.pythonPackage.modules),
-            this.#getExistingAnnotations(this.pythonPackage.pathAsString()),
+            this.#getExistingAnnotations(this.pythonPackage.id),
         );
     }
 
@@ -57,7 +57,7 @@ export class AnnotatedPythonPackageBuilder {
                     pythonModule.fromImports,
                     this.#buildAnnotatedPythonClasses(pythonModule),
                     this.#buildAnnotatedPythonFunctions(pythonModule),
-                    this.#getExistingAnnotations(pythonModule.pathAsString()),
+                    this.#getExistingAnnotations(pythonModule.id),
                 ),
         );
     }
@@ -74,7 +74,7 @@ export class AnnotatedPythonPackageBuilder {
                     pythonClass.isPublic,
                     pythonClass.description,
                     pythonClass.fullDocstring,
-                    this.#getExistingAnnotations(pythonClass.pathAsString()),
+                    this.#getExistingAnnotations(pythonClass.id),
                 ),
         );
     }
@@ -101,7 +101,7 @@ export class AnnotatedPythonPackageBuilder {
             pythonFunction.isPublic,
             pythonFunction.description,
             pythonFunction.fullDocstring,
-            this.#getExistingAnnotations(pythonFunction.pathAsString()),
+            this.#getExistingAnnotations(pythonFunction.id),
         );
     }
 
@@ -119,7 +119,7 @@ export class AnnotatedPythonPackageBuilder {
                     pythonParameter.isPublic,
                     pythonParameter.typeInDocs,
                     pythonParameter.description,
-                    this.#getExistingAnnotations(pythonParameter.pathAsString()),
+                    this.#getExistingAnnotations(pythonParameter.id),
                 ),
         );
     }
@@ -132,7 +132,7 @@ export class AnnotatedPythonPackageBuilder {
                     pythonResult.typeInDocs,
                     pythonResult.typeInDocs,
                     pythonResult.description,
-                    this.#getExistingAnnotations(pythonResult.pathAsString()),
+                    this.#getExistingAnnotations(pythonResult.id),
                 ),
         );
     }

--- a/api-editor/gui/src/features/annotations/forms/AttributeForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/AttributeForm.tsx
@@ -9,7 +9,7 @@ interface AttributeFormProps {
 }
 
 export const AttributeForm: React.FC<AttributeFormProps> = function ({ target }) {
-    const targetPath = target.pathAsString();
+    const targetPath = target.id;
 
     // Hooks -----------------------------------------------------------------------------------------------------------
     const previousAnnotation = useAppSelector(selectAttribute(targetPath));

--- a/api-editor/gui/src/features/annotations/forms/BoundaryForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/BoundaryForm.tsx
@@ -52,7 +52,7 @@ const initialFormState = function (previousInterval: Optional<Interval>): Bounda
 };
 
 export const BoundaryForm: React.FC<BoundaryFormProps> = function ({ target }) {
-    const targetPath = target.pathAsString();
+    const targetPath = target.id;
     const prevInterval = useAppSelector(selectBoundary(targetPath))?.interval;
 
     // Hooks -----------------------------------------------------------------------------------------------------------

--- a/api-editor/gui/src/features/annotations/forms/CalledAfterForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/CalledAfterForm.tsx
@@ -16,7 +16,7 @@ interface CalledAfterFormState {
 }
 
 export const CalledAfterForm: React.FC<CalledAfterFormProps> = function ({ target }) {
-    const targetPath = target.pathAsString();
+    const targetPath = target.id;
     const currentCalledAfters = Object.keys(useAppSelector(selectCalledAfters(targetPath)));
 
     const remainingCalledAfters = target

--- a/api-editor/gui/src/features/annotations/forms/ConstantForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/ConstantForm.tsx
@@ -9,7 +9,7 @@ interface ConstantFormProps {
 }
 
 export const ConstantForm: React.FC<ConstantFormProps> = function ({ target }) {
-    const targetPath = target.pathAsString();
+    const targetPath = target.id;
 
     // Hooks -----------------------------------------------------------------------------------------------------------
     const constantDefinition = useAppSelector(selectConstant(targetPath));

--- a/api-editor/gui/src/features/annotations/forms/DescriptionForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/DescriptionForm.tsx
@@ -18,7 +18,7 @@ interface DescriptionFormState {
 }
 
 export const DescriptionForm: React.FC<DescriptionFormProps> = function ({ target }) {
-    const targetPath = target.pathAsString();
+    const targetPath = target.id;
     const prevNewDescription = useAppSelector(selectDescription(targetPath))?.newDescription;
     const oldDescription = target.description;
 

--- a/api-editor/gui/src/features/annotations/forms/EnumForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/EnumForm.tsx
@@ -31,10 +31,10 @@ interface EnumFormState {
 }
 
 export const EnumForm: React.FC<EnumFormProps> = function ({ target }) {
-    const targetPath = target.pathAsString();
+    const targetPath = target.id;
 
     // Hooks -----------------------------------------------------------------------------------------------------------
-    const enumDefinition = useAppSelector(selectEnum(target.pathAsString()));
+    const enumDefinition = useAppSelector(selectEnum(target.id));
     const dispatch = useAppDispatch();
 
     const {

--- a/api-editor/gui/src/features/annotations/forms/GroupForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/GroupForm.tsx
@@ -22,7 +22,7 @@ interface GroupFormState {
 }
 
 export const GroupForm: React.FC<GroupFormProps> = function ({ target, groupName }) {
-    const targetPath = target.pathAsString();
+    const targetPath = target.id;
     const currentGroups = useAppSelector(selectGroups(targetPath));
     let prevGroupAnnotation: GroupAnnotation | undefined;
     if (groupName && currentGroups) {

--- a/api-editor/gui/src/features/annotations/forms/MoveForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/MoveForm.tsx
@@ -17,7 +17,7 @@ interface MoveFormState {
 }
 
 export const MoveForm: React.FC<MoveFormProps> = function ({ target }) {
-    const targetPath = target.pathAsString();
+    const targetPath = target.id;
     const prevDestination = useAppSelector(selectMove(targetPath))?.destination;
     const oldModulePath = target?.parent()?.name;
 

--- a/api-editor/gui/src/features/annotations/forms/OptionalForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/OptionalForm.tsx
@@ -9,7 +9,7 @@ interface OptionalFormProps {
 }
 
 export const OptionalForm: React.FC<OptionalFormProps> = function ({ target }) {
-    const targetPath = target.pathAsString();
+    const targetPath = target.id;
 
     // Hooks -----------------------------------------------------------------------------------------------------------
     const optionalDefinition = useAppSelector(selectOptional(targetPath));

--- a/api-editor/gui/src/features/annotations/forms/RenameForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/RenameForm.tsx
@@ -17,7 +17,7 @@ interface RenameFormState {
 }
 
 export const RenameForm: React.FC<RenameFormProps> = function ({ target }) {
-    const targetPath = target.pathAsString();
+    const targetPath = target.id;
     const prevNewName = useAppSelector(selectRenaming(targetPath))?.newName;
     const oldName = target.name;
 

--- a/api-editor/gui/src/features/annotations/forms/TodoForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/TodoForm.tsx
@@ -16,7 +16,7 @@ interface TodoFormState {
 }
 
 export const TodoForm: React.FC<TodoFormProps> = function ({ target }) {
-    const targetPath = target.pathAsString();
+    const targetPath = target.id;
     const prevNewTodo = useAppSelector(selectTodo(targetPath))?.newTodo;
 
     // Hooks -----------------------------------------------------------------------------------------------------------

--- a/api-editor/gui/src/features/packageData/apiSlice.ts
+++ b/api-editor/gui/src/features/packageData/apiSlice.ts
@@ -98,6 +98,7 @@ const selectSortedPythonPackages = createSelector(
                                                             (usages.functionUsages.get(a.id) ?? 0),
                                                     ),
                                                     cls.isPublic,
+                                                    cls.reexportedBy,
                                                     cls.description,
                                                     cls.fullDocstring,
                                                 ),

--- a/api-editor/gui/src/features/packageData/apiSlice.ts
+++ b/api-editor/gui/src/features/packageData/apiSlice.ts
@@ -70,10 +70,10 @@ const selectSortedPythonPackages = createSelector(
                 return pythonPackage;
             case SortingMode.Usages: // Descending
                 return pythonPackage.shallowCopy({
-                    modules: pythonPackage.modules
+                    modules: [...pythonPackage.modules]
                         .map((module) =>
                             module.shallowCopy({
-                                classes: module.classes
+                                classes: [...module.classes]
                                     .map((cls) =>
                                         cls.shallowCopy({
                                             methods: [...cls.methods].sort(

--- a/api-editor/gui/src/features/packageData/model/PythonClass.test.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonClass.test.ts
@@ -1,43 +1,4 @@
 import { PythonClass } from './PythonClass';
-import { PythonFunction } from './PythonFunction';
-import { PythonModule } from './PythonModule';
-import { PythonPackage } from './PythonPackage';
-import { PythonParameter } from './PythonParameter';
-
-test('path without parent', () => {
-    const pythonClass = new PythonClass('Class', 'Class', 'Class');
-    expect(pythonClass.path()).toEqual(['Class']);
-});
-
-test('path with ancestors', () => {
-    const pythonClass = new PythonClass('Class', 'Class', 'Class');
-
-    // eslint-disable-next-line no-new
-    new PythonPackage('distribution', 'package', '0.0.1', [
-        new PythonModule('module', 'module', [], [], [pythonClass]),
-    ]);
-
-    expect(pythonClass.path()).toEqual(['package', 'module', 'Class']);
-});
-
-test('getByRelativePath with correct path', () => {
-    const pythonParameter = new PythonParameter('param', 'param', 'param');
-    const pythonClass = new PythonClass(
-        'Class',
-        'Class',
-        'Class',
-        [],
-        [],
-        [new PythonFunction('function', 'function', 'function', [], [pythonParameter])],
-    );
-    expect(pythonClass.getByRelativePath(['function', 'param'])).toBe(pythonParameter);
-});
-
-test('getByRelativePath with misleading path', () => {
-    const pythonClass = new PythonClass('Class', 'Class', 'Class');
-    // eslint-disable-next-line testing-library/prefer-presence-queries
-    expect(pythonClass.getByRelativePath(['child'])).toBeNull();
-});
 
 test('toString without decorators and superclasses', () => {
     const pythonClass = new PythonClass('Class', 'Class', 'Class');

--- a/api-editor/gui/src/features/packageData/model/PythonClass.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonClass.ts
@@ -14,6 +14,7 @@ export class PythonClass extends PythonDeclaration {
         readonly superclasses: string[] = [],
         readonly methods: PythonFunction[] = [],
         readonly isPublic: boolean = true,
+        readonly reexportedBy: string[] = [],
         readonly description = '',
         readonly fullDocstring = '',
     ) {

--- a/api-editor/gui/src/features/packageData/model/PythonClass.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonClass.ts
@@ -3,6 +3,19 @@ import { PythonDeclaration } from './PythonDeclaration';
 import { PythonFunction } from './PythonFunction';
 import { PythonModule } from './PythonModule';
 
+interface PythonClassShallowCopy {
+    id?: string;
+    name?: string;
+    qualifiedName?: string;
+    decorators?: string[];
+    superclasses?: string[];
+    methods?: PythonFunction[];
+    isPublic?: boolean;
+    reexportedBy?: string[];
+    description?: string;
+    fullDocstring?: string;
+}
+
 export class PythonClass extends PythonDeclaration {
     containingModule: Optional<PythonModule>;
 
@@ -15,8 +28,8 @@ export class PythonClass extends PythonDeclaration {
         readonly methods: PythonFunction[] = [],
         readonly isPublic: boolean = true,
         readonly reexportedBy: string[] = [],
-        readonly description = '',
-        readonly fullDocstring = '',
+        readonly description: string = '',
+        readonly fullDocstring: string = '',
     ) {
         super();
 
@@ -33,6 +46,32 @@ export class PythonClass extends PythonDeclaration {
 
     children(): PythonFunction[] {
         return this.methods;
+    }
+
+    shallowCopy({
+        id = this.id,
+        name = this.name,
+        qualifiedName = this.qualifiedName,
+        decorators = this.decorators,
+        superclasses = this.superclasses,
+        methods = this.methods,
+        isPublic = this.isPublic,
+        reexportedBy = this.reexportedBy,
+        description = this.description,
+        fullDocstring = this.fullDocstring,
+    }: PythonClassShallowCopy = {}): PythonClass {
+        return new PythonClass(
+            id,
+            name,
+            qualifiedName,
+            decorators,
+            superclasses,
+            methods,
+            isPublic,
+            reexportedBy,
+            description,
+            fullDocstring,
+        );
     }
 
     toString(): string {

--- a/api-editor/gui/src/features/packageData/model/PythonClass.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonClass.ts
@@ -35,10 +35,6 @@ export class PythonClass extends PythonDeclaration {
         return this.methods;
     }
 
-    isPublicDeclaration(): boolean {
-        return this.isPublic;
-    }
-
     toString(): string {
         let result = '';
 

--- a/api-editor/gui/src/features/packageData/model/PythonDeclaration.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonDeclaration.ts
@@ -1,8 +1,9 @@
-import { isEmptyList } from '../../../common/util/listOperations';
 import { Optional } from '../../../common/util/types';
 
 export abstract class PythonDeclaration {
+    abstract readonly id: string;
     abstract readonly name: string;
+    abstract readonly isPublic: boolean;
 
     abstract parent(): Optional<PythonDeclaration>;
 
@@ -12,47 +13,10 @@ export abstract class PythonDeclaration {
         return this.name;
     }
 
-    isPublicDeclaration(): boolean {
-        return true;
-    }
-
     *descendantsOrSelf(): Generator<PythonDeclaration> {
         yield this;
         for (const child of this.children()) {
             yield* child.descendantsOrSelf();
         }
-    }
-
-    path(): string[] {
-        let current: Optional<PythonDeclaration> = this;
-        const result: string[] = [];
-
-        while (current !== null && current !== undefined) {
-            result.unshift(current.getUniqueName());
-            current = current.parent();
-        }
-
-        return result;
-    }
-
-    pathAsString(): string {
-        return this.path().join('/');
-    }
-
-    getByRelativePath(relativePath: string[]): Optional<PythonDeclaration> {
-        if (isEmptyList(relativePath)) {
-            return this;
-        }
-
-        const [head, ...tail] = relativePath;
-        return (
-            this.children()
-                .find((it) => it.getUniqueName() === head)
-                ?.getByRelativePath(tail) ?? null
-        );
-    }
-
-    getByRelativePathAsString(relativePath: string): Optional<PythonDeclaration> {
-        return this.getByRelativePath(relativePath.split('/').slice(1));
     }
 }

--- a/api-editor/gui/src/features/packageData/model/PythonFunction.test.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonFunction.test.ts
@@ -1,7 +1,4 @@
-import { PythonClass } from './PythonClass';
 import { PythonFunction } from './PythonFunction';
-import { PythonModule } from './PythonModule';
-import { PythonPackage } from './PythonPackage';
 import { PythonParameter } from './PythonParameter';
 
 test('toString without decorators and parameters', () => {

--- a/api-editor/gui/src/features/packageData/model/PythonFunction.test.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonFunction.test.ts
@@ -4,40 +4,6 @@ import { PythonModule } from './PythonModule';
 import { PythonPackage } from './PythonPackage';
 import { PythonParameter } from './PythonParameter';
 
-test('path without parent', () => {
-    const pythonFunction = new PythonFunction('function', 'function', 'function');
-    expect(pythonFunction.path()).toEqual(['function']);
-});
-
-test('path with ancestors', () => {
-    const pythonFunction = new PythonFunction('function', 'function', 'function');
-
-    // eslint-disable-next-line no-new
-    new PythonPackage('distribution', 'package', '0.0.1', [
-        new PythonModule(
-            'module',
-            'module',
-            [],
-            [],
-            [new PythonClass('Class', 'Class', 'Class', [], [], [pythonFunction])],
-        ),
-    ]);
-
-    expect(pythonFunction.path()).toEqual(['package', 'module', 'Class', 'function']);
-});
-
-test('getByRelativePath with correct path', () => {
-    const pythonParameter = new PythonParameter('param', 'param', 'param');
-    const pythonFunction = new PythonFunction('function', 'function', 'function', [], [pythonParameter]);
-    expect(pythonFunction.getByRelativePath(['param'])).toBe(pythonParameter);
-});
-
-test('getByRelativePath with misleading path', () => {
-    const pythonFunction = new PythonFunction('function', 'function', 'function');
-    // eslint-disable-next-line testing-library/prefer-presence-queries
-    expect(pythonFunction.getByRelativePath(['child'])).toBeNull();
-});
-
 test('toString without decorators and parameters', () => {
     const pythonFunction = new PythonFunction('function', 'function', 'function');
     expect(pythonFunction.toString()).toBe('def function()');

--- a/api-editor/gui/src/features/packageData/model/PythonFunction.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonFunction.ts
@@ -2,7 +2,7 @@ import { Optional } from '../../../common/util/types';
 import { PythonClass } from './PythonClass';
 import { PythonDeclaration } from './PythonDeclaration';
 import { PythonModule } from './PythonModule';
-import { PythonParameter } from './PythonParameter';
+import { PythonParameter, PythonParameterAssignment } from './PythonParameter';
 import { PythonResult } from './PythonResult';
 
 export class PythonFunction extends PythonDeclaration {
@@ -41,10 +41,6 @@ export class PythonFunction extends PythonDeclaration {
         return this.parameters;
     }
 
-    isPublicDeclaration(): boolean {
-        return this.isPublic;
-    }
-
     getUniqueName(): string {
         const segments = this.id.split('/');
         return segments[segments.length - 1];
@@ -63,11 +59,7 @@ export class PythonFunction extends PythonDeclaration {
     }
 
     explicitParameters(): PythonParameter[] {
-        if (this.parent() instanceof PythonModule) {
-            return this.children();
-        }
-
-        return this.children().slice(1);
+        return this.parameters.filter((it) => it.assignedBy !== PythonParameterAssignment.IMPLICIT);
     }
 
     siblingFunctions(): PythonFunction[] {

--- a/api-editor/gui/src/features/packageData/model/PythonFunction.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonFunction.ts
@@ -5,6 +5,19 @@ import { PythonModule } from './PythonModule';
 import { PythonParameter, PythonParameterAssignment } from './PythonParameter';
 import { PythonResult } from './PythonResult';
 
+interface PythonFunctionShallowCopy {
+    id?: string;
+    name?: string;
+    qualifiedName?: string;
+    decorators?: string[];
+    parameters?: PythonParameter[];
+    results?: PythonResult[];
+    isPublic?: boolean;
+    reexportedBy?: string[];
+    description?: string;
+    fullDocstring?: string;
+}
+
 export class PythonFunction extends PythonDeclaration {
     containingModuleOrClass: Optional<PythonModule | PythonClass>;
 
@@ -67,6 +80,32 @@ export class PythonFunction extends PythonDeclaration {
             (this.parent()
                 ?.children()
                 .filter((it) => it instanceof PythonFunction && it.name !== this.name) as PythonFunction[]) ?? []
+        );
+    }
+
+    shallowCopy({
+        id = this.id,
+        name = this.name,
+        qualifiedName = this.qualifiedName,
+        decorators = this.decorators,
+        parameters = this.parameters,
+        results = this.results,
+        isPublic = this.isPublic,
+        reexportedBy = this.reexportedBy,
+        description = this.description,
+        fullDocstring = this.fullDocstring,
+    }: PythonFunctionShallowCopy = {}): PythonFunction {
+        return new PythonFunction(
+            id,
+            name,
+            qualifiedName,
+            decorators,
+            parameters,
+            results,
+            isPublic,
+            reexportedBy,
+            description,
+            fullDocstring,
         );
     }
 

--- a/api-editor/gui/src/features/packageData/model/PythonFunction.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonFunction.ts
@@ -16,6 +16,7 @@ export class PythonFunction extends PythonDeclaration {
         readonly parameters: PythonParameter[] = [],
         readonly results: PythonResult[] = [],
         readonly isPublic: boolean = false,
+        readonly reexportedBy: string[] = [],
         readonly description = '',
         readonly fullDocstring = '',
     ) {

--- a/api-editor/gui/src/features/packageData/model/PythonModule.test.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonModule.test.ts
@@ -1,40 +1,4 @@
-import { PythonFunction } from './PythonFunction';
 import { PythonModule } from './PythonModule';
-import { PythonPackage } from './PythonPackage';
-import { PythonParameter } from './PythonParameter';
-
-test('path without parent', () => {
-    const pythonModule = new PythonModule('module', 'module');
-    expect(pythonModule.path()).toEqual(['module']);
-});
-
-test('path with parent', () => {
-    const pythonModule = new PythonModule('module', 'module');
-
-    // eslint-disable-next-line no-new
-    new PythonPackage('distribution', 'package', '0.0.1', [pythonModule]);
-
-    expect(pythonModule.path()).toEqual(['package', 'module']);
-});
-
-test('getByRelativePath with correct path', () => {
-    const pythonParameter = new PythonParameter('param', 'param', 'param');
-    const pythonModule = new PythonModule(
-        'module',
-        'module',
-        [],
-        [],
-        [],
-        [new PythonFunction('function', 'function', 'function', [], [pythonParameter])],
-    );
-    expect(pythonModule.getByRelativePath(['function', 'param'])).toBe(pythonParameter);
-});
-
-test('getByRelativePath with misleading path', () => {
-    const pythonModule = new PythonModule('module', 'module');
-    // eslint-disable-next-line testing-library/prefer-presence-queries
-    expect(pythonModule.getByRelativePath(['child'])).toBeNull();
-});
 
 test('toString', () => {
     const pythonModule = new PythonModule('module', 'module');

--- a/api-editor/gui/src/features/packageData/model/PythonModule.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonModule.ts
@@ -6,6 +6,15 @@ import { PythonFunction } from './PythonFunction';
 import { PythonImport } from './PythonImport';
 import { PythonPackage } from './PythonPackage';
 
+interface PythonPackageShallowCopy {
+    id?: string;
+    name?: string;
+    imports?: PythonImport[];
+    fromImports?: PythonFromImport[];
+    classes?: PythonClass[];
+    functions?: PythonFunction[];
+}
+
 export class PythonModule extends PythonDeclaration {
     readonly isPublic: boolean;
 
@@ -40,6 +49,17 @@ export class PythonModule extends PythonDeclaration {
 
     children(): (PythonClass | PythonFunction)[] {
         return [...this.classes, ...this.functions];
+    }
+
+    shallowCopy({
+        id = this.id,
+        name = this.name,
+        imports = this.imports,
+        fromImports = this.fromImports,
+        classes = this.classes,
+        functions = this.functions,
+    }: PythonPackageShallowCopy = {}): PythonModule {
+        return new PythonModule(id, name, imports, fromImports, classes, functions);
     }
 
     toString(): string {

--- a/api-editor/gui/src/features/packageData/model/PythonModule.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonModule.ts
@@ -7,6 +7,8 @@ import { PythonImport } from './PythonImport';
 import { PythonPackage } from './PythonPackage';
 
 export class PythonModule extends PythonDeclaration {
+    readonly isPublic: boolean;
+
     containingPackage: Optional<PythonPackage>;
 
     constructor(
@@ -19,6 +21,8 @@ export class PythonModule extends PythonDeclaration {
     ) {
         super();
 
+        this.isPublic = !this.name.split('.').some((it) => it.startsWith('_'));
+
         this.containingPackage = null;
 
         this.classes.forEach((it) => {
@@ -28,10 +32,6 @@ export class PythonModule extends PythonDeclaration {
         this.functions.forEach((it) => {
             it.containingModuleOrClass = this;
         });
-    }
-
-    isPublicDeclaration(): boolean {
-        return !this.name.split('.').some((it) => it.startsWith('_'));
     }
 
     parent(): Optional<PythonPackage> {

--- a/api-editor/gui/src/features/packageData/model/PythonPackage.test.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonPackage.test.ts
@@ -1,25 +1,4 @@
-import { PythonClass } from './PythonClass';
-import { PythonModule } from './PythonModule';
 import { PythonPackage } from './PythonPackage';
-
-test('path', () => {
-    const pythonPackage = new PythonPackage('distribution', 'package', '0.0.1');
-    expect(pythonPackage.path()).toEqual(['package']);
-});
-
-test('getByRelativePath with correct path', () => {
-    const pythonClass = new PythonClass('Class', 'Class', 'Class');
-    const pythonPackage = new PythonPackage('distribution', 'package', '0.0.1', [
-        new PythonModule('module', 'module', [], [], [pythonClass]),
-    ]);
-    expect(pythonPackage.getByRelativePath(['module', 'Class'])).toBe(pythonClass);
-});
-
-test('getByRelativePath with misleading path', () => {
-    const pythonPackage = new PythonPackage('distribution', 'package', '0.0.1');
-    // eslint-disable-next-line testing-library/prefer-presence-queries
-    expect(pythonPackage.getByRelativePath(['child'])).toBeNull();
-});
 
 test('toString', () => {
     const pythonPackage = new PythonPackage('distribution', 'package', '0.0.1');

--- a/api-editor/gui/src/features/packageData/model/PythonPackage.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonPackage.ts
@@ -1,5 +1,8 @@
+import { PythonClass } from './PythonClass';
 import { PythonDeclaration } from './PythonDeclaration';
 import { PythonModule } from './PythonModule';
+import { PythonFunction } from './PythonFunction';
+import { Optional } from '../../../common/util/types';
 
 export class PythonPackage extends PythonDeclaration {
     constructor(
@@ -7,6 +10,7 @@ export class PythonPackage extends PythonDeclaration {
         readonly name: string,
         readonly version: string,
         readonly modules: PythonModule[] = [],
+        private readonly reexportMap: Map<string, PythonClass | PythonFunction> = new Map(),
     ) {
         super();
 
@@ -21,6 +25,15 @@ export class PythonPackage extends PythonDeclaration {
 
     children(): PythonModule[] {
         return this.modules;
+    }
+
+    getByRelativePath(relativePath: string[]): Optional<PythonDeclaration> {
+        const id = this.name + '/' + relativePath.join('/');
+        if (this.reexportMap.has(id)) {
+            return this.reexportMap.get(id);
+        }
+
+        return super.getByRelativePath(relativePath);
     }
 
     toString(): string {

--- a/api-editor/gui/src/features/packageData/model/PythonPackage.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonPackage.ts
@@ -1,19 +1,21 @@
-import { PythonClass } from './PythonClass';
 import { PythonDeclaration } from './PythonDeclaration';
 import { PythonModule } from './PythonModule';
-import { PythonFunction } from './PythonFunction';
 import { Optional } from '../../../common/util/types';
 
 export class PythonPackage extends PythonDeclaration {
+    readonly id: string;
+    readonly isPublic: boolean = true;
+
     constructor(
         readonly distribution: string,
         readonly name: string,
         readonly version: string,
         readonly modules: PythonModule[] = [],
-        private readonly reexportMap: Map<string, PythonClass | PythonFunction> = new Map(),
+        private readonly idToDeclaration: Map<string, PythonDeclaration> = new Map(),
     ) {
         super();
 
+        this.id = name;
         this.modules.forEach((it) => {
             it.containingPackage = this;
         });
@@ -27,13 +29,10 @@ export class PythonPackage extends PythonDeclaration {
         return this.modules;
     }
 
-    getByRelativePath(relativePath: string[]): Optional<PythonDeclaration> {
-        const id = this.name + '/' + relativePath.join('/');
-        if (this.reexportMap.has(id)) {
-            return this.reexportMap.get(id);
+    getDeclarationById(id: string): Optional<PythonDeclaration> {
+        if (this.idToDeclaration.has(id)) {
+            return this.idToDeclaration.get(id);
         }
-
-        return super.getByRelativePath(relativePath);
     }
 
     toString(): string {

--- a/api-editor/gui/src/features/packageData/model/PythonPackage.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonPackage.ts
@@ -48,7 +48,7 @@ export class PythonPackage extends PythonDeclaration {
         version = this.version,
         modules = this.modules,
     }: PythonPackageShallowCopy = {}): PythonPackage {
-        return new PythonPackage(distribution, name, version, modules);
+        return new PythonPackage(distribution, name, version, modules, this.idToDeclaration);
     }
 
     toString(): string {

--- a/api-editor/gui/src/features/packageData/model/PythonPackage.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonPackage.ts
@@ -2,6 +2,13 @@ import { PythonDeclaration } from './PythonDeclaration';
 import { PythonModule } from './PythonModule';
 import { Optional } from '../../../common/util/types';
 
+interface PythonPackageShallowCopy {
+    distribution?: string;
+    name?: string;
+    version?: string;
+    modules?: PythonModule[];
+}
+
 export class PythonPackage extends PythonDeclaration {
     readonly id: string;
     readonly isPublic: boolean = true;
@@ -33,6 +40,15 @@ export class PythonPackage extends PythonDeclaration {
         if (this.idToDeclaration.has(id)) {
             return this.idToDeclaration.get(id);
         }
+    }
+
+    shallowCopy({
+        distribution = this.distribution,
+        name = this.name,
+        version = this.version,
+        modules = this.modules,
+    }: PythonPackageShallowCopy = {}): PythonPackage {
+        return new PythonPackage(distribution, name, version, modules);
     }
 
     toString(): string {

--- a/api-editor/gui/src/features/packageData/model/PythonPackageBuilder.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonPackageBuilder.ts
@@ -57,7 +57,6 @@ const parsePythonModuleJson = function (
     functions: Map<string, PythonFunction>,
     idToDeclaration: Map<string, PythonDeclaration>,
 ): PythonModule {
-
     // Classes
     const classesInModule = moduleJson.classes
         .filter((classId) => classes.has(classId) && classes.get(classId)!.reexportedBy.length === 0)

--- a/api-editor/gui/src/features/packageData/model/PythonPackageBuilder.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonPackageBuilder.ts
@@ -58,7 +58,9 @@ const parsePythonModuleJson = function (
     const classesInModule = moduleJson.classes
         .filter((classId) => classes.has(classId) && classes.get(classId)!.reexportedBy.length === 0)
         .map((classId) => classes.get(classId)!);
-    const reexportedClasses = [...classes.values()].filter((it) => it.reexportedBy.includes(moduleJson.id));
+    const reexportedClasses = [...classes.values()].filter(
+        (it) => it.reexportedBy.length > 0 && it.reexportedBy[0] === moduleJson.id,
+    );
     const allClasses = [...classesInModule, ...reexportedClasses];
     for (const cls of reexportedClasses) {
         reexportMap.set(cls.id, cls);
@@ -67,7 +69,9 @@ const parsePythonModuleJson = function (
     const functionsInModule = moduleJson.functions
         .filter((functionId) => functions.has(functionId) && functions.get(functionId)!.reexportedBy.length === 0)
         .map((functionId) => functions.get(functionId)!);
-    const reexportedFunctions = [...functions.values()].filter((it) => it.reexportedBy.includes(moduleJson.id));
+    const reexportedFunctions = [...functions.values()].filter(
+        (it) => it.reexportedBy.length > 0 && it.reexportedBy[0] === moduleJson.id,
+    );
     const allFunctions = [...functionsInModule, ...reexportedFunctions];
     for (const func of reexportedFunctions) {
         reexportMap.set(func.id, func);

--- a/api-editor/gui/src/features/packageData/model/PythonParameter.test.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonParameter.test.ts
@@ -1,45 +1,4 @@
-import { PythonClass } from './PythonClass';
-import { PythonFunction } from './PythonFunction';
-import { PythonModule } from './PythonModule';
-import { PythonPackage } from './PythonPackage';
 import { PythonParameter } from './PythonParameter';
-
-test('path without parent', () => {
-    const pythonParameter = new PythonParameter('param', 'param', 'param');
-    expect(pythonParameter.path()).toEqual(['param']);
-});
-
-test('path with ancestors', () => {
-    const pythonParameter = new PythonParameter('param', 'param', 'param');
-
-    // eslint-disable-next-line no-new
-    new PythonPackage('distribution', 'package', '0.0.1', [
-        new PythonModule(
-            'module',
-            'module',
-            [],
-            [],
-            [
-                new PythonClass(
-                    'Class',
-                    'Class',
-                    'Class',
-                    [],
-                    [],
-                    [new PythonFunction('function', 'function', 'function', [], [pythonParameter])],
-                ),
-            ],
-        ),
-    ]);
-
-    expect(pythonParameter.path()).toEqual(['package', 'module', 'Class', 'function', 'param']);
-});
-
-test('getByRelativePath', () => {
-    const pythonParameter = new PythonParameter('param', 'param', 'param');
-    // eslint-disable-next-line testing-library/prefer-presence-queries
-    expect(pythonParameter.getByRelativePath(['child'])).toBeNull();
-});
 
 test('toString', () => {
     const pythonParameter = new PythonParameter('param', 'param', 'param');

--- a/api-editor/gui/src/features/packageData/model/PythonParameter.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonParameter.ts
@@ -40,10 +40,6 @@ export class PythonParameter extends PythonDeclaration {
         return [];
     }
 
-    isPublicDeclaration(): boolean {
-        return this.isPublic;
-    }
-
     isExplicitParameter(): boolean {
         return this.assignedBy !== PythonParameterAssignment.IMPLICIT;
     }

--- a/api-editor/gui/src/features/packageData/model/PythonResult.test.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonResult.test.ts
@@ -1,45 +1,4 @@
-import { PythonClass } from './PythonClass';
-import { PythonFunction } from './PythonFunction';
-import { PythonModule } from './PythonModule';
-import { PythonPackage } from './PythonPackage';
 import { PythonResult } from './PythonResult';
-
-test('path without parent', () => {
-    const pythonResult = new PythonResult('result');
-    expect(pythonResult.path()).toEqual(['result']);
-});
-
-test('path with ancestors', () => {
-    const pythonResult = new PythonResult('result');
-
-    // eslint-disable-next-line no-new
-    new PythonPackage('distribution', 'package', '0.0.1', [
-        new PythonModule(
-            'module',
-            'module',
-            [],
-            [],
-            [
-                new PythonClass(
-                    'Class',
-                    'Class',
-                    'Class',
-                    [],
-                    [],
-                    [new PythonFunction('function', 'function', 'function', [], [], [pythonResult])],
-                ),
-            ],
-        ),
-    ]);
-
-    expect(pythonResult.path()).toEqual(['package', 'module', 'Class', 'function', 'result']);
-});
-
-test('getByRelativePath', () => {
-    const pythonResult = new PythonResult('result');
-    // eslint-disable-next-line testing-library/prefer-presence-queries
-    expect(pythonResult.getByRelativePath(['child'])).toBeNull();
-});
 
 test('toString', () => {
     const pythonResult = new PythonResult('result');

--- a/api-editor/gui/src/features/packageData/model/PythonResult.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonResult.ts
@@ -3,10 +3,16 @@ import { PythonDeclaration } from './PythonDeclaration';
 import { PythonFunction } from './PythonFunction';
 
 export class PythonResult extends PythonDeclaration {
+    readonly id: string;
+    readonly isPublic: boolean;
+
     containingFunction: Optional<PythonFunction>;
 
     constructor(readonly name: string, readonly typeInDocs: string = '', readonly description: string = '') {
         super();
+
+        this.id = name;
+        this.isPublic = true;
 
         this.containingFunction = null;
     }

--- a/api-editor/gui/src/features/packageData/model/filters/AbstractPythonFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/AbstractPythonFilter.ts
@@ -78,12 +78,9 @@ export abstract class AbstractPythonFilter {
             .filter((it) => it !== null);
 
         // Create filtered package
-        return new PythonPackage(
-            pythonPackage.distribution,
-            pythonPackage.name,
-            pythonPackage.version,
-            modules as PythonModule[],
-        );
+        return pythonPackage.shallowCopy({
+            modules: modules as PythonModule[],
+        });
     }
 
     /**
@@ -116,14 +113,10 @@ export abstract class AbstractPythonFilter {
         }
 
         // Otherwise, create filtered module
-        return new PythonModule(
-            pythonModule.id,
-            pythonModule.name,
-            pythonModule.imports,
-            pythonModule.fromImports,
-            classes as PythonClass[],
-            functions as PythonFunction[],
-        );
+        return pythonModule.shallowCopy({
+            classes: classes as PythonClass[],
+            functions: functions as PythonFunction[],
+        });
     }
 
     /**
@@ -151,18 +144,9 @@ export abstract class AbstractPythonFilter {
         }
 
         // Otherwise, create filtered class
-        return new PythonClass(
-            pythonClass.id,
-            pythonClass.name,
-            pythonClass.qualifiedName,
-            pythonClass.decorators,
-            pythonClass.superclasses,
-            methods as PythonFunction[],
-            pythonClass.isPublic,
-            pythonClass.reexportedBy,
-            pythonClass.description,
-            pythonClass.fullDocstring,
-        );
+        return pythonClass.shallowCopy({
+            methods: methods as PythonFunction[],
+        });
     }
 
     /**
@@ -188,17 +172,8 @@ export abstract class AbstractPythonFilter {
         }
 
         // Otherwise, create filtered function
-        return new PythonFunction(
-            pythonFunction.id,
-            pythonFunction.name,
-            pythonFunction.qualifiedName,
-            pythonFunction.decorators,
+        return pythonFunction.shallowCopy({
             parameters,
-            pythonFunction.results,
-            pythonFunction.isPublic,
-            pythonFunction.reexportedBy,
-            pythonFunction.description,
-            pythonFunction.fullDocstring,
-        );
+        });
     }
 }

--- a/api-editor/gui/src/features/packageData/model/filters/AbstractPythonFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/AbstractPythonFilter.ts
@@ -159,6 +159,7 @@ export abstract class AbstractPythonFilter {
             pythonClass.superclasses,
             methods as PythonFunction[],
             pythonClass.isPublic,
+            pythonClass.reexportedBy,
             pythonClass.description,
             pythonClass.fullDocstring,
         );
@@ -195,6 +196,7 @@ export abstract class AbstractPythonFilter {
             parameters,
             pythonFunction.results,
             pythonFunction.isPublic,
+            pythonFunction.reexportedBy,
             pythonFunction.description,
             pythonFunction.fullDocstring,
         );

--- a/api-editor/gui/src/features/packageData/model/filters/AnnotationFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/AnnotationFilter.ts
@@ -1,11 +1,11 @@
-import { PythonClass } from '../PythonClass';
-import { PythonFunction } from '../PythonFunction';
-import { PythonModule } from '../PythonModule';
-import { PythonParameter } from '../PythonParameter';
-import { AbstractPythonFilter } from './AbstractPythonFilter';
-import { PythonDeclaration } from '../PythonDeclaration';
-import { AnnotationStore } from '../../../annotations/annotationSlice';
-import { UsageCountStore } from '../../../usages/model/UsageCountStore';
+import {PythonClass} from '../PythonClass';
+import {PythonFunction} from '../PythonFunction';
+import {PythonModule} from '../PythonModule';
+import {PythonParameter} from '../PythonParameter';
+import {AbstractPythonFilter} from './AbstractPythonFilter';
+import {PythonDeclaration} from '../PythonDeclaration';
+import {AnnotationStore} from '../../../annotations/annotationSlice';
+import {UsageCountStore} from '../../../usages/model/UsageCountStore';
 
 /**
  * Keeps only declarations with either an arbitrary or a specific annotation.
@@ -44,7 +44,7 @@ export class AnnotationFilter extends AbstractPythonFilter {
         annotations: AnnotationStore,
         _usages: UsageCountStore,
     ): boolean {
-        const id = pythonDeclaration.pathAsString();
+        const id = pythonDeclaration.id;
 
         switch (this.type) {
             case AnnotationType.Any:

--- a/api-editor/gui/src/features/packageData/model/filters/AnnotationFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/AnnotationFilter.ts
@@ -1,11 +1,11 @@
-import {PythonClass} from '../PythonClass';
-import {PythonFunction} from '../PythonFunction';
-import {PythonModule} from '../PythonModule';
-import {PythonParameter} from '../PythonParameter';
-import {AbstractPythonFilter} from './AbstractPythonFilter';
-import {PythonDeclaration} from '../PythonDeclaration';
-import {AnnotationStore} from '../../../annotations/annotationSlice';
-import {UsageCountStore} from '../../../usages/model/UsageCountStore';
+import { PythonClass } from '../PythonClass';
+import { PythonFunction } from '../PythonFunction';
+import { PythonModule } from '../PythonModule';
+import { PythonParameter } from '../PythonParameter';
+import { AbstractPythonFilter } from './AbstractPythonFilter';
+import { PythonDeclaration } from '../PythonDeclaration';
+import { AnnotationStore } from '../../../annotations/annotationSlice';
+import { UsageCountStore } from '../../../usages/model/UsageCountStore';
 
 /**
  * Keeps only declarations with either an arbitrary or a specific annotation.

--- a/api-editor/gui/src/features/packageData/model/filters/VisibilityFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/VisibilityFilter.ts
@@ -43,7 +43,7 @@ export class VisibilityFilter extends AbstractPythonFilter {
         _annotations: AnnotationStore,
         _usages: UsageCountStore,
     ): boolean {
-        return pythonDeclaration.isPublicDeclaration() === (this.visibility === Visibility.Public);
+        return pythonDeclaration.isPublic === (this.visibility === Visibility.Public);
     }
 }
 

--- a/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
@@ -24,16 +24,12 @@ export const ActionBar: React.FC<ActionBarProps> = function ({ declaration }) {
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
 
-    console.log("-----------------------------------------------------");
-
     const pythonPackage = useAppSelector(selectFilteredPythonPackage);
     const pythonFilter = useAppSelector(selectFilter);
     const annotations = useAppSelector(selectAnnotations);
     const usages = useAppSelector(selectUsages);
     const isMatched = (node: PythonDeclaration): boolean =>
         pythonFilter.shouldKeepDeclaration(node, annotations, usages);
-
-    console.log(pythonPackage);
 
     return (
         <HStack borderTop={1} layerStyle="subtleBorder" padding="0.5em 1em" marginTop={0} w="100%">
@@ -128,7 +124,6 @@ const getNextElementPath = function (
 };
 
 const getNextElementInTree = function (current: PythonDeclaration): PythonDeclaration | null {
-    console.log(current);
     if (current.children().length > 0) {
         return current.children()[0];
     } else if (current.parent()) {
@@ -192,6 +187,7 @@ const getLastElementInTree = function (current: PythonDeclaration): PythonDeclar
 
 const getAncestors = function (navStr: string, filteredPythonPackage: PythonPackage): string[] {
     const ancestors: string[] = [];
+
     let currentElement = filteredPythonPackage.getDeclarationById(navStr);
     if (currentElement) {
         currentElement = currentElement.parent();
@@ -200,6 +196,7 @@ const getAncestors = function (navStr: string, filteredPythonPackage: PythonPack
             currentElement = currentElement.parent();
         }
     }
+
     return ancestors;
 };
 

--- a/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
@@ -109,7 +109,7 @@ const getNextElementPath = function (
     const nextElement = getNextElementInTree(current);
     if (nextElement) {
         if (filter.shouldKeepDeclaration(nextElement, annotations, usages)) {
-            return nextElement.pathAsString();
+            return nextElement.id;
         }
         return getNextElementPath(nextElement, filter, annotations, usages);
     }
@@ -149,7 +149,7 @@ const getPreviousElementPath = function (
     const previousElement = getPreviousElementInTree(current);
     if (previousElement) {
         if (filter.shouldKeepDeclaration(previousElement, annotations, usages)) {
-            return previousElement.pathAsString();
+            return previousElement.id;
         }
         return getPreviousElementPath(previousElement, filter, annotations, usages);
     }
@@ -180,11 +180,11 @@ const getLastElementInTree = function (current: PythonDeclaration): PythonDeclar
 
 const getAncestors = function (navStr: string, filteredPythonPackage: PythonPackage): string[] {
     const ancestors: string[] = [];
-    let currentElement = filteredPythonPackage.getByRelativePathAsString(navStr);
+    let currentElement = filteredPythonPackage.getDeclarationById(navStr);
     if (currentElement) {
         currentElement = currentElement.parent();
         while (currentElement) {
-            ancestors.push(currentElement.pathAsString());
+            ancestors.push(currentElement.id);
             currentElement = currentElement.parent();
         }
     }
@@ -192,7 +192,7 @@ const getAncestors = function (navStr: string, filteredPythonPackage: PythonPack
 };
 
 const getDescendantsOrSelf = function (current: PythonDeclaration): string[] {
-    return [...current.descendantsOrSelf()].map((descendant) => descendant.pathAsString());
+    return [...current.descendantsOrSelf()].map((descendant) => descendant.id);
 };
 
 const getMatchedNodesAndParents = function (
@@ -225,7 +225,7 @@ const doGetMatchedNodesAndParents = function (
     }
 
     if (shouldExpandThisNode) {
-        nodesToExpand.push(current.pathAsString());
+        nodesToExpand.push(current.id);
     }
 
     return {

--- a/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
@@ -101,17 +101,17 @@ export const ActionBar: React.FC<ActionBarProps> = function ({ declaration, pyth
 };
 
 const getNextElementPath = function (
-    current: PythonDeclaration,
+    start: PythonDeclaration,
     filter: AbstractPythonFilter,
     annotations: AnnotationStore,
     usages: UsageCountStore,
 ): string | null {
-    const nextElement = getNextElementInTree(current);
-    if (nextElement) {
-        if (filter.shouldKeepDeclaration(nextElement, annotations, usages)) {
-            return nextElement.id;
+    let current = getNextElementInTree(start);
+    while (current !== start && current !== null) {
+        if (filter.shouldKeepDeclaration(current, annotations, usages)) {
+            return current.id;
         }
-        return getNextElementPath(nextElement, filter, annotations, usages);
+        current = getNextElementInTree(current);
     }
     return null;
 };
@@ -141,17 +141,17 @@ const getNextFromParentInTree = function (current: PythonDeclaration): PythonDec
 };
 
 const getPreviousElementPath = function (
-    current: PythonDeclaration,
+    start: PythonDeclaration,
     filter: AbstractPythonFilter,
     annotations: AnnotationStore,
     usages: UsageCountStore,
 ): string | null {
-    const previousElement = getPreviousElementInTree(current);
-    if (previousElement) {
-        if (filter.shouldKeepDeclaration(previousElement, annotations, usages)) {
-            return previousElement.id;
+    let current = getPreviousElementInTree(start);
+    while (current !== start && current !== null) {
+        if (filter.shouldKeepDeclaration(current, annotations, usages)) {
+            return current.id;
         }
-        return getPreviousElementPath(previousElement, filter, annotations, usages);
+        current = getPreviousElementInTree(current);
     }
     return null;
 };

--- a/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
@@ -7,22 +7,33 @@ import { AnnotationStore, selectAnnotations } from '../../annotations/annotation
 import { useNavigate } from 'react-router';
 import { useAppDispatch, useAppSelector } from '../../../app/hooks';
 import { UsageCountStore } from '../../usages/model/UsageCountStore';
-import { setAllCollapsedInTreeView, setAllExpandedInTreeView, setExactlyExpandedInTreeView } from '../../ui/uiSlice';
+import {
+    selectFilter,
+    setAllCollapsedInTreeView,
+    setAllExpandedInTreeView,
+    setExactlyExpandedInTreeView,
+} from '../../ui/uiSlice';
+import { selectFilteredPythonPackage } from '../apiSlice';
+import { selectUsages } from '../../usages/usageSlice';
 
 interface ActionBarProps {
     declaration: PythonDeclaration;
-    pythonPackage: PythonPackage;
-    pythonFilter: AbstractPythonFilter;
-    usages: UsageCountStore;
 }
 
-export const ActionBar: React.FC<ActionBarProps> = function ({ declaration, pythonPackage, pythonFilter, usages }) {
+export const ActionBar: React.FC<ActionBarProps> = function ({ declaration }) {
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
 
+    console.log("-----------------------------------------------------");
+
+    const pythonPackage = useAppSelector(selectFilteredPythonPackage);
+    const pythonFilter = useAppSelector(selectFilter);
     const annotations = useAppSelector(selectAnnotations);
+    const usages = useAppSelector(selectUsages);
     const isMatched = (node: PythonDeclaration): boolean =>
         pythonFilter.shouldKeepDeclaration(node, annotations, usages);
+
+    console.log(pythonPackage);
 
     return (
         <HStack borderTop={1} layerStyle="subtleBorder" padding="0.5em 1em" marginTop={0} w="100%">
@@ -117,6 +128,7 @@ const getNextElementPath = function (
 };
 
 const getNextElementInTree = function (current: PythonDeclaration): PythonDeclaration | null {
+    console.log(current);
     if (current.children().length > 0) {
         return current.children()[0];
     } else if (current.parent()) {

--- a/api-editor/gui/src/features/packageData/selectionView/ClassView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ClassView.tsx
@@ -12,7 +12,7 @@ interface ClassViewProps {
 }
 
 export const ClassView: React.FC<ClassViewProps> = function ({ pythonClass }) {
-    const id = pythonClass.pathAsString();
+    const id = pythonClass.id;
 
     return (
         <Stack spacing={8}>

--- a/api-editor/gui/src/features/packageData/selectionView/FunctionView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/FunctionView.tsx
@@ -16,7 +16,7 @@ interface FunctionViewProps {
 }
 
 export const FunctionView: React.FC<FunctionViewProps> = function ({ pythonFunction }) {
-    const id = pythonFunction.pathAsString();
+    const id = pythonFunction.id;
 
     // If more @calledAfter annotations can be added
     const currentCalledAfters = Object.keys(useAppSelector(selectCalledAfters(id)));

--- a/api-editor/gui/src/features/packageData/selectionView/ParameterNode.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ParameterNode.tsx
@@ -12,7 +12,7 @@ interface ParameterNodeProps {
 }
 
 export const ParameterNode: React.FC<ParameterNodeProps> = function ({ isTitle, pythonParameter }) {
-    const id = pythonParameter.pathAsString();
+    const id = pythonParameter.id;
 
     const isConstructorParameter = pythonParameter.parent()?.name === '__init__';
     const isExplicitParameter = pythonParameter.isExplicitParameter();

--- a/api-editor/gui/src/features/packageData/selectionView/SelectionView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/SelectionView.tsx
@@ -4,24 +4,18 @@ import { useLocation } from 'react-router';
 import { PythonClass } from '../model/PythonClass';
 import { PythonFunction } from '../model/PythonFunction';
 import { PythonModule } from '../model/PythonModule';
-import { PythonPackage } from '../model/PythonPackage';
 import { PythonParameter } from '../model/PythonParameter';
 import { ClassView } from './ClassView';
 import { FunctionView } from './FunctionView';
 import { ModuleView } from './ModuleView';
 import { ParameterView } from './ParameterView';
-import { AbstractPythonFilter } from '../model/filters/AbstractPythonFilter';
 import { ActionBar } from './ActionBar';
-import { UsageCountStore } from '../../usages/model/UsageCountStore';
+import { useAppSelector } from '../../../app/hooks';
+import { selectRawPythonPackage } from '../apiSlice';
 
-interface SelectionViewProps {
-    pythonPackage: PythonPackage;
-    pythonFilter: AbstractPythonFilter;
-    usages: UsageCountStore;
-}
-
-export const SelectionView: React.FC<SelectionViewProps> = function ({ pythonPackage, pythonFilter, usages }) {
-    const declaration = pythonPackage.getDeclarationById(useLocation().pathname.split('/').splice(1).join('/'));
+export const SelectionView: React.FC = function () {
+    const rawPythonPackage = useAppSelector(selectRawPythonPackage);
+    const declaration = rawPythonPackage.getDeclarationById(useLocation().pathname.split('/').splice(1).join('/'));
 
     if (!declaration) {
         return null;
@@ -38,12 +32,7 @@ export const SelectionView: React.FC<SelectionViewProps> = function ({ pythonPac
                 </Box>
             </Box>
 
-            <ActionBar
-                declaration={declaration}
-                pythonPackage={pythonPackage}
-                pythonFilter={pythonFilter}
-                usages={usages}
-            />
+            <ActionBar declaration={declaration} />
         </VStack>
     );
 };

--- a/api-editor/gui/src/features/packageData/selectionView/SelectionView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/SelectionView.tsx
@@ -21,7 +21,7 @@ interface SelectionViewProps {
 }
 
 export const SelectionView: React.FC<SelectionViewProps> = function ({ pythonPackage, pythonFilter, usages }) {
-    const declaration = pythonPackage.getByRelativePath(useLocation().pathname.split('/').splice(2));
+    const declaration = pythonPackage.getDeclarationById(useLocation().pathname.split('/').splice(1).join('/'));
 
     if (!declaration) {
         return null;

--- a/api-editor/gui/src/features/packageData/treeView/TreeNode.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/TreeNode.tsx
@@ -50,7 +50,7 @@ export const TreeNode: React.FC<TreeNodeProps> = function ({
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
 
-    const showChildren = useAppSelector(selectIsExpandedInTreeView(declaration.pathAsString()));
+    const showChildren = useAppSelector(selectIsExpandedInTreeView(declaration.id));
     const annotations = useAppSelector(selectAnnotations);
 
     const level = levelOf(declaration);
@@ -62,14 +62,14 @@ export const TreeNode: React.FC<TreeNodeProps> = function ({
 
     const handleNodeClick = (event: MouseEvent) => {
         if (event.shiftKey) {
-            dispatch(toggleIsExpandedInTreeView(declaration.pathAsString()));
+            dispatch(toggleIsExpandedInTreeView(declaration.id));
         } else {
-            navigate(`/${declaration.pathAsString()}`);
+            navigate(`/${declaration.id}`);
         }
     };
 
     const handleVisibilityIndicatorClick = (event: MouseEvent) => {
-        dispatch(toggleIsExpandedInTreeView(declaration.pathAsString()));
+        dispatch(toggleIsExpandedInTreeView(declaration.id));
         event.stopPropagation();
     };
 
@@ -104,9 +104,9 @@ export const TreeNode: React.FC<TreeNodeProps> = function ({
 };
 
 const levelOf = function (declaration: PythonDeclaration): number {
-    return declaration.path().length - 2;
+    return declaration.id.split('/').length - 2;
 };
 
 const isSelected = function (declaration: PythonDeclaration, currentPathname: string): boolean {
-    return `/${declaration.pathAsString()}` === currentPathname;
+    return `/${declaration.id}` === currentPathname;
 };

--- a/api-editor/gui/src/features/packageData/treeView/TreeView.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/TreeView.tsx
@@ -71,7 +71,7 @@ export const TreeView: React.FC<TreeViewProps> = memo(({ pythonPackage, filter, 
                     itemSize={24}
                     itemCount={children.length}
                     itemData={{ children, filter, usages }}
-                    itemKey={(index, data) => data.children[index]?.pathAsString()}
+                    itemKey={(index, data) => data.children[index].id}
                     width="100%"
                     height={height}
                     style={{
@@ -93,7 +93,7 @@ const walkChildrenInPreorder = function (
     declaration: PythonDeclaration,
 ): PythonDeclaration[] {
     return declaration.children().flatMap((it) => {
-        if (allExpandedItemsInTreeView[it.pathAsString()]) {
+        if (allExpandedItemsInTreeView[it.id]) {
             return [it, ...walkChildrenInPreorder(allExpandedItemsInTreeView, it)];
         } else {
             return [it];

--- a/api-editor/gui/src/features/usages/UsageImportDialog.tsx
+++ b/api-editor/gui/src/features/usages/UsageImportDialog.tsx
@@ -20,13 +20,13 @@ import { isValidJsonFile } from '../../common/util/validation';
 import { UsageCountJson, UsageCountStore } from './model/UsageCountStore';
 import { toggleUsageImportDialog } from '../ui/uiSlice';
 import { setUsages } from './usageSlice';
-import { selectPythonPackage } from '../packageData/apiSlice';
+import { selectRawPythonPackage } from '../packageData/apiSlice';
 
 export const UsageImportDialog: React.FC = function () {
     const [fileName, setFileName] = useState('');
     const [newUsages, setNewUsages] = useState<string>();
     const dispatch = useAppDispatch();
-    const api = useAppSelector(selectPythonPackage);
+    const api = useAppSelector(selectRawPythonPackage);
 
     const submit = async () => {
         if (newUsages) {

--- a/api-editor/gui/src/features/usages/model/UsageCountStore.ts
+++ b/api-editor/gui/src/features/usages/model/UsageCountStore.ts
@@ -1,9 +1,9 @@
 import { PythonPackage } from '../../packageData/model/PythonPackage';
 import { PythonParameter } from '../../packageData/model/PythonParameter';
-import {PythonDeclaration} from "../../packageData/model/PythonDeclaration";
-import {PythonModule} from "../../packageData/model/PythonModule";
-import {PythonClass} from "../../packageData/model/PythonClass";
-import {PythonFunction} from "../../packageData/model/PythonFunction";
+import { PythonDeclaration } from '../../packageData/model/PythonDeclaration';
+import { PythonModule } from '../../packageData/model/PythonModule';
+import { PythonClass } from '../../packageData/model/PythonClass';
+import { PythonFunction } from '../../packageData/model/PythonFunction';
 
 export interface UsageCountJson {
     module_counts?: {

--- a/api-editor/gui/src/features/usages/model/UsageCountStore.ts
+++ b/api-editor/gui/src/features/usages/model/UsageCountStore.ts
@@ -87,7 +87,7 @@ export class UsageCountStore {
      */
     private addImplicitUsagesOfDefaultValues(api: PythonPackage) {
         for (const [parameterId, parameterUsageCount] of this.parameterUsages.entries()) {
-            const parameter = api.getByRelativePathAsString(parameterId);
+            const parameter = api.getDeclarationById(parameterId);
             if (!(parameter instanceof PythonParameter)) {
                 continue;
             }

--- a/api-editor/gui/src/features/usages/model/UsageCountStore.ts
+++ b/api-editor/gui/src/features/usages/model/UsageCountStore.ts
@@ -1,5 +1,9 @@
 import { PythonPackage } from '../../packageData/model/PythonPackage';
 import { PythonParameter } from '../../packageData/model/PythonParameter';
+import {PythonDeclaration} from "../../packageData/model/PythonDeclaration";
+import {PythonModule} from "../../packageData/model/PythonModule";
+import {PythonClass} from "../../packageData/model/PythonClass";
+import {PythonFunction} from "../../packageData/model/PythonFunction";
 
 export interface UsageCountJson {
     module_counts?: {
@@ -64,6 +68,20 @@ export class UsageCountStore {
         );
         this.parameterMaxUsefulness =
             this.parameterUsefulness.size === 0 ? 0 : Math.max(...this.parameterUsefulness.values());
+    }
+
+    getUsageCount(declaration: PythonDeclaration): number {
+        if (declaration instanceof PythonModule) {
+            return this.moduleUsages.get(declaration.id) ?? 0;
+        } else if (declaration instanceof PythonClass) {
+            return this.classUsages.get(declaration.id) ?? 0;
+        } else if (declaration instanceof PythonFunction) {
+            return this.functionUsages.get(declaration.id) ?? 0;
+        } else if (declaration instanceof PythonParameter) {
+            return this.parameterUsages.get(declaration.id) ?? 0;
+        } else {
+            return 0;
+        }
     }
 
     toJson(): UsageCountJson {

--- a/package-parser/package_parser/model/api/_api.py
+++ b/package-parser/package_parser/model/api/_api.py
@@ -204,6 +204,7 @@ class Class:
             json.get("decorators", []),
             json.get("superclasses", []),
             json.get("is_public", True),
+            json.get("reexported_by", []),
             json.get("description", ""),
             json.get("docstring", ""),
         )
@@ -220,6 +221,7 @@ class Class:
         decorators: list[str],
         superclasses: list[str],
         is_public: bool,
+        reexported_by: list[str],
         description: str,
         docstring: str,
     ) -> None:
@@ -229,6 +231,7 @@ class Class:
         self.superclasses: list[str] = superclasses
         self.methods: list[str] = []
         self.is_public: bool = is_public
+        self.reexported_by: list[str] = reexported_by
         self.description: str = description
         self.docstring: str = docstring
 
@@ -248,6 +251,7 @@ class Class:
             "superclasses": self.superclasses,
             "methods": self.methods,
             "is_public": self.is_public,
+            "reexported_by": self.reexported_by,
             "description": self.description,
             "docstring": self.docstring,
         }
@@ -261,6 +265,7 @@ class Function:
     parameters: list[Parameter]
     results: list[Result]
     is_public: bool
+    reexported_by: list[str]
     description: str
     docstring: str
 
@@ -276,6 +281,7 @@ class Function:
             ],
             [Result.from_json(result_json) for result_json in json.get("results", [])],
             json.get("is_public", True),
+            json.get("reexported_by", []),
             json.get("description", ""),
             json.get("docstring", ""),
         )
@@ -293,6 +299,7 @@ class Function:
             "parameters": [parameter.to_json() for parameter in self.parameters],
             "results": [result.to_json() for result in self.results],
             "is_public": self.is_public,
+            "reexported_by": self.reexported_by,
             "description": self.description,
             "docstring": self.docstring,
         }

--- a/package-parser/package_parser/processing/api/_ast_visitor.py
+++ b/package-parser/package_parser/processing/api/_ast_visitor.py
@@ -95,10 +95,10 @@ class _AstVisitor:
                     for declaration, _ in global_node.names:
                         reexported_name = f"{base_import_path}.{declaration}"
 
-                        if reexported_name.startswith(module_node.name):
-                            if reexported_name not in self.reexported:
-                                self.reexported[reexported_name] = []
-                            self.reexported[reexported_name] += [id_]
+                        # if reexported_name.startswith(module_node.name):
+                        if reexported_name not in self.reexported:
+                            self.reexported[reexported_name] = []
+                        self.reexported[reexported_name] += [id_]
 
         # Remember module, so we can later add classes and global functions
         module = Module(
@@ -320,11 +320,12 @@ class _AstVisitor:
             return True
 
         # Containing class is re-exported (always false if the current API element is not a method)
-        if parent_qualified_name(qualified_name) in self.reexported:
+        if isinstance(self.__declaration_stack[-1], Class) and parent_qualified_name(qualified_name) in self.reexported:
             return True
 
         # The slicing is necessary so __init__ functions are not excluded (already handled in the first condition).
         return all(not it.startswith("_") for it in qualified_name.split(".")[:-1])
+
 
 def is_public_module(module_name: str) -> bool:
     return all(not it.startswith("_") for it in module_name.split("."))

--- a/package-parser/package_parser/processing/api/_ast_visitor.py
+++ b/package-parser/package_parser/processing/api/_ast_visitor.py
@@ -22,7 +22,9 @@ from ._file_filters import _is_init_file
 
 class _AstVisitor:
     def __init__(self, api: API) -> None:
-        self.reexported: dict[str, list[str]] = {}
+        # Key of dict is ID of declaration. Value is list of modules that re-export this declaration. For each module
+        # we store its ID and its qualified name.
+        self.reexported: dict[str, list[tuple[str, str, str]]] = {}
         self.api: API = api
         self.__declaration_stack: list[Union[Module, Class, Function]] = []
 
@@ -91,14 +93,15 @@ class _AstVisitor:
                     from_imports.append(FromImport(base_import_path, name, alias))
 
                 # Find re-exported declarations in __init__.py files
-                if _is_init_file(module_node.file) and is_public_module(module_node.qname()):
+                if _is_init_file(module_node.file):
                     for declaration, _ in global_node.names:
-                        reexported_name = f"{base_import_path}.{declaration}"
+                        reexported_id = f"{base_import_path}.{declaration}"
 
                         # if reexported_name.startswith(module_node.name):
-                        if reexported_name not in self.reexported:
-                            self.reexported[reexported_name] = []
-                        self.reexported[reexported_name] += [id_]
+                        if reexported_id not in self.reexported:
+                            self.reexported[reexported_id] = []
+                        self.reexported[reexported_id] += [(id_, module_node.qname())]
+
 
         # Remember module, so we can later add classes and global functions
         module = Module(
@@ -134,7 +137,7 @@ class _AstVisitor:
             decorator_names,
             class_node.basenames,
             self.is_public(class_node.name, qname),
-            self.reexported.get(qname, []),
+            self.reexported.get(qname, []), # TODO
             _AstVisitor.__description(numpydoc),
             class_node.doc,
         )
@@ -164,6 +167,7 @@ class _AstVisitor:
 
         numpydoc = NumpyDocString(inspect.cleandoc(function_node.doc or ""))
         is_public = self.is_public(function_node.name, qname)
+        reexports = self._transitive_hull_for_public_reexports(qname)
 
         function = Function(
             self.__get_function_id(function_node.name, decorator_names),
@@ -174,7 +178,7 @@ class _AstVisitor:
             ),
             [],  # TODO: results
             is_public,
-            self.reexported.get(qname, []),
+            ,
             _AstVisitor.__description(numpydoc),
             function_node.doc,
         )
@@ -316,16 +320,36 @@ class _AstVisitor:
         if name.startswith("_") and not name.endswith("__"):
             return False
 
-        if qualified_name in self.reexported:
+        if self._is_publicly_reexported(qualified_name):
             return True
 
-        # Containing class is re-exported (always false if the current API element is not a method)
-        if isinstance(self.__declaration_stack[-1], Class) and parent_qualified_name(qualified_name) in self.reexported:
+        # Containing class is reexported
+        if isinstance(self.__declaration_stack[-1], Class) and self._is_publicly_reexported(
+            parent_qualified_name(qualified_name)
+        ):
             return True
 
         # The slicing is necessary so __init__ functions are not excluded (already handled in the first condition).
         return all(not it.startswith("_") for it in qualified_name.split(".")[:-1])
 
+    def _is_publicly_reexported(self, id_: str) -> bool:
+        return len(self._transitive_hull_for_public_reexports(id_)) > 0
 
-def is_public_module(module_name: str) -> bool:
+    def _transitive_hull_for_public_reexports(self, id_: str) -> list[tuple[str, str]]:
+        return [
+            (id_, qualified_name)
+            for id_, qualified_name
+            in self._transitive_hull_for_reexports(id_)
+            if _is_public_module(qualified_name)
+        ]
+
+    def _transitive_hull_for_reexports(self, id_: str) -> list[tuple[str, str]]:
+        result = []
+        for id_, id_ in self.reexported.get(id_, []):
+            result.append((id_, id_))
+            result.extend(self._transitive_hull_for_reexports(id_))
+        return result
+
+
+def _is_public_module(module_name: str) -> bool:
     return all(not it.startswith("_") for it in module_name.split("."))

--- a/package-parser/package_parser/processing/api/_ast_visitor.py
+++ b/package-parser/package_parser/processing/api/_ast_visitor.py
@@ -91,7 +91,7 @@ class _AstVisitor:
                     from_imports.append(FromImport(base_import_path, name, alias))
 
                 # Find re-exported declarations in __init__.py files
-                if _is_init_file(module_node.file):
+                if _is_init_file(module_node.file) and is_public_module(module_node.qname()):
                     for declaration, _ in global_node.names:
                         reexported_name = f"{base_import_path}.{declaration}"
 
@@ -325,3 +325,6 @@ class _AstVisitor:
 
         # The slicing is necessary so __init__ functions are not excluded (already handled in the first condition).
         return all(not it.startswith("_") for it in qualified_name.split(".")[:-1])
+
+def is_public_module(module_name: str) -> bool:
+    return all(not it.startswith("_") for it in module_name.split("."))

--- a/package-parser/package_parser/processing/api/_ast_visitor.py
+++ b/package-parser/package_parser/processing/api/_ast_visitor.py
@@ -94,14 +94,18 @@ class _AstVisitor:
                     from_imports.append(FromImport(base_import_path, name, alias))
 
                 # Find re-exported declarations in __init__.py files
-                if _is_init_file(module_node.file) and is_public_module(module_node.qname()):
+                if _is_init_file(module_node.file) and is_public_module(
+                    module_node.qname()
+                ):
                     for declaration, _ in global_node.names:
                         context = InferenceContext()
                         context.lookupname = declaration
                         node = safe_infer(global_node, context)
 
                         if node is None:
-                            logging.warning(f"Could not resolve 'from {global_node.modname} import {declaration}")
+                            logging.warning(
+                                f"Could not resolve 'from {global_node.modname} import {declaration}"
+                            )
                             continue
 
                         reexported_name = node.qname()
@@ -331,7 +335,10 @@ class _AstVisitor:
             return True
 
         # Containing class is re-exported (always false if the current API element is not a method)
-        if isinstance(self.__declaration_stack[-1], Class) and parent_qualified_name(qualified_name) in self.reexported:
+        if (
+            isinstance(self.__declaration_stack[-1], Class)
+            and parent_qualified_name(qualified_name) in self.reexported
+        ):
             return True
 
         # The slicing is necessary so __init__ functions are not excluded (already handled in the first condition).


### PR DESCRIPTION
Closes #509.

### Summary of Changes

* If declarations are declared in a private module but reexported in a public one they are now properly shown underneath the public module in the tree view. This considerably cleans up the tree view.
* The usage count attached to modules (see #642) also makes more sense now.
* Moreover, when adapters are generated, they also match the public module structure now without exposing internal details.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/173676459-8ba0a925-b00e-40fc-8022-06d99c2cc6ca.png)
