### PR TITLE
feat(backend): change server config via command line arguments

### DIFF
--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/server/Application.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/server/Application.kt
@@ -3,8 +3,7 @@ package com.larsreimann.api_editor.server
 import com.larsreimann.safeds.SafeDSStandaloneSetup
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
-import io.ktor.server.engine.embeddedServer
-import io.ktor.server.netty.Netty
+import io.ktor.server.netty.EngineMain
 import io.ktor.server.plugins.callloging.CallLogging
 import io.ktor.server.plugins.compression.Compression
 import io.ktor.server.plugins.compression.deflate
@@ -13,14 +12,15 @@ import io.ktor.server.plugins.compression.minimumSize
 import io.ktor.server.request.path
 import org.slf4j.event.Level
 
-fun main() {
+fun main(args: Array<String>) {
     SafeDSStandaloneSetup.doSetup()
+    EngineMain.main(args)
+}
 
-    embeddedServer(Netty, port = 4280, host = "localhost") {
-        configureHTTP()
-        configureMonitoring()
-        configureRouting()
-    }.start(wait = true)
+fun Application.module() {
+    configureHTTP()
+    configureMonitoring()
+    configureRouting()
 }
 
 fun Application.configureHTTP() {

--- a/api-editor/backend/src/main/resources/application.conf
+++ b/api-editor/backend/src/main/resources/application.conf
@@ -1,0 +1,9 @@
+ktor {
+    deployment {
+        host = "localhost"
+        port = 4280
+    }
+    application {
+        modules = [ com.larsreimann.api_editor.server.ApplicationKt.module ]
+    }
+}

--- a/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/server/ApplicationTest.kt
+++ b/api-editor/backend/src/test/kotlin/com/larsreimann/api_editor/server/ApplicationTest.kt
@@ -26,7 +26,6 @@ import com.larsreimann.api_editor.model.SerializablePythonModule
 import com.larsreimann.api_editor.model.SerializablePythonPackage
 import com.larsreimann.api_editor.model.SerializablePythonParameter
 import com.larsreimann.api_editor.model.SerializablePythonResult
-import com.larsreimann.api_editor.server.configureRouting
 import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -44,10 +43,6 @@ class ApplicationTest {
     @Test
     fun testEcho() {
         testApplication {
-            application {
-                configureRouting()
-            }
-
             val testPythonPackage = SerializablePythonPackage(
                 distribution = "test-distribution",
                 name = "test-package",


### PR DESCRIPTION
### Summary of Changes

Allow configuration of backend server to be overwritten by command line arguments. This is particularly useful to run multiple instances of the program at once on separate ports. See [Ktor documentation](https://ktor.io/docs/configurations.html#command-line) for details.