### PR TITLE
fix(gui): properly collapse subtree in tree view

### DIFF
--- a/api-editor/gui/src/features/packageData/treeView/TreeNode.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/TreeNode.tsx
@@ -9,6 +9,7 @@ import {
     HeatMapMode,
     selectHeatMapMode,
     selectIsExpandedInTreeView,
+    setAllCollapsedInTreeView,
     toggleIsExpandedInTreeView,
 } from '../../ui/uiSlice';
 import { VisibilityIndicator } from './VisibilityIndicator';
@@ -60,16 +61,24 @@ export const TreeNode: React.FC<TreeNodeProps> = function ({
 
     const fontWeight = filter.shouldKeepDeclaration(declaration, annotations, usages) ? 'bold' : undefined;
 
+    const toggleExpanded = () => {
+        if (showChildren) {
+            dispatch(setAllCollapsedInTreeView([...declaration.descendantsOrSelf()].map((d) => d.id)));
+        } else {
+            dispatch(toggleIsExpandedInTreeView(declaration.id));
+        }
+    };
+
     const handleNodeClick = (event: MouseEvent) => {
         if (event.shiftKey) {
-            dispatch(toggleIsExpandedInTreeView(declaration.id));
+            toggleExpanded();
         } else {
             navigate(`/${declaration.id}`);
         }
     };
 
     const handleVisibilityIndicatorClick = (event: MouseEvent) => {
-        dispatch(toggleIsExpandedInTreeView(declaration.id));
+        toggleExpanded();
         event.stopPropagation();
     };
 


### PR DESCRIPTION
Closes #680.

### Summary of Changes

Collapse all descendent nodes when the root of a subtree is collapsed.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/174437467-37f995f8-c266-42cc-9664-e9610b482460.png)

![image](https://user-images.githubusercontent.com/2501322/174437499-f8251a41-1f73-47fd-b831-33229a86148b.png)

