### PR TITLE
feat(gui): show validation messages in form of batch rename and move

### DIFF
--- a/api-editor/gui/src/features/annotations/batchforms/DestinationBatchForm.tsx
+++ b/api-editor/gui/src/features/annotations/batchforms/DestinationBatchForm.tsx
@@ -1,4 +1,4 @@
-import { FormLabel, Input } from '@chakra-ui/react';
+import { FormControl, FormErrorIcon, FormErrorMessage, FormLabel, Input } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useAppDispatch } from '../../../app/hooks';
@@ -24,7 +24,11 @@ export const DestinationBatchForm: React.FC<DestinationBatchFormProps> = functio
 }) {
     const dispatch = useAppDispatch();
 
-    const { handleSubmit, register } = useForm<DestinationBatchFormState>({
+    const {
+        handleSubmit,
+        register,
+        formState: { errors },
+    } = useForm<DestinationBatchFormState>({
         defaultValues: {
             destination: '',
         },
@@ -59,12 +63,18 @@ export const DestinationBatchForm: React.FC<DestinationBatchFormProps> = functio
                 onConfirm={handleSubmit(handleConfirm)}
                 onCancel={handleCancel}
             >
-                <FormLabel>Destination module:</FormLabel>
-                <Input
-                    {...register('destination', {
-                        required: 'This is required.',
-                    })}
-                />
+                <FormControl isInvalid={Boolean(errors?.destination)}>
+                    <FormLabel>Destination module:</FormLabel>
+                    <Input
+                        {...register('destination', {
+                            required: 'This is required.',
+                        })}
+                    />
+                    <FormErrorMessage>
+                        <FormErrorIcon /> {errors.destination?.message}
+                    </FormErrorMessage>
+                </FormControl>
+
                 <FormLabel>This will annotate classes and global functions.</FormLabel>
             </AnnotationBatchForm>
             {confirmWindowVisible && (

--- a/api-editor/gui/src/features/annotations/batchforms/OldNewBatchForm.tsx
+++ b/api-editor/gui/src/features/annotations/batchforms/OldNewBatchForm.tsx
@@ -6,6 +6,9 @@ import {
     AlertDialogHeader,
     AlertDialogOverlay,
     Button,
+    FormControl,
+    FormErrorIcon,
+    FormErrorMessage,
     FormLabel,
     Heading,
     Input,
@@ -37,7 +40,11 @@ export const OldNewBatchForm: React.FC<OldNewBatchFormProps> = function ({
 }) {
     const dispatch = useAppDispatch();
 
-    const { handleSubmit, register } = useForm<OldNewBatchFormState>({
+    const {
+        handleSubmit,
+        register,
+        formState: { errors },
+    } = useForm<OldNewBatchFormState>({
         defaultValues: {
             oldString: '',
             newString: '',
@@ -73,19 +80,30 @@ export const OldNewBatchForm: React.FC<OldNewBatchFormProps> = function ({
                 onConfirm={handleSubmit(handleConfirm)}
                 onCancel={handleCancel}
             >
-                <FormLabel>String to be replaced:</FormLabel>
-                <Input
-                    {...register('oldString', {
-                        required: 'This is required.',
-                    })}
-                />
+                <FormControl isInvalid={Boolean(errors.oldString)}>
+                    <FormLabel>String to be replaced:</FormLabel>
+                    <Input
+                        {...register('oldString', {
+                            required: 'This is required.',
+                        })}
+                    />
+                    <FormErrorMessage>
+                        <FormErrorIcon /> {errors.oldString?.message}
+                    </FormErrorMessage>
+                </FormControl>
 
-                <FormLabel>Replacement String:</FormLabel>
-                <Input
-                    {...register('newString', {
-                        required: 'This is required.',
-                    })}
-                />
+                <FormControl isInvalid={Boolean(errors.newString)}>
+                    <FormLabel>Replacement String:</FormLabel>
+                    <Input
+                        {...register('newString', {
+                            required: 'This is required.',
+                        })}
+                    />
+                    <FormErrorMessage>
+                        <FormErrorIcon /> {errors.newString?.message}
+                    </FormErrorMessage>
+                </FormControl>
+
                 <FormLabel>This will annotate classes, functions, and parameters.</FormLabel>
             </AnnotationBatchForm>
             {confirmWindowVisible && (


### PR DESCRIPTION
Closes #675.

### Summary of Changes

Show the validation messages of the input fields in the forms for batch rename and batch move.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/174403145-c410426e-91ad-4fe4-b575-d4cb37790aff.png)

![image](https://user-images.githubusercontent.com/2501322/174403177-f07b05b7-ef7b-4801-93f5-e661fd4e821a.png)

