### PR TITLE
feat(gui): more ways to filter by name

### DIFF
--- a/api-editor/gui/src/common/FilterHelpButton.tsx
+++ b/api-editor/gui/src/common/FilterHelpButton.tsx
@@ -72,10 +72,18 @@ export const FilterHelpButton = function () {
                             </ListItem>
                             <ListItem>
                                 <ChakraText>
-                                    <strong>name:xy</strong>
+                                    <strong>name:[substring]</strong>
                                 </ChakraText>
                                 <ChakraText>
-                                    Displays only elements with names that contain the given string xy.
+                                    Displays only elements with names that contain the given [substring].
+                                </ChakraText>
+                            </ListItem>
+                            <ListItem>
+                                <ChakraText>
+                                    <strong>name:/[regex]/</strong>
+                                </ChakraText>
+                                <ChakraText>
+                                    Displays only elements with names that match the given [regex].
                                 </ChakraText>
                             </ListItem>
                             <ListItem>

--- a/api-editor/gui/src/common/FilterHelpButton.tsx
+++ b/api-editor/gui/src/common/FilterHelpButton.tsx
@@ -72,10 +72,12 @@ export const FilterHelpButton = function () {
                             </ListItem>
                             <ListItem>
                                 <ChakraText>
-                                    <strong>name:[substring]</strong>
+                                    <strong>name:[operator][string]</strong>
                                 </ChakraText>
                                 <ChakraText>
-                                    Displays only elements with names that contain the given [substring].
+                                    Displays only elements with matching names. Replace [operator] with <em>=</em> to
+                                    display only elements that match the [string] exactly or with <em>~</em> to display
+                                    only elements that match the [string] as a substring.
                                 </ChakraText>
                             </ListItem>
                             <ListItem>

--- a/api-editor/gui/src/common/FilterHelpButton.tsx
+++ b/api-editor/gui/src/common/FilterHelpButton.tsx
@@ -75,18 +75,16 @@ export const FilterHelpButton = function () {
                                     <strong>name:[operator][string]</strong>
                                 </ChakraText>
                                 <ChakraText>
-                                    Displays only elements with matching names. Replace [operator] with <em>=</em> to
-                                    display only elements that match the [string] exactly or with <em>~</em> to display
-                                    only elements that match the [string] as a substring.
+                                    Displays only elements with matching names (case-sensitive). Replace [operator] with{' '}
+                                    <em>=</em> to display only elements that match the [string] exactly or with{' '}
+                                    <em>~</em> to display only elements that contain the [string] as a substring.
                                 </ChakraText>
                             </ListItem>
                             <ListItem>
                                 <ChakraText>
                                     <strong>name:/[regex]/</strong>
                                 </ChakraText>
-                                <ChakraText>
-                                    Displays only elements with names that match the given [regex].
-                                </ChakraText>
+                                <ChakraText>Displays only elements with names that match the given [regex].</ChakraText>
                             </ListItem>
                             <ListItem>
                                 <ChakraText>
@@ -114,8 +112,8 @@ export const FilterHelpButton = function () {
                                 </ChakraText>
                                 <ChakraText>
                                     Displays only elements that are used a certain number of times. Replace [operator]
-                                    with one of <em>&lt;, &lt;=, &gt;=, &gt;</em> or omit it to match by equality.
-                                    Replace [expected] with the expected number of usages.
+                                    with one of <em>&lt;, &lt;=, =, &gt;=, &gt;</em>. Replace [expected] with the
+                                    expected number of usages.
                                 </ChakraText>
                             </ListItem>
                             <ListItem>
@@ -124,8 +122,8 @@ export const FilterHelpButton = function () {
                                 </ChakraText>
                                 <ChakraText>
                                     Displays only elements that have a certain usefulness. Replace [operator] with one
-                                    of <em>&lt;, &lt;=, &gt;=, &gt;</em> or omit it to match by equality. Replace
-                                    [expected] with the expected usefulness.
+                                    of <em>&lt;, &lt;=, =, &gt;=, &gt;</em>. Replace [expected] with the expected
+                                    usefulness.
                                 </ChakraText>
                             </ListItem>
                             <ListItem>

--- a/api-editor/gui/src/features/packageData/model/filters/AbstractPythonFilter.test.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/AbstractPythonFilter.test.ts
@@ -90,7 +90,7 @@ beforeEach(() => {
 
 describe('AbstractPythonFilter::applyToPackage', () => {
     test('keeps modules for which the filter returns true, and their ancestors.', () => {
-        const filter = new NameStringFilter('test_module_1');
+        const filter = new NameStringFilter('test_module_1', false);
         const filteredPackage = filter.applyToPackage(pythonPackage, annotations, new UsageCountStore());
 
         const modules = filteredPackage.modules;
@@ -104,7 +104,7 @@ describe('AbstractPythonFilter::applyToPackage', () => {
     });
 
     test('keeps classes for which the filter returns true, their ancestors, and their descendants', () => {
-        const filter = new NameStringFilter('test_class_1');
+        const filter = new NameStringFilter('test_class_1', false);
         const filteredPackage = filter.applyToPackage(pythonPackage, annotations, new UsageCountStore());
 
         const modules = filteredPackage.modules;
@@ -121,7 +121,7 @@ describe('AbstractPythonFilter::applyToPackage', () => {
     });
 
     test('keeps methods for which the filter returns true, their ancestors, and their descendants', () => {
-        const filter = new NameStringFilter('test_method_1');
+        const filter = new NameStringFilter('test_method_1', false);
         const filteredPackage = filter.applyToPackage(pythonPackage, annotations, new UsageCountStore());
 
         const modules = filteredPackage.modules;
@@ -141,7 +141,7 @@ describe('AbstractPythonFilter::applyToPackage', () => {
     });
 
     test('keeps global functions for which the filter returns true, their ancestors, and their descendants', () => {
-        const filter = new NameStringFilter('test_global_function_1');
+        const filter = new NameStringFilter('test_global_function_1', false);
         const filteredPackage = filter.applyToPackage(pythonPackage, annotations, new UsageCountStore());
 
         const modules = filteredPackage.modules;
@@ -158,7 +158,7 @@ describe('AbstractPythonFilter::applyToPackage', () => {
     });
 
     test('keeps parameters for which the filter returns true, their ancestors, and their descendants', () => {
-        const filter = new NameStringFilter('test_parameter_1');
+        const filter = new NameStringFilter('test_parameter_1', false);
         const filteredPackage = filter.applyToPackage(pythonPackage, annotations, new UsageCountStore());
 
         const modules = filteredPackage.modules;

--- a/api-editor/gui/src/features/packageData/model/filters/AbstractPythonFilter.test.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/AbstractPythonFilter.test.ts
@@ -5,7 +5,7 @@ import { PythonParameter } from '../PythonParameter';
 import { PythonModule } from '../PythonModule';
 import { PythonClass } from '../PythonClass';
 import { PythonFunction } from '../PythonFunction';
-import { NameFilter } from './NameFilter';
+import { NameStringFilter } from './NameStringFilter';
 import { initialAnnotationStore as annotations } from '../../../annotations/annotationSlice';
 import { PythonDeclaration } from '../PythonDeclaration';
 import { UsageCountStore } from '../../../usages/model/UsageCountStore';
@@ -90,7 +90,7 @@ beforeEach(() => {
 
 describe('AbstractPythonFilter::applyToPackage', () => {
     test('keeps modules for which the filter returns true, and their ancestors.', () => {
-        const filter = new NameFilter('test_module_1');
+        const filter = new NameStringFilter('test_module_1');
         const filteredPackage = filter.applyToPackage(pythonPackage, annotations, new UsageCountStore());
 
         const modules = filteredPackage.modules;
@@ -104,7 +104,7 @@ describe('AbstractPythonFilter::applyToPackage', () => {
     });
 
     test('keeps classes for which the filter returns true, their ancestors, and their descendants', () => {
-        const filter = new NameFilter('test_class_1');
+        const filter = new NameStringFilter('test_class_1');
         const filteredPackage = filter.applyToPackage(pythonPackage, annotations, new UsageCountStore());
 
         const modules = filteredPackage.modules;
@@ -121,7 +121,7 @@ describe('AbstractPythonFilter::applyToPackage', () => {
     });
 
     test('keeps methods for which the filter returns true, their ancestors, and their descendants', () => {
-        const filter = new NameFilter('test_method_1');
+        const filter = new NameStringFilter('test_method_1');
         const filteredPackage = filter.applyToPackage(pythonPackage, annotations, new UsageCountStore());
 
         const modules = filteredPackage.modules;
@@ -141,7 +141,7 @@ describe('AbstractPythonFilter::applyToPackage', () => {
     });
 
     test('keeps global functions for which the filter returns true, their ancestors, and their descendants', () => {
-        const filter = new NameFilter('test_global_function_1');
+        const filter = new NameStringFilter('test_global_function_1');
         const filteredPackage = filter.applyToPackage(pythonPackage, annotations, new UsageCountStore());
 
         const modules = filteredPackage.modules;
@@ -158,7 +158,7 @@ describe('AbstractPythonFilter::applyToPackage', () => {
     });
 
     test('keeps parameters for which the filter returns true, their ancestors, and their descendants', () => {
-        const filter = new NameFilter('test_parameter_1');
+        const filter = new NameStringFilter('test_parameter_1');
         const filteredPackage = filter.applyToPackage(pythonPackage, annotations, new UsageCountStore());
 
         const modules = filteredPackage.modules;

--- a/api-editor/gui/src/features/packageData/model/filters/NameRegexFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/NameRegexFilter.ts
@@ -19,7 +19,7 @@ export class NameRegexFilter extends AbstractPythonFilter {
     constructor(regex: string) {
         super();
 
-        this.regex = RegExp(regex, "u");
+        this.regex = RegExp(regex, 'u');
     }
 
     shouldKeepModule(pythonModule: PythonModule, annotations: AnnotationStore, usages: UsageCountStore): boolean {

--- a/api-editor/gui/src/features/packageData/model/filters/NameRegexFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/NameRegexFilter.ts
@@ -1,0 +1,52 @@
+import { PythonClass } from '../PythonClass';
+import { PythonFunction } from '../PythonFunction';
+import { PythonModule } from '../PythonModule';
+import { PythonParameter } from '../PythonParameter';
+import { AbstractPythonFilter } from './AbstractPythonFilter';
+import { PythonDeclaration } from '../PythonDeclaration';
+import { AnnotationStore } from '../../../annotations/annotationSlice';
+import { UsageCountStore } from '../../../usages/model/UsageCountStore';
+
+/**
+ * Keeps only declarations that have a name matching the given regex.
+ */
+export class NameRegexFilter extends AbstractPythonFilter {
+    readonly regex: RegExp;
+
+    /**
+     * @param regex The regex that must match the name of the declaration.
+     */
+    constructor(regex: string) {
+        super();
+
+        this.regex = RegExp(regex, "u");
+    }
+
+    shouldKeepModule(pythonModule: PythonModule, annotations: AnnotationStore, usages: UsageCountStore): boolean {
+        return this.shouldKeepDeclaration(pythonModule, annotations, usages);
+    }
+
+    shouldKeepClass(pythonClass: PythonClass, annotations: AnnotationStore, usages: UsageCountStore): boolean {
+        return this.shouldKeepDeclaration(pythonClass, annotations, usages);
+    }
+
+    shouldKeepFunction(pythonFunction: PythonFunction, annotations: AnnotationStore, usages: UsageCountStore): boolean {
+        return this.shouldKeepDeclaration(pythonFunction, annotations, usages);
+    }
+
+    shouldKeepParameter(
+        pythonParameter: PythonParameter,
+        annotations: AnnotationStore,
+        usages: UsageCountStore,
+    ): boolean {
+        return this.shouldKeepDeclaration(pythonParameter, annotations, usages);
+    }
+
+    shouldKeepDeclaration(
+        pythonDeclaration: PythonDeclaration,
+        _annotations: AnnotationStore,
+        _usages: UsageCountStore,
+    ): boolean {
+        return this.regex.test(pythonDeclaration.name);
+    }
+}

--- a/api-editor/gui/src/features/packageData/model/filters/NameStringFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/NameStringFilter.ts
@@ -10,7 +10,7 @@ import { UsageCountStore } from '../../../usages/model/UsageCountStore';
 /**
  * Keeps only declarations that have a given string in their name.
  */
-export class NameFilter extends AbstractPythonFilter {
+export class NameStringFilter extends AbstractPythonFilter {
     /**
      * @param substring The string that must be part of the name of the declaration.
      */

--- a/api-editor/gui/src/features/packageData/model/filters/NameStringFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/NameStringFilter.ts
@@ -11,7 +11,6 @@ import { UsageCountStore } from '../../../usages/model/UsageCountStore';
  * Keeps only declarations that have a given string in their name.
  */
 export class NameStringFilter extends AbstractPythonFilter {
-
     /**
      * @param string The string that must be part of the name of the declaration.
      * @param matchExactly Whether the name must match the substring exactly.

--- a/api-editor/gui/src/features/packageData/model/filters/NameStringFilter.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/NameStringFilter.ts
@@ -11,10 +11,12 @@ import { UsageCountStore } from '../../../usages/model/UsageCountStore';
  * Keeps only declarations that have a given string in their name.
  */
 export class NameStringFilter extends AbstractPythonFilter {
+
     /**
-     * @param substring The string that must be part of the name of the declaration.
+     * @param string The string that must be part of the name of the declaration.
+     * @param matchExactly Whether the name must match the substring exactly.
      */
-    constructor(readonly substring: string) {
+    constructor(readonly string: string, readonly matchExactly: boolean) {
         super();
     }
 
@@ -43,6 +45,10 @@ export class NameStringFilter extends AbstractPythonFilter {
         _annotations: AnnotationStore,
         _usages: UsageCountStore,
     ): boolean {
-        return pythonDeclaration.name.toLowerCase().includes(this.substring.toLowerCase());
+        if (this.matchExactly) {
+            return pythonDeclaration.name === this.string;
+        } else {
+            return pythonDeclaration.name.includes(this.string);
+        }
     }
 }

--- a/api-editor/gui/src/features/packageData/model/filters/filterFactory.test.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/filterFactory.test.ts
@@ -2,7 +2,7 @@ import { createFilterFromString, isValidFilterToken } from './filterFactory';
 import { ConjunctiveFilter } from './ConjunctiveFilter';
 import { Visibility, VisibilityFilter } from './VisibilityFilter';
 import { NegatedFilter } from './NegatedFilter';
-import { NameFilter } from './NameFilter';
+import { NameStringFilter } from './NameStringFilter';
 import { UsageFilter } from './UsageFilter';
 import { UsefulnessFilter } from './UsefulnessFilter';
 import { greaterThan } from './comparisons';
@@ -62,8 +62,8 @@ describe('createFilterFromString', () => {
         expect((completeFilter as ConjunctiveFilter).filters).toHaveLength(1);
 
         const positiveFilter = (completeFilter as ConjunctiveFilter).filters[0];
-        expect(positiveFilter).toBeInstanceOf(NameFilter);
-        expect((positiveFilter as NameFilter).substring).toBe('foo');
+        expect(positiveFilter).toBeInstanceOf(NameStringFilter);
+        expect((positiveFilter as NameStringFilter).substring).toBe('foo');
     });
 
     test('handles usages filter', () => {

--- a/api-editor/gui/src/features/packageData/model/filters/filterFactory.test.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/filterFactory.test.ts
@@ -63,7 +63,7 @@ describe('createFilterFromString', () => {
 
         const positiveFilter = (completeFilter as ConjunctiveFilter).filters[0];
         expect(positiveFilter).toBeInstanceOf(NameStringFilter);
-        expect((positiveFilter as NameStringFilter).substring).toBe('foo');
+        expect((positiveFilter as NameStringFilter).string).toBe('foo');
     });
 
     test('handles usages filter', () => {

--- a/api-editor/gui/src/features/packageData/model/filters/filterFactory.test.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/filterFactory.test.ts
@@ -57,7 +57,7 @@ describe('createFilterFromString', () => {
     });
 
     test('handles name filter', () => {
-        const completeFilter = createFilterFromString('name:foo');
+        const completeFilter = createFilterFromString('name:=foo');
         expect(completeFilter).toBeInstanceOf(ConjunctiveFilter);
         expect((completeFilter as ConjunctiveFilter).filters).toHaveLength(1);
 
@@ -93,7 +93,7 @@ describe('isValidFilterToken', () => {
     test.each([
         ['is:public', true],
         ['!is:public', true],
-        ['name:foo', true],
+        ['name:=foo', true],
         ['usages:>2', true],
         ['usefulness:>2', true],
         ['annotation:@calledAfter', true], // https://github.com/lars-reimann/api-editor/issues/669

--- a/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
@@ -12,7 +12,7 @@ import { equals, greaterThan, greaterThanOrEqual, lessThan, lessThanOrEqual } fr
 import { ParameterAssignmentFilter } from './ParameterAssignmentFilter';
 import { PythonParameterAssignment } from '../PythonParameter';
 import { RequiredOrOptional, RequiredOrOptionalFilter } from './RequiredOrOptionalFilter';
-import {NameRegexFilter} from "./NameRegexFilter";
+import { NameRegexFilter } from './NameRegexFilter';
 
 /**
  * Creates a filter from the given string. This method handles conjunctions, negations, and non-negated tokens.
@@ -128,10 +128,7 @@ const parsePositiveToken = function (token: string): Optional<AbstractPythonFilt
     const nameStringMatch = /^name:(?<comparison>[=~])(?<name>\w+)$/u.exec(token);
     if (nameStringMatch) {
         const comparisonOperator = nameStringMatch?.groups?.comparison as string;
-        return new NameStringFilter(
-            nameStringMatch?.groups?.name as string,
-            comparisonOperator === '='
-        );
+        return new NameStringFilter(nameStringMatch?.groups?.name as string, comparisonOperator === '=');
     }
 
     const nameRegexMatch = /^name:\/(?<regex>.*)\/$/u.exec(token);

--- a/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
@@ -1,5 +1,5 @@
 import { ConjunctiveFilter } from './ConjunctiveFilter';
-import { NameFilter } from './NameFilter';
+import { NameStringFilter } from './NameStringFilter';
 import { AbstractPythonFilter } from './AbstractPythonFilter';
 import { DeclarationType, DeclarationTypeFilter } from './DeclarationTypeFilter';
 import { Visibility, VisibilityFilter } from './VisibilityFilter';
@@ -12,6 +12,7 @@ import { equals, greaterThan, greaterThanOrEqual, lessThan, lessThanOrEqual } fr
 import { ParameterAssignmentFilter } from './ParameterAssignmentFilter';
 import { PythonParameterAssignment } from '../PythonParameter';
 import { RequiredOrOptional, RequiredOrOptionalFilter } from './RequiredOrOptionalFilter';
+import {NameRegexFilter} from "./NameRegexFilter";
 
 /**
  * Creates a filter from the given string. This method handles conjunctions, negations, and non-negated tokens.
@@ -124,9 +125,14 @@ const parsePositiveToken = function (token: string): Optional<AbstractPythonFilt
     }
 
     // Name
-    const nameMatch = /^name:(?<name>\w+)$/u.exec(token);
-    if (nameMatch) {
-        return new NameFilter(nameMatch?.groups?.name as string);
+    const nameStringMatch = /^name:(?<name>\w+)$/u.exec(token);
+    if (nameStringMatch) {
+        return new NameStringFilter(nameStringMatch?.groups?.name as string);
+    }
+
+    const nameRegexMatch = /^name:\/(?<regex>.*)\/$/u.exec(token);
+    if (nameRegexMatch) {
+        return new NameRegexFilter(nameRegexMatch?.groups?.regex as string);
     }
 
     // Usages

--- a/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
@@ -125,9 +125,13 @@ const parsePositiveToken = function (token: string): Optional<AbstractPythonFilt
     }
 
     // Name
-    const nameStringMatch = /^name:(?<name>\w+)$/u.exec(token);
+    const nameStringMatch = /^name:(?<comparison>[=~])(?<name>\w+)$/u.exec(token);
     if (nameStringMatch) {
-        return new NameStringFilter(nameStringMatch?.groups?.name as string);
+        const comparisonOperator = nameStringMatch?.groups?.comparison as string;
+        return new NameStringFilter(
+            nameStringMatch?.groups?.name as string,
+            comparisonOperator === '='
+        );
     }
 
     const nameRegexMatch = /^name:\/(?<regex>.*)\/$/u.exec(token);

--- a/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
+++ b/api-editor/gui/src/features/packageData/model/filters/filterFactory.ts
@@ -140,7 +140,7 @@ const parsePositiveToken = function (token: string): Optional<AbstractPythonFilt
     }
 
     // Usages
-    const usageMatch = /^usages(?<comparison>:(<|<=|>=|>)?)(?<expected>\d+)$/u.exec(token);
+    const usageMatch = /^usages:(?<comparison>(<|<=|=|>=|>)?)(?<expected>\d+)$/u.exec(token);
     if (usageMatch) {
         const comparisonOperator = usageMatch?.groups?.comparison as string;
         const comparison = comparisonFunction(comparisonOperator);
@@ -154,7 +154,7 @@ const parsePositiveToken = function (token: string): Optional<AbstractPythonFilt
     }
 
     // Usefulness
-    const usefulnessMatch = /^usefulness(?<comparison>:(<|<=|>=|>)?)(?<expected>\d+)$/u.exec(token);
+    const usefulnessMatch = /^usefulness:(?<comparison>(<|<=|=|>=|>)?)(?<expected>\d+)$/u.exec(token);
     if (usefulnessMatch) {
         const comparisonOperator = usefulnessMatch?.groups?.comparison as string;
         const comparison = comparisonFunction(comparisonOperator);
@@ -170,15 +170,15 @@ const parsePositiveToken = function (token: string): Optional<AbstractPythonFilt
 
 const comparisonFunction = function (comparisonOperator: string): ((a: number, b: number) => boolean) | null {
     switch (comparisonOperator) {
-        case ':<':
+        case '<':
             return lessThan;
-        case ':<=':
+        case '<=':
             return lessThanOrEqual;
-        case ':':
+        case '=':
             return equals;
-        case ':>=':
+        case '>=':
             return greaterThanOrEqual;
-        case ':>':
+        case '>':
             return greaterThan;
         default:
             return null;


### PR DESCRIPTION
Closes #682.

### Summary of Changes

* Change `name:xy` to `name:~xy` (substring matching)
* `name:~xy` is now case-sensitve
* Add `name:=xy` for exact matching of the name (also case-sensitive)
* Add `name:/xy/ to match the name by a regex
* Change `usages:20` to `usages:=20`
* Change `usefulness:20` to `usefulness:=20`
