### PR TITLE
feat(gui): go to parent

### DIFF
--- a/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
@@ -29,6 +29,7 @@ export const ActionBar: React.FC<ActionBarProps> = function ({ declaration }) {
     return (
         <HStack borderTop={1} layerStyle="subtleBorder" padding="0.5em 1em" marginTop={0} w="100%">
             <Button
+                accessKey="p"
                 disabled={!declaration}
                 onClick={() => {
                     let navStr = getPreviousElementPath(
@@ -51,6 +52,7 @@ export const ActionBar: React.FC<ActionBarProps> = function ({ declaration }) {
                 Previous
             </Button>
             <Button
+                accessKey="n"
                 disabled={!declaration}
                 onClick={() => {
                     let navStr = getNextElementPath(allDeclarations, declaration!, pythonFilter, annotations, usages);

--- a/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
@@ -68,6 +68,19 @@ export const ActionBar: React.FC<ActionBarProps> = function ({ declaration }) {
             >
                 Next
             </Button>
+
+            <Button
+                accessKey="p"
+                onClick={() => {
+                    const parent = declaration?.parent();
+                    if (parent && !(parent instanceof PythonPackage)) {
+                        navigate(`/${parent.id}`);
+                    }
+                }}
+            >
+                Go to parent
+            </Button>
+
             <Button
                 accessKey="a"
                 onClick={() => {
@@ -84,6 +97,7 @@ export const ActionBar: React.FC<ActionBarProps> = function ({ declaration }) {
             >
                 Collapse All
             </Button>
+
             <Button
                 accessKey="y"
                 disabled={!declaration}

--- a/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ActionBar.tsx
@@ -70,7 +70,7 @@ export const ActionBar: React.FC<ActionBarProps> = function ({ declaration }) {
             </Button>
 
             <Button
-                accessKey="p"
+                accessKey="u"
                 onClick={() => {
                     const parent = declaration?.parent();
                     if (parent && !(parent instanceof PythonPackage)) {


### PR DESCRIPTION
Closes #672.

### Summary of Changes

* Add a button to the action bar to go to the parent of the selected element. It can also be activated by pressing `Alt+U` (up).
* Add missing keyboard shortcuts: `Alt+P` for previous, `Alt+N` for next.