### PR TITLE
fix(gui): close batch mode dropdown after an option was chosen

### DIFF
--- a/api-editor/gui/src/common/MenuBar.tsx
+++ b/api-editor/gui/src/common/MenuBar.tsx
@@ -105,7 +105,7 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
                 <DeleteAllAnnotations />
 
                 <Box>
-                    <Menu closeOnSelect={false}>
+                    <Menu>
                         <MenuButton as={Button} rightIcon={<Icon as={FaChevronDown} />} disabled={!usernameIsValid}>
                             Batch
                         </MenuButton>


### PR DESCRIPTION
Closes #735.

### Summary of Changes

After the user has chosen an option in the batch mode dropdown (menu bar) the dropdown is now closed properly.