### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,49 @@
+name: Main
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./api-editor
+
+    strategy:
+      matrix:
+        node-version: [ 16.x ]
+        java-version: [ 17 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: api-editor/gui/package-lock.json
+
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java-version }}
+          cache: gradle
+
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle
+      - name: Setup Gradle
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          files: api-editor/backend/build/libs/*-all.jar

--- a/api-editor/backend/build.gradle.kts
+++ b/api-editor/backend/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val javaVersion: String by project
@@ -24,6 +25,10 @@ java {
 
 tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = javaVersion
+}
+
+tasks.withType<ShadowJar> {
+    archiveFileName.set("${project.group}-${project.name}-${project.version}-all.jar")
 }
 
 // Dependencies --------------------------------------------------------------------------------------------------------

--- a/api-editor/build.gradle.kts
+++ b/api-editor/build.gradle.kts
@@ -32,7 +32,7 @@ kover {
 // Subprojects ---------------------------------------------------------------------------------------------------------
 
 subprojects {
-    group = "com.larsreimann"
+    group = "com.larsreimann.api-editor"
     version = "0.0.1"
 
     repositories {


### PR DESCRIPTION
Closes #647.

### Summary of Changes

Add a release workflow that is triggered when a new tag following the format `v*.*.*` is pushed.
