### PR TITLE
fix(gui): detect numbers using scientific notation as literals

### DIFF
--- a/api-editor/gui/src/features/packageData/selectionView/ParameterView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ParameterView.tsx
@@ -108,5 +108,5 @@ const isStringifiedLiteral = function (value: string): boolean {
     if (value === 'True' || value === 'False') {
         return true;
     }
-    return Boolean(value.match(/^[+-]?\d+(\.\d*)?$/u));
+    return !Number.isNaN(Number.parseFloat(value));
 };


### PR DESCRIPTION
Closes #757.

### Summary of Changes

Instead of comparing a string with some self-made regex to figure out whether represents a number literal, we now try to parse the string as a float. If this is successful, we treat it as a number literal.

### Screenshots

Parameter value distribution of `#/sklearn/sklearn.linear_model._coordinate_descent/ElasticNetCV/__init__/eps`:

![image](https://user-images.githubusercontent.com/2501322/175614328-4d3b3e8d-b808-43af-93ea-f6f822cdeef6.png)
