### PR TITLE
fix(gui): `annotation:@calledAfter` not seen as valid filter

### DIFF
--- a/api-editor/gui/src/features/packageData/model/filters/filterFactory.test.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/filterFactory.test.ts
@@ -90,18 +90,18 @@ describe('createFilterFromString', () => {
 });
 
 describe('isValidFilterToken', () => {
-    test.each`
-        token                    | expectedResult
-        ${'is:public'}           | ${true}
-        ${'!is:public'}          | ${true}
-        ${'name:foo'}            | ${true}
-        ${'usages:>2'}           | ${true}
-        ${'usefulness:>2'}       | ${true}
-        ${'is:'}                 | ${false}
-        ${'is:public:'}          | ${false}
-        ${'annotations:any'}     | ${false}
-        ${'annotation:optional'} | ${false}
-    `("handles detect valid/invalid tokens (token: '$token')", ({ token, expectedResult }) => {
+    test.each([
+        ['is:public', true],
+        ['!is:public', true],
+        ['name:foo', true],
+        ['usages:>2', true],
+        ['usefulness:>2', true],
+        ['annotation:@calledAfter', true], // https://github.com/lars-reimann/api-editor/issues/669
+        ['is:', false],
+        ['is:public:', false],
+        ['annotations:any', false],
+        ['annotation:optional', false],
+    ])("handles detect valid/invalid tokens (token: '%s')", (token: string, expectedResult: boolean) => {
         expect(isValidFilterToken(token)).toBe(expectedResult);
     });
 });

--- a/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
@@ -95,7 +95,7 @@ const parsePositiveToken = function (token: string): Optional<AbstractPythonFilt
             return new AnnotationFilter(AnnotationType.Attribute);
         case 'annotation:@boundary':
             return new AnnotationFilter(AnnotationType.Boundary);
-        case 'annotation:@calledAfter':
+        case 'annotation:@calledafter':
             return new AnnotationFilter(AnnotationType.CalledAfter);
         case 'is:complete': // Deliberate special case. It should be transparent to users it's an annotation.
             return new AnnotationFilter(AnnotationType.Complete);


### PR DESCRIPTION
Closes #669.

### Summary of Changes

`annotation:@calledAfter` works now.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/174357090-a5eaf2c4-85d1-4ac7-9451-35624b4f00cd.png)


