### PR TITLE
feat(gui): only matches and their ancestors when filtering

### DIFF
--- a/api-editor/gui/src/features/packageData/apiSlice.ts
+++ b/api-editor/gui/src/features/packageData/apiSlice.ts
@@ -64,42 +64,6 @@ export const apiReducer = reducer;
 
 const selectAPI = (state: RootState) => state.api;
 export const selectRawPythonPackage = (state: RootState) => selectAPI(state).pythonPackage;
-// const selectSortedPythonPackages = createSelector(
-//     [selectRawPythonPackage, selectSortingMode, selectUsages],
-//     (pythonPackage, sortingMode, usages) => {
-//         switch (sortingMode) {
-//             case SortingMode.Alphabetical:
-//                 return pythonPackage;
-//             case SortingMode.Usages: // Descending
-//                 return pythonPackage.shallowCopy({
-//                     modules: [...pythonPackage.modules]
-//                         .map((module) =>
-//                             module.shallowCopy({
-//                                 classes: [...module.classes]
-//                                     .map((cls) =>
-//                                         cls.shallowCopy({
-//                                             methods: [...cls.methods].sort(
-//                                                 (a, b) =>
-//                                                     (usages.functionUsages.get(b.id) ?? 0) -
-//                                                     (usages.functionUsages.get(a.id) ?? 0),
-//                                             ),
-//                                         }),
-//                                     )
-//                                     .sort(
-//                                         (a, b) =>
-//                                             (usages.classUsages.get(b.id) ?? 0) - (usages.classUsages.get(a.id) ?? 0),
-//                                     ),
-//                                 functions: [...module.functions].sort(
-//                                     (a, b) =>
-//                                         (usages.functionUsages.get(b.id) ?? 0) - (usages.functionUsages.get(a.id) ?? 0),
-//                                 ),
-//                             }),
-//                         )
-//                         .sort((a, b) => (usages.moduleUsages.get(b.id) ?? 0) - (usages.moduleUsages.get(a.id) ?? 0)),
-//                 });
-//         }
-//     },
-// );
 export const selectFilteredPythonPackage = createSelector(
     [selectRawPythonPackage, selectAnnotations, selectUsages, selectFilter],
     (pythonPackage, annotations, usages, filter) => {

--- a/api-editor/gui/src/features/packageData/model/filters/AbstractPythonFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/AbstractPythonFilter.ts
@@ -92,11 +92,6 @@ export abstract class AbstractPythonFilter {
         annotations: AnnotationStore,
         usages: UsageCountStore,
     ): PythonModule | null {
-        // If the module is kept, keep the entire subtree
-        if (this.shouldKeepModule(pythonModule, annotations, usages)) {
-            return pythonModule;
-        }
-
         // Filter classes
         const classes = pythonModule.classes
             .map((it) => this.applyToClass(it, annotations, usages))
@@ -108,7 +103,11 @@ export abstract class AbstractPythonFilter {
             .filter((it) => it !== null);
 
         // Return null if all classes and functions are removed
-        if (isEmptyList(classes) && isEmptyList(functions)) {
+        if (
+            !this.shouldKeepModule(pythonModule, annotations, usages) &&
+            isEmptyList(classes) &&
+            isEmptyList(functions)
+        ) {
             return null;
         }
 
@@ -128,18 +127,13 @@ export abstract class AbstractPythonFilter {
         annotations: AnnotationStore,
         usages: UsageCountStore,
     ): PythonClass | null {
-        // If the class is kept, keep the entire subtree
-        if (this.shouldKeepClass(pythonClass, annotations, usages)) {
-            return pythonClass;
-        }
-
         // Filter methods
         const methods = pythonClass.methods
             .map((it) => this.applyToFunction(it, annotations, usages))
             .filter((it) => it !== null);
 
         // Return null if all methods are removed
-        if (isEmptyList(methods)) {
+        if (!this.shouldKeepClass(pythonClass, annotations, usages) && isEmptyList(methods)) {
             return null;
         }
 
@@ -158,16 +152,11 @@ export abstract class AbstractPythonFilter {
         annotations: AnnotationStore,
         usages: UsageCountStore,
     ): PythonFunction | null {
-        // If the function is kept, keep the entire subtree
-        if (this.shouldKeepFunction(pythonFunction, annotations, usages)) {
-            return pythonFunction;
-        }
-
         // Filter parameters
         const parameters = pythonFunction.parameters.filter((it) => this.shouldKeepParameter(it, annotations, usages));
 
         // Return null if all parameters are removed
-        if (isEmptyList(parameters)) {
+        if (!this.shouldKeepFunction(pythonFunction, annotations, usages) && isEmptyList(parameters)) {
             return null;
         }
 

--- a/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
@@ -139,7 +139,7 @@ const getNextElementInTree = function (
         return current;
     }
 
-    const index = declarations.indexOf(current);
+    const index = declarations.findIndex(it => it.id === current.id);
     const nextIndex = (index + 1) % declarations.length;
     return declarations[nextIndex];
 };
@@ -169,7 +169,7 @@ const getPreviousElementInTree = function (
         return current;
     }
 
-    const index = declarations.indexOf(current);
+    const index = declarations.findIndex(it => it.id === current.id);
     const previousIndex = (index - 1 + declarations.length) % declarations.length;
     return declarations[previousIndex];
 };


### PR DESCRIPTION
Closes #584.

### Summary of Changes

Only show nodes in the tree view if they match the filter or if one of their descendants matches. Don't show them anymore when just an ancestor matches.

### Screenshots (if necessary)

#### Before

#### After

![image](https://user-images.githubusercontent.com/2501322/174140501-780eb2a6-160d-4454-ba4f-ee876f1bf7c6.png)
