### PR TITLE
feat(gui): action bar spanning full width of screen

### DIFF
--- a/api-editor/gui/src/app/App.tsx
+++ b/api-editor/gui/src/app/App.tsx
@@ -1,5 +1,4 @@
 import {
-    Box,
     Grid,
     GridItem,
     ListItem,
@@ -10,7 +9,6 @@ import {
     ModalHeader,
     ModalOverlay,
     UnorderedList,
-    VStack,
 } from '@chakra-ui/react';
 import React, { useEffect, useState } from 'react';
 import { MenuBar } from '../common/MenuBar';
@@ -73,9 +71,9 @@ export const App: React.FC = function () {
     return (
         <>
             <Grid
-                autoColumns="0fr 1fr"
+                autoColumns="0fr 1fr 0fr"
                 autoRows="0fr 1fr"
-                templateAreas='"menu menu" "leftPane rightPane"'
+                templateAreas='"menu menu" "leftPane rightPane" "footer footer"'
                 w="100vw"
                 h="100vh"
             >
@@ -132,18 +130,17 @@ export const App: React.FC = function () {
                     {currentUserAction.type === 'todo' && <TodoForm target={userActionTarget || rawPythonPackage} />}
                 </GridItem>
                 <GridItem gridArea="rightPane" overflow="auto">
-                    <VStack h="100%" spacing={0}>
-                        <Box flexGrow={1} overflowY="auto" width="100%">
-                            <SelectionView />
-                        </Box>
-                        {currentUserAction.type === 'none' && <ActionBar declaration={declaration} />}
-                    </VStack>
+                    <SelectionView />
+                </GridItem>
+                <GridItem gridArea="footer" colSpan={2}>
+                    {currentUserAction.type === 'none' && <ActionBar declaration={declaration} />}
                 </GridItem>
 
                 {showAnnotationImportDialog && <AnnotationImportDialog />}
                 {showAPIImportDialog && <PackageDataImportDialog setFilter={setFilterString} />}
                 {showUsagesImportDialog && <UsageImportDialog />}
             </Grid>
+
             <Modal
                 isOpen={showInferErrorDialog}
                 onClose={() => setShowInferErrorDialog(false)}


### PR DESCRIPTION
Closes #657.

### Summary of Changes

The action bar now spans the full width of the screen rather than just the right pane.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/174153217-d1fa76f5-5dbc-4106-8111-d2137e815eb6.png)

