### PR TITLE
feat(gui): filter by qualified name

### DIFF
--- a/api-editor/gui/src/features/filter/FilterHelpButton.tsx
+++ b/api-editor/gui/src/features/filter/FilterHelpButton.tsx
@@ -85,8 +85,8 @@ export const FilterHelpButton = function () {
                                 </ChakraText>
                                 <ChakraText>
                                     Displays only elements with matching names (case-sensitive). Replace [operator] with{' '}
-                                    <em>=</em> to display only elements that match the [string] exactly or with{' '}
-                                    <em>~</em> to display only elements that contain the [string] as a substring.
+                                    <em>=</em> to display only elements that match [string] exactly or with{' '}
+                                    <em>~</em> to display only elements that contain [string] as a substring.
                                 </ChakraText>
                             </ListItem>
                             <ListItem>
@@ -94,6 +94,22 @@ export const FilterHelpButton = function () {
                                     <strong>name:/[regex]/</strong>
                                 </ChakraText>
                                 <ChakraText>Displays only elements with names that match the given [regex].</ChakraText>
+                            </ListItem>
+                            <ListItem>
+                                <ChakraText>
+                                    <strong>qname:[operator][string]</strong>
+                                </ChakraText>
+                                <ChakraText>
+                                    Displays only elements with matching qualified names (case-sensitive). Replace [operator] with{' '}
+                                    <em>=</em> to display only elements that match [string] exactly or with{' '}
+                                    <em>~</em> to display only elements that contain [string] as a substring.
+                                </ChakraText>
+                            </ListItem>
+                            <ListItem>
+                                <ChakraText>
+                                    <strong>qname:/[regex]/</strong>
+                                </ChakraText>
+                                <ChakraText>Displays only elements with qualified names that match the given [regex].</ChakraText>
                             </ListItem>
                             <ListItem>
                                 <ChakraText>

--- a/api-editor/gui/src/features/filter/FilterHelpButton.tsx
+++ b/api-editor/gui/src/features/filter/FilterHelpButton.tsx
@@ -85,8 +85,8 @@ export const FilterHelpButton = function () {
                                 </ChakraText>
                                 <ChakraText>
                                     Displays only elements with matching names (case-sensitive). Replace [operator] with{' '}
-                                    <em>=</em> to display only elements that match [string] exactly or with{' '}
-                                    <em>~</em> to display only elements that contain [string] as a substring.
+                                    <em>=</em> to display only elements that match [string] exactly or with <em>~</em>{' '}
+                                    to display only elements that contain [string] as a substring.
                                 </ChakraText>
                             </ListItem>
                             <ListItem>
@@ -100,16 +100,18 @@ export const FilterHelpButton = function () {
                                     <strong>qname:[operator][string]</strong>
                                 </ChakraText>
                                 <ChakraText>
-                                    Displays only elements with matching qualified names (case-sensitive). Replace [operator] with{' '}
-                                    <em>=</em> to display only elements that match [string] exactly or with{' '}
-                                    <em>~</em> to display only elements that contain [string] as a substring.
+                                    Displays only elements with matching qualified names (case-sensitive). Replace
+                                    [operator] with <em>=</em> to display only elements that match [string] exactly or
+                                    with <em>~</em> to display only elements that contain [string] as a substring.
                                 </ChakraText>
                             </ListItem>
                             <ListItem>
                                 <ChakraText>
                                     <strong>qname:/[regex]/</strong>
                                 </ChakraText>
-                                <ChakraText>Displays only elements with qualified names that match the given [regex].</ChakraText>
+                                <ChakraText>
+                                    Displays only elements with qualified names that match the given [regex].
+                                </ChakraText>
                             </ListItem>
                             <ListItem>
                                 <ChakraText>

--- a/api-editor/gui/src/features/filter/model/QualifiedNameRegexFilter.ts
+++ b/api-editor/gui/src/features/filter/model/QualifiedNameRegexFilter.ts
@@ -5,6 +5,7 @@ import { PythonParameter } from '../../packageData/model/PythonParameter';
 import { AnnotationStore } from '../../annotations/annotationSlice';
 import { UsageCountStore } from '../../usages/model/UsageCountStore';
 import { AbstractPythonFilter } from './AbstractPythonFilter';
+import {PythonDeclaration} from "../../packageData/model/PythonDeclaration";
 
 /**
  * Keeps only declarations that have a qualified name matching the given regex.
@@ -21,32 +22,32 @@ export class QualifiedNameRegexFilter extends AbstractPythonFilter {
         this.regex = RegExp(regex, 'u');
     }
 
-    shouldKeepModule(pythonModule: PythonModule, _annotations: AnnotationStore, _usages: UsageCountStore): boolean {
+    shouldKeepModule(pythonModule: PythonModule, annotations: AnnotationStore, usages: UsageCountStore): boolean {
         // For modules the qualified name is the same as the name.
-        return this.shouldKeepQualifiedName(pythonModule.name);
+        return this.shouldKeepDeclaration(pythonModule, annotations, usages);
     }
 
-    shouldKeepClass(pythonClass: PythonClass, _annotations: AnnotationStore, _usages: UsageCountStore): boolean {
-        return this.shouldKeepQualifiedName(pythonClass.qualifiedName);
+    shouldKeepClass(pythonClass: PythonClass, annotations: AnnotationStore, usages: UsageCountStore): boolean {
+        return this.shouldKeepDeclaration(pythonClass, annotations, usages);
     }
 
-    shouldKeepFunction(
-        pythonFunction: PythonFunction,
-        _annotations: AnnotationStore,
-        _usages: UsageCountStore,
-    ): boolean {
-        return this.shouldKeepQualifiedName(pythonFunction.qualifiedName);
+    shouldKeepFunction(pythonFunction: PythonFunction, annotations: AnnotationStore, usages: UsageCountStore): boolean {
+        return this.shouldKeepDeclaration(pythonFunction, annotations, usages);
     }
 
     shouldKeepParameter(
         pythonParameter: PythonParameter,
+        annotations: AnnotationStore,
+        usages: UsageCountStore,
+    ): boolean {
+        return this.shouldKeepDeclaration(pythonParameter, annotations, usages);
+    }
+
+    shouldKeepDeclaration(
+        pythonDeclaration: PythonDeclaration,
         _annotations: AnnotationStore,
         _usages: UsageCountStore,
     ): boolean {
-        return this.shouldKeepQualifiedName(pythonParameter.qualifiedName);
-    }
-
-    private shouldKeepQualifiedName(qualifiedName: string): boolean {
-        return this.regex.test(qualifiedName);
+        return this.regex.test(pythonDeclaration.preferredQualifiedName());
     }
 }

--- a/api-editor/gui/src/features/filter/model/QualifiedNameRegexFilter.ts
+++ b/api-editor/gui/src/features/filter/model/QualifiedNameRegexFilter.ts
@@ -1,0 +1,52 @@
+import { PythonClass } from '../../packageData/model/PythonClass';
+import { PythonFunction } from '../../packageData/model/PythonFunction';
+import { PythonModule } from '../../packageData/model/PythonModule';
+import { PythonParameter } from '../../packageData/model/PythonParameter';
+import { AnnotationStore } from '../../annotations/annotationSlice';
+import { UsageCountStore } from '../../usages/model/UsageCountStore';
+import { AbstractPythonFilter } from './AbstractPythonFilter';
+
+/**
+ * Keeps only declarations that have a qualified name matching the given regex.
+ */
+export class QualifiedNameRegexFilter extends AbstractPythonFilter {
+    readonly regex: RegExp;
+
+    /**
+     * @param regex The regex that must match the qualified name of the declaration.
+     */
+    constructor(regex: string) {
+        super();
+
+        this.regex = RegExp(regex, 'u');
+    }
+
+    shouldKeepModule(pythonModule: PythonModule, _annotations: AnnotationStore, _usages: UsageCountStore): boolean {
+        // For modules the qualified name is the same as the name.
+        return this.shouldKeepQualifiedName(pythonModule.name);
+    }
+
+    shouldKeepClass(pythonClass: PythonClass, _annotations: AnnotationStore, _usages: UsageCountStore): boolean {
+        return this.shouldKeepQualifiedName(pythonClass.qualifiedName);
+    }
+
+    shouldKeepFunction(
+        pythonFunction: PythonFunction,
+        _annotations: AnnotationStore,
+        _usages: UsageCountStore,
+    ): boolean {
+        return this.shouldKeepQualifiedName(pythonFunction.qualifiedName);
+    }
+
+    shouldKeepParameter(
+        pythonParameter: PythonParameter,
+        _annotations: AnnotationStore,
+        _usages: UsageCountStore,
+    ): boolean {
+        return this.shouldKeepQualifiedName(pythonParameter.qualifiedName);
+    }
+
+    private shouldKeepQualifiedName(qualifiedName: string): boolean {
+        return this.regex.test(qualifiedName);
+    }
+}

--- a/api-editor/gui/src/features/filter/model/QualifiedNameRegexFilter.ts
+++ b/api-editor/gui/src/features/filter/model/QualifiedNameRegexFilter.ts
@@ -5,7 +5,7 @@ import { PythonParameter } from '../../packageData/model/PythonParameter';
 import { AnnotationStore } from '../../annotations/annotationSlice';
 import { UsageCountStore } from '../../usages/model/UsageCountStore';
 import { AbstractPythonFilter } from './AbstractPythonFilter';
-import {PythonDeclaration} from "../../packageData/model/PythonDeclaration";
+import { PythonDeclaration } from '../../packageData/model/PythonDeclaration';
 
 /**
  * Keeps only declarations that have a qualified name matching the given regex.

--- a/api-editor/gui/src/features/filter/model/QualifiedNameStringFilter.ts
+++ b/api-editor/gui/src/features/filter/model/QualifiedNameStringFilter.ts
@@ -5,6 +5,7 @@ import { PythonParameter } from '../../packageData/model/PythonParameter';
 import { AnnotationStore } from '../../annotations/annotationSlice';
 import { UsageCountStore } from '../../usages/model/UsageCountStore';
 import { AbstractPythonFilter } from './AbstractPythonFilter';
+import {PythonDeclaration} from "../../packageData/model/PythonDeclaration";
 
 /**
  * Keeps only declarations that have a given string in their qualified name.
@@ -18,36 +19,36 @@ export class QualifiedNameStringFilter extends AbstractPythonFilter {
         super();
     }
 
-    shouldKeepModule(pythonModule: PythonModule, _annotations: AnnotationStore, _usages: UsageCountStore): boolean {
+    shouldKeepModule(pythonModule: PythonModule, annotations: AnnotationStore, usages: UsageCountStore): boolean {
         // For modules the qualified name is the same as the name.
-        return this.shouldKeepQualifiedName(pythonModule.name);
+        return this.shouldKeepDeclaration(pythonModule, annotations, usages);
     }
 
-    shouldKeepClass(pythonClass: PythonClass, _annotations: AnnotationStore, _usages: UsageCountStore): boolean {
-        return this.shouldKeepQualifiedName(pythonClass.qualifiedName);
+    shouldKeepClass(pythonClass: PythonClass, annotations: AnnotationStore, usages: UsageCountStore): boolean {
+        return this.shouldKeepDeclaration(pythonClass, annotations, usages);
     }
 
-    shouldKeepFunction(
-        pythonFunction: PythonFunction,
-        _annotations: AnnotationStore,
-        _usages: UsageCountStore,
-    ): boolean {
-        return this.shouldKeepQualifiedName(pythonFunction.qualifiedName);
+    shouldKeepFunction(pythonFunction: PythonFunction, annotations: AnnotationStore, usages: UsageCountStore): boolean {
+        return this.shouldKeepDeclaration(pythonFunction, annotations, usages);
     }
 
     shouldKeepParameter(
         pythonParameter: PythonParameter,
+        annotations: AnnotationStore,
+        usages: UsageCountStore,
+    ): boolean {
+        return this.shouldKeepDeclaration(pythonParameter, annotations, usages);
+    }
+
+    shouldKeepDeclaration(
+        pythonDeclaration: PythonDeclaration,
         _annotations: AnnotationStore,
         _usages: UsageCountStore,
     ): boolean {
-        return this.shouldKeepQualifiedName(pythonParameter.qualifiedName);
-    }
-
-    private shouldKeepQualifiedName(qualifiedName: string): boolean {
         if (this.matchExactly) {
-            return qualifiedName === this.string;
+            return pythonDeclaration.preferredQualifiedName() === this.string;
         } else {
-            return qualifiedName.includes(this.string);
+            return pythonDeclaration.preferredQualifiedName().includes(this.string);
         }
     }
 }

--- a/api-editor/gui/src/features/filter/model/QualifiedNameStringFilter.ts
+++ b/api-editor/gui/src/features/filter/model/QualifiedNameStringFilter.ts
@@ -1,0 +1,53 @@
+import { PythonClass } from '../../packageData/model/PythonClass';
+import { PythonFunction } from '../../packageData/model/PythonFunction';
+import { PythonModule } from '../../packageData/model/PythonModule';
+import { PythonParameter } from '../../packageData/model/PythonParameter';
+import { AnnotationStore } from '../../annotations/annotationSlice';
+import { UsageCountStore } from '../../usages/model/UsageCountStore';
+import { AbstractPythonFilter } from './AbstractPythonFilter';
+
+/**
+ * Keeps only declarations that have a given string in their qualified name.
+ */
+export class QualifiedNameStringFilter extends AbstractPythonFilter {
+    /**
+     * @param string The string that must be part of the qualified name of the declaration.
+     * @param matchExactly Whether the qualified name must match the substring exactly.
+     */
+    constructor(readonly string: string, readonly matchExactly: boolean) {
+        super();
+    }
+
+    shouldKeepModule(pythonModule: PythonModule, _annotations: AnnotationStore, _usages: UsageCountStore): boolean {
+        // For modules the qualified name is the same as the name.
+        return this.shouldKeepQualifiedName(pythonModule.name);
+    }
+
+    shouldKeepClass(pythonClass: PythonClass, _annotations: AnnotationStore, _usages: UsageCountStore): boolean {
+        return this.shouldKeepQualifiedName(pythonClass.qualifiedName);
+    }
+
+    shouldKeepFunction(
+        pythonFunction: PythonFunction,
+        _annotations: AnnotationStore,
+        _usages: UsageCountStore,
+    ): boolean {
+        return this.shouldKeepQualifiedName(pythonFunction.qualifiedName);
+    }
+
+    shouldKeepParameter(
+        pythonParameter: PythonParameter,
+        _annotations: AnnotationStore,
+        _usages: UsageCountStore,
+    ): boolean {
+        return this.shouldKeepQualifiedName(pythonParameter.qualifiedName);
+    }
+
+    private shouldKeepQualifiedName(qualifiedName: string): boolean {
+        if (this.matchExactly) {
+            return qualifiedName === this.string;
+        } else {
+            return qualifiedName.includes(this.string);
+        }
+    }
+}

--- a/api-editor/gui/src/features/filter/model/QualifiedNameStringFilter.ts
+++ b/api-editor/gui/src/features/filter/model/QualifiedNameStringFilter.ts
@@ -5,7 +5,7 @@ import { PythonParameter } from '../../packageData/model/PythonParameter';
 import { AnnotationStore } from '../../annotations/annotationSlice';
 import { UsageCountStore } from '../../usages/model/UsageCountStore';
 import { AbstractPythonFilter } from './AbstractPythonFilter';
-import {PythonDeclaration} from "../../packageData/model/PythonDeclaration";
+import { PythonDeclaration } from '../../packageData/model/PythonDeclaration';
 
 /**
  * Keeps only declarations that have a given string in their qualified name.

--- a/api-editor/gui/src/features/filter/model/filterFactory.ts
+++ b/api-editor/gui/src/features/filter/model/filterFactory.ts
@@ -14,6 +14,8 @@ import { RequiredOrOptional, RequiredOrOptionalFilter } from './RequiredOrOption
 import { NameRegexFilter } from './NameRegexFilter';
 import { DoneFilter } from './DoneFilter';
 import { PythonParameterAssignment } from '../../packageData/model/PythonParameter';
+import { QualifiedNameStringFilter } from './QualifiedNameStringFilter';
+import { QualifiedNameRegexFilter } from './QualifiedNameRegexFilter';
 
 /**
  * Creates a filter from the given string. This method handles conjunctions, negations, and non-negated tokens.
@@ -139,6 +141,21 @@ const parsePositiveToken = function (token: string): Optional<AbstractPythonFilt
     const nameRegexMatch = /^name:\/(?<regex>.*)\/$/u.exec(token);
     if (nameRegexMatch) {
         return new NameRegexFilter(nameRegexMatch?.groups?.regex as string);
+    }
+
+    // Name
+    const qualifiedNameStringMatch = /^qname:(?<comparison>[=~])(?<qname>[\w.]+)$/u.exec(token);
+    if (qualifiedNameStringMatch) {
+        const comparisonOperator = qualifiedNameStringMatch?.groups?.comparison as string;
+        return new QualifiedNameStringFilter(
+            qualifiedNameStringMatch?.groups?.qname as string,
+            comparisonOperator === '=',
+        );
+    }
+
+    const qualifiedNameRegexMatch = /^qname:\/(?<regex>.*)\/$/u.exec(token);
+    if (qualifiedNameRegexMatch) {
+        return new QualifiedNameRegexFilter(qualifiedNameRegexMatch?.groups?.regex as string);
     }
 
     // Usages

--- a/api-editor/gui/src/features/filter/model/filterFactory.ts
+++ b/api-editor/gui/src/features/filter/model/filterFactory.ts
@@ -140,7 +140,11 @@ const parsePositiveToken = function (token: string): Optional<AbstractPythonFilt
 
     const nameRegexMatch = /^name:\/(?<regex>.*)\/$/u.exec(token);
     if (nameRegexMatch) {
-        return new NameRegexFilter(nameRegexMatch?.groups?.regex as string);
+        try {
+            return new NameRegexFilter(nameRegexMatch?.groups?.regex as string);
+        } catch (e) {
+            return undefined;
+        }
     }
 
     // Name
@@ -155,7 +159,11 @@ const parsePositiveToken = function (token: string): Optional<AbstractPythonFilt
 
     const qualifiedNameRegexMatch = /^qname:\/(?<regex>.*)\/$/u.exec(token);
     if (qualifiedNameRegexMatch) {
-        return new QualifiedNameRegexFilter(qualifiedNameRegexMatch?.groups?.regex as string);
+        try {
+            return new QualifiedNameRegexFilter(qualifiedNameRegexMatch?.groups?.regex as string);
+        } catch (e) {
+            return undefined;
+        }
     }
 
     // Usages

--- a/api-editor/gui/src/features/packageData/model/PythonClass.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonClass.ts
@@ -48,6 +48,14 @@ export class PythonClass extends PythonDeclaration {
         return this.methods;
     }
 
+    preferredQualifiedName(): string {
+        if (this.containingModule) {
+            return `${this.containingModule.preferredQualifiedName()}.${this.name}`;
+        } else {
+            return this.name;
+        }
+    }
+
     shallowCopy({
         id = this.id,
         name = this.name,

--- a/api-editor/gui/src/features/packageData/model/PythonDeclaration.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonDeclaration.ts
@@ -9,6 +9,8 @@ export abstract class PythonDeclaration {
 
     abstract children(): PythonDeclaration[];
 
+    abstract preferredQualifiedName(): string;
+
     getUniqueName(): string {
         return this.name;
     }

--- a/api-editor/gui/src/features/packageData/model/PythonFunction.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonFunction.ts
@@ -59,6 +59,14 @@ export class PythonFunction extends PythonDeclaration {
         return segments[segments.length - 1];
     }
 
+    preferredQualifiedName(): string {
+        if (this.containingModuleOrClass) {
+            return `${this.containingModuleOrClass.preferredQualifiedName()}.${this.name}`;
+        } else {
+            return this.name;
+        }
+    }
+
     isGlobal(): boolean {
         return this.containingModuleOrClass instanceof PythonModule;
     }

--- a/api-editor/gui/src/features/packageData/model/PythonModule.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonModule.ts
@@ -51,6 +51,10 @@ export class PythonModule extends PythonDeclaration {
         return [...this.classes, ...this.functions];
     }
 
+    preferredQualifiedName(): string {
+        return this.name;
+    }
+
     shallowCopy({
         id = this.id,
         name = this.name,

--- a/api-editor/gui/src/features/packageData/model/PythonPackage.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonPackage.ts
@@ -39,6 +39,10 @@ export class PythonPackage extends PythonDeclaration {
         return this.modules;
     }
 
+    preferredQualifiedName(): string {
+        return this.name;
+    }
+
     getDeclarationById(id: string): Optional<PythonDeclaration> {
         if (this.idToDeclaration.has(id)) {
             return this.idToDeclaration.get(id);

--- a/api-editor/gui/src/features/packageData/model/PythonParameter.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonParameter.ts
@@ -40,6 +40,14 @@ export class PythonParameter extends PythonDeclaration {
         return [];
     }
 
+    preferredQualifiedName(): string {
+        if (this.containingFunction) {
+            return `${this.containingFunction.preferredQualifiedName()}.${this.name}`;
+        } else {
+            return this.name;
+        }
+    }
+
     isExplicitParameter(): boolean {
         return this.assignedBy !== PythonParameterAssignment.IMPLICIT;
     }

--- a/api-editor/gui/src/features/packageData/model/PythonResult.ts
+++ b/api-editor/gui/src/features/packageData/model/PythonResult.ts
@@ -25,6 +25,14 @@ export class PythonResult extends PythonDeclaration {
         return [];
     }
 
+    preferredQualifiedName(): string {
+        if (this.containingFunction) {
+            return `${this.containingFunction.preferredQualifiedName()}.${this.name}`;
+        } else {
+            return this.name;
+        }
+    }
+
     toString(): string {
         return `Result "${this.name}"`;
     }


### PR DESCRIPTION
Closes #696.

### Summary of Changes

* New filter `qname:=[string]` to match an exact qualified name
* New filter `qname:~[string]` to match elements that have the `[string]` in their qualified name
* New filter `qname:/[regex]/` to match elements with a qualified name that matches the `[regex]`
