### PR TITLE
fix(gui): maximum width for parameter value chart

### DIFF
--- a/api-editor/gui/src/features/packageData/selectionView/ParameterView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ParameterView.tsx
@@ -1,4 +1,4 @@
-import { Heading, Stack, Text as ChakraText } from '@chakra-ui/react';
+import { Box, Heading, Stack, Text as ChakraText } from '@chakra-ui/react';
 import React from 'react';
 import { PythonParameter } from '../model/PythonParameter';
 import { ParameterNode } from './ParameterNode';
@@ -53,7 +53,9 @@ export const ParameterView: React.FC<ParameterViewProps> = function ({ pythonPar
                     <Heading as="h4" size="md">
                         Most Common Values
                     </Heading>
+                    <Box w="30vw" maxWidth="640px">
                     {createBarChart(parameterUsages)}
+                    </Box>
                 </Stack>
             )}
         </Stack>

--- a/api-editor/gui/src/features/packageData/selectionView/ParameterView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ParameterView.tsx
@@ -54,7 +54,7 @@ export const ParameterView: React.FC<ParameterViewProps> = function ({ pythonPar
                         Most Common Values
                     </Heading>
                     <Box w="30vw" maxWidth="640px">
-                    {createBarChart(parameterUsages)}
+                        {createBarChart(parameterUsages)}
                     </Box>
                 </Stack>
             )}


### PR DESCRIPTION
### Summary of Changes

Set a maximum width on the chart that display the values of parameters. Otherwise, it would be too prominent on bigger screens.