### PR TITLE
fix(gui): previous/next if selected element not appear in filtered tree view

### DIFF
--- a/api-editor/gui/src/features/packageData/apiSlice.ts
+++ b/api-editor/gui/src/features/packageData/apiSlice.ts
@@ -64,6 +64,17 @@ export const apiReducer = reducer;
 
 const selectAPI = (state: RootState) => state.api;
 export const selectRawPythonPackage = (state: RootState) => selectAPI(state).pythonPackage;
+export const selectFlatSortedDeclarationList = createSelector(
+    [selectRawPythonPackage, selectSortingMode, selectUsages],
+    (pythonPackage, sortingMode, usages) => {
+        switch (sortingMode) {
+            case SortingMode.Alphabetical:
+                return walkChildrenInPreorder(pythonPackage, sortAlphabetically);
+            case SortingMode.Usages: // Descending
+                return walkChildrenInPreorder(pythonPackage, sortByUsages(usages));
+        }
+    },
+);
 export const selectFilteredPythonPackage = createSelector(
     [selectRawPythonPackage, selectAnnotationStore, selectUsages, selectFilter],
     (pythonPackage, annotations, usages, filter) => {
@@ -88,7 +99,7 @@ export const selectMatchedNodes = createSelector(
 export const selectNumberOfMatchedNodes = createSelector([selectMatchedNodes], (matchedNodes) => {
     return matchedNodes.length;
 });
-export const selectFlatSortedDeclarationList = createSelector(
+export const selectFlatFilteredAndSortedDeclarationList = createSelector(
     [selectFilteredPythonPackage, selectSortingMode, selectUsages],
     (pythonPackage, sortingMode, usages) => {
         switch (sortingMode) {

--- a/api-editor/gui/src/features/packageData/treeView/TreeView.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/TreeView.tsx
@@ -19,7 +19,7 @@ import { FunctionNode } from './FunctionNode';
 import { ModuleNode } from './ModuleNode';
 import { ParameterNode } from './ParameterNode';
 import { AutoSizer } from '../../../common/AutoSizer';
-import { selectFlatSortedDeclarationList } from '../apiSlice';
+import { selectFlatFilteredAndSortedDeclarationList } from '../apiSlice';
 import { selectUsages } from '../../usages/usageSlice';
 
 interface ScrollOffset {
@@ -36,7 +36,7 @@ export const TreeView: React.FC = memo(() => {
     const filter = useAppSelector(selectFilter);
     const usages = useAppSelector(selectUsages);
     const allExpanded = useAppSelector(selectAllExpandedInTreeView);
-    const flatSortedList = useAppSelector(selectFlatSortedDeclarationList);
+    const flatSortedList = useAppSelector(selectFlatFilteredAndSortedDeclarationList);
     const children = getNodes(allExpanded, flatSortedList);
     const previousScrollOffset = useAppSelector(selectTreeViewScrollOffset);
 


### PR DESCRIPTION
Closes #752.

### Summary of Changes

The previous/next buttons should now behave correctly if an element is selected that no longer appears in the filtered tree view.