### PR TITLE
feat(gui): change "done" to "complete"

### DIFF
--- a/api-editor/gui/src/common/FilterHelpButton.tsx
+++ b/api-editor/gui/src/common/FilterHelpButton.tsx
@@ -48,9 +48,9 @@ export const FilterHelpButton = function () {
                             </ListItem>
                             <ListItem>
                                 <ChakraText>
-                                    <strong>is:done</strong>
+                                    <strong>is:complete</strong>
                                 </ChakraText>
-                                <ChakraText>Displays only elements that are marked as done.</ChakraText>
+                                <ChakraText>Displays only elements that are marked as complete.</ChakraText>
                             </ListItem>
                             <ListItem>
                                 <ChakraText>

--- a/api-editor/gui/src/features/annotations/AnnotationDropdown.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationDropdown.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Icon, Menu, MenuButton, MenuItem, MenuList } from '@chakra
 import React from 'react';
 import { FaChevronDown } from 'react-icons/fa';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
-import { addPure, addRemove, addRequired, selectDone } from './annotationSlice';
+import { addPure, addRemove, addRequired, selectComplete } from './annotationSlice';
 import {
     showAttributeAnnotationForm,
     showBoundaryAnnotationForm,
@@ -53,7 +53,7 @@ export const AnnotationDropdown: React.FC<AnnotationDropdownProps> = function ({
     target,
 }) {
     const dispatch = useAppDispatch();
-    const isDone = Boolean(useAppSelector(selectDone(target)));
+    const isComplete = Boolean(useAppSelector(selectComplete(target)));
 
     return (
         // Box gets rid of popper.js warning "CSS margin styles cannot be used"
@@ -64,7 +64,7 @@ export const AnnotationDropdown: React.FC<AnnotationDropdownProps> = function ({
                     size="sm"
                     variant="outline"
                     rightIcon={<Icon as={FaChevronDown} />}
-                    disabled={isDone}
+                    disabled={isComplete}
                 >
                     Annotations
                 </MenuButton>

--- a/api-editor/gui/src/features/annotations/AnnotationView.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationView.tsx
@@ -17,9 +17,9 @@ import {
     removeMove,
     removeOptional,
     removePure,
+    removeRemove,
     removeRenaming,
     removeRequired,
-    removeRemove,
     removeTodo,
     selectAttribute,
     selectBoundary,
@@ -31,11 +31,10 @@ import {
     selectMove,
     selectOptional,
     selectPure,
+    selectRemove,
     selectRenaming,
     selectRequired,
-    selectRemove,
     selectTodo,
-    selectComplete,
 } from './annotationSlice';
 import {
     showAttributeAnnotationForm,
@@ -249,16 +248,14 @@ interface AnnotationProps {
     onDelete: () => void;
 }
 
-const Annotation: React.FC<AnnotationProps> = function ({ target, name, onDelete, onEdit, type }) {
-    const isDone = Boolean(useAppSelector(selectComplete(target)));
-
+const Annotation: React.FC<AnnotationProps> = function ({ name, onDelete, onEdit, type }) {
     return (
         <ButtonGroup size="sm" variant="outline" isAttached>
             <Button
                 leftIcon={<FaWrench />}
                 flexGrow={1}
                 justifyContent="flex-start"
-                disabled={!onEdit || isDone}
+                disabled={!onEdit}
                 onClick={onEdit}
             >
                 @{type}
@@ -268,13 +265,7 @@ const Annotation: React.FC<AnnotationProps> = function ({ target, name, onDelete
                     </ChakraText>
                 )}
             </Button>
-            <IconButton
-                icon={<FaTrash />}
-                aria-label="Delete annotation"
-                colorScheme="red"
-                disabled={isDone}
-                onClick={onDelete}
-            />
+            <IconButton icon={<FaTrash />} aria-label="Delete annotation" colorScheme="red" onClick={onDelete} />
         </ButtonGroup>
     );
 };

--- a/api-editor/gui/src/features/annotations/AnnotationView.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationView.tsx
@@ -35,7 +35,7 @@ import {
     selectRequired,
     selectRemove,
     selectTodo,
-    selectDone,
+    selectComplete,
 } from './annotationSlice';
 import {
     showAttributeAnnotationForm,
@@ -250,7 +250,7 @@ interface AnnotationProps {
 }
 
 const Annotation: React.FC<AnnotationProps> = function ({ target, name, onDelete, onEdit, type }) {
-    const isDone = Boolean(useAppSelector(selectDone(target)));
+    const isDone = Boolean(useAppSelector(selectComplete(target)));
 
     return (
         <ButtonGroup size="sm" variant="outline" isAttached>

--- a/api-editor/gui/src/features/annotations/CompleteButton.tsx
+++ b/api-editor/gui/src/features/annotations/CompleteButton.tsx
@@ -2,32 +2,32 @@ import { Button, Icon } from '@chakra-ui/react';
 import React from 'react';
 import { FaCheck } from 'react-icons/fa';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
-import { addDone, removeDone, selectDone } from './annotationSlice';
+import { addComplete, removeComplete, selectComplete } from './annotationSlice';
 
-interface DoneButtonProps {
+interface CompleteButtonProps {
     target: string;
 }
 
-export const DoneButton: React.FC<DoneButtonProps> = function ({ target }) {
+export const CompleteButton: React.FC<CompleteButtonProps> = function ({ target }) {
     const dispatch = useAppDispatch();
-    const isDone = useAppSelector(selectDone(target));
+    const isComplete = useAppSelector(selectComplete(target));
 
-    if (isDone) {
+    if (isComplete) {
         return (
             <Button
                 size="sm"
                 variant="solid"
                 colorScheme="green"
                 rightIcon={<Icon as={FaCheck} />}
-                onClick={() => dispatch(removeDone(target))}
+                onClick={() => dispatch(removeComplete(target))}
             >
-                Done
+                Complete
             </Button>
         );
     } else {
         return (
-            <Button size="sm" variant="outline" onClick={() => dispatch(addDone({ target }))}>
-                Mark as done
+            <Button size="sm" variant="outline" onClick={() => dispatch(addComplete({ target }))}>
+                Mark as complete
             </Button>
         );
     }

--- a/api-editor/gui/src/features/annotations/annotationSlice.ts
+++ b/api-editor/gui/src/features/annotations/annotationSlice.ts
@@ -590,8 +590,8 @@ export const selectCalledAfters =
         selectAnnotations(state).calledAfters[target] ?? {};
 export const selectComplete =
     (target: string) =>
-        (state: RootState): CompleteAnnotation | undefined =>
-            selectAnnotations(state).completes[target];
+    (state: RootState): CompleteAnnotation | undefined =>
+        selectAnnotations(state).completes[target];
 export const selectConstant =
     (target: string) =>
     (state: RootState): ConstantAnnotation | undefined =>

--- a/api-editor/gui/src/features/annotations/annotationSlice.ts
+++ b/api-editor/gui/src/features/annotations/annotationSlice.ts
@@ -27,14 +27,14 @@ export interface AnnotationStore {
     calledAfters: {
         [target: string]: { [calledAfterName: string]: CalledAfterAnnotation };
     };
+    completes: {
+        [target: string]: CompleteAnnotation;
+    };
     constants: {
         [target: string]: ConstantAnnotation;
     };
     descriptions: {
         [target: string]: DescriptionAnnotation;
-    };
-    dones: {
-        [target: string]: DoneAnnotation;
     };
     enums: {
         [target: string]: EnumAnnotation;
@@ -154,6 +154,19 @@ export interface CalledAfterTarget {
     readonly calledAfterName: string;
 }
 
+/**
+ * The element is fully annotated and all annotations are checked.
+ *
+ * **Important:** While this is implemented as an annotation it should **not** be counted in the heat map or the
+ * statistics.
+ */
+export interface CompleteAnnotation {
+    /**
+     * ID of the annotated Python declaration.
+     */
+    readonly target: string;
+}
+
 export interface ConstantAnnotation {
     /**
      * ID of the annotated Python declaration
@@ -181,19 +194,6 @@ export interface DescriptionAnnotation {
      * Description for the declaration.
      */
     readonly newDescription: string;
-}
-
-/**
- * The element is fully annotated and all annotations are checked.
- *
- * **Important:** While this is implemented as an annotation it should **not** be counted in the heat map or the
- * statistics.
- */
-export interface DoneAnnotation {
-    /**
-     * ID of the annotated Python declaration.
-     */
-    readonly target: string;
 }
 
 export interface EnumAnnotation {
@@ -323,9 +323,9 @@ export const initialState: AnnotationStore = {
     attributes: {},
     boundaries: {},
     calledAfters: {},
+    completes: {},
     constants: {},
     descriptions: {},
-    dones: {},
     enums: {},
     groups: {},
     moves: {},
@@ -421,6 +421,12 @@ const annotationsSlice = createSlice({
                 delete state.calledAfters[action.payload.target];
             }
         },
+        addComplete(state, action: PayloadAction<CompleteAnnotation>) {
+            state.completes[action.payload.target] = action.payload;
+        },
+        removeComplete(state, action: PayloadAction<string>) {
+            delete state.completes[action.payload];
+        },
         upsertConstant(state, action: PayloadAction<ConstantAnnotation>) {
             state.constants[action.payload.target] = action.payload;
         },
@@ -432,12 +438,6 @@ const annotationsSlice = createSlice({
         },
         removeDescription(state, action: PayloadAction<string>) {
             delete state.descriptions[action.payload];
-        },
-        addDone(state, action: PayloadAction<DoneAnnotation>) {
-            state.dones[action.payload.target] = action.payload;
-        },
-        removeDone(state, action: PayloadAction<string>) {
-            delete state.dones[action.payload];
         },
         upsertEnum(state, action: PayloadAction<EnumAnnotation>) {
             state.enums[action.payload.target] = action.payload;
@@ -548,12 +548,12 @@ export const {
     removeBoundary,
     upsertCalledAfter,
     removeCalledAfter,
+    addComplete,
+    removeComplete,
     upsertConstant,
     removeConstant,
     upsertDescription,
     removeDescription,
-    addDone,
-    removeDone,
     upsertEnum,
     removeEnum,
     upsertGroup,
@@ -588,6 +588,10 @@ export const selectCalledAfters =
     (target: string) =>
     (state: RootState): { [calledAfter: string]: CalledAfterAnnotation } =>
         selectAnnotations(state).calledAfters[target] ?? {};
+export const selectComplete =
+    (target: string) =>
+        (state: RootState): CompleteAnnotation | undefined =>
+            selectAnnotations(state).completes[target];
 export const selectConstant =
     (target: string) =>
     (state: RootState): ConstantAnnotation | undefined =>
@@ -596,10 +600,6 @@ export const selectDescription =
     (target: string) =>
     (state: RootState): DescriptionAnnotation | undefined =>
         selectAnnotations(state).descriptions[target];
-export const selectDone =
-    (target: string) =>
-    (state: RootState): DoneAnnotation | undefined =>
-        selectAnnotations(state).dones[target];
 export const selectEnum =
     (target: string) =>
     (state: RootState): EnumAnnotation | undefined =>

--- a/api-editor/gui/src/features/packageData/model/filters/AnnotationFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/AnnotationFilter.ts
@@ -52,9 +52,9 @@ export class AnnotationFilter extends AbstractPythonFilter {
                     id in annotations.attributes ||
                     id in annotations.boundaries ||
                     id in annotations.calledAfters ||
+                    // Deliberately not checking annotations.complete. It should be transparent it's an annotation.
                     id in annotations.constants ||
                     id in annotations.descriptions ||
-                    // Deliberately not checking annotations.done. It should be transparent to users it's an annotation.
                     id in annotations.enums ||
                     id in annotations.groups ||
                     id in annotations.moves ||
@@ -71,12 +71,12 @@ export class AnnotationFilter extends AbstractPythonFilter {
                 return id in annotations.boundaries;
             case AnnotationType.CalledAfter:
                 return id in annotations.calledAfters;
+            case AnnotationType.Complete:
+                return id in annotations.completes;
             case AnnotationType.Constant:
                 return id in annotations.constants;
             case AnnotationType.Description:
                 return id in annotations.descriptions;
-            case AnnotationType.Done:
-                return id in annotations.dones;
             case AnnotationType.Enum:
                 return id in annotations.enums;
             case AnnotationType.Group:
@@ -106,9 +106,9 @@ export enum AnnotationType {
     Attribute,
     Boundary,
     CalledAfter,
+    Complete,
     Constant,
     Description,
-    Done,
     Enum,
     Group,
     Move,

--- a/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
@@ -97,12 +97,12 @@ const parsePositiveToken = function (token: string): Optional<AbstractPythonFilt
             return new AnnotationFilter(AnnotationType.Boundary);
         case 'annotation:@calledAfter':
             return new AnnotationFilter(AnnotationType.CalledAfter);
+        case 'is:complete': // Deliberate special case. It should be transparent to users it's an annotation.
+            return new AnnotationFilter(AnnotationType.Complete);
         case 'annotation:@constant':
             return new AnnotationFilter(AnnotationType.Constant);
         case 'annotation:@description':
             return new AnnotationFilter(AnnotationType.Description);
-        case 'is:done': // Deliberate special case. It should be transparent to users it's an annotation.
-            return new AnnotationFilter(AnnotationType.Done);
         case 'annotation:@enum':
             return new AnnotationFilter(AnnotationType.Enum);
         case 'annotation:@group':

--- a/api-editor/gui/src/features/packageData/selectionView/ClassView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ClassView.tsx
@@ -5,7 +5,7 @@ import { AnnotationView } from '../../annotations/AnnotationView';
 import { PythonClass } from '../model/PythonClass';
 import { DocumentationText } from './DocumentationText';
 import { SectionListViewItem } from './SectionListViewItem';
-import { DoneButton } from '../../annotations/DoneButton';
+import { CompleteButton } from '../../annotations/CompleteButton';
 
 interface ClassViewProps {
     pythonClass: PythonClass;
@@ -24,7 +24,7 @@ export const ClassView: React.FC<ClassViewProps> = function ({ pythonClass }) {
                     {pythonClass.isPublic && (
                         <>
                             <AnnotationDropdown target={id} showDescription showMove showRemove showRename showTodo />
-                            <DoneButton target={id} />
+                            <CompleteButton target={id} />
                         </>
                     )}
                 </HStack>

--- a/api-editor/gui/src/features/packageData/selectionView/FunctionView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/FunctionView.tsx
@@ -9,7 +9,7 @@ import { DocumentationText } from './DocumentationText';
 import { ParameterNode } from './ParameterNode';
 import { useAppSelector } from '../../../app/hooks';
 import { selectCalledAfters } from '../../annotations/annotationSlice';
-import { DoneButton } from '../../annotations/DoneButton';
+import { CompleteButton } from '../../annotations/CompleteButton';
 
 interface FunctionViewProps {
     pythonFunction: PythonFunction;
@@ -44,7 +44,7 @@ export const FunctionView: React.FC<FunctionViewProps> = function ({ pythonFunct
                                 showRename
                                 showTodo
                             />
-                            <DoneButton target={id} />
+                            <CompleteButton target={id} />
                         </>
                     )}
                 </HStack>

--- a/api-editor/gui/src/features/packageData/selectionView/ParameterNode.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ParameterNode.tsx
@@ -4,7 +4,7 @@ import { AnnotationDropdown } from '../../annotations/AnnotationDropdown';
 import { AnnotationView } from '../../annotations/AnnotationView';
 import { PythonParameter } from '../model/PythonParameter';
 import { DocumentationText } from './DocumentationText';
-import { DoneButton } from '../../annotations/DoneButton';
+import { CompleteButton } from '../../annotations/CompleteButton';
 
 interface ParameterNodeProps {
     pythonParameter: PythonParameter;
@@ -42,7 +42,7 @@ export const ParameterNode: React.FC<ParameterNodeProps> = function ({ isTitle, 
                             showRename
                             showRequired
                         />
-                        <DoneButton target={id} />
+                        <CompleteButton target={id} />
                     </>
                 )}
             </HStack>


### PR DESCRIPTION
### Summary of Changes

API elements can now be marked as "complete" rather than "done". The semantics are that no further annotations need to be added to this element. Therefore, it also only prevents adding new annotations. Existing annotations can still be edited.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/174260392-0217d869-3ffe-4abd-9886-4222ec5b6cbf.png)

![image](https://user-images.githubusercontent.com/2501322/174260459-8be77e5b-c345-4127-b3d7-1e52fe11e7ec.png)

