### PR TITLE
feat(gui): option to expand documentation by default

### DIFF
--- a/api-editor/gui/src/common/MenuBar.tsx
+++ b/api-editor/gui/src/common/MenuBar.tsx
@@ -21,7 +21,7 @@ import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { selectAnnotationStore, selectUsernameIsValid } from '../features/annotations/annotationSlice';
 import {
     BatchMode,
-    HeatMapMode,
+    HeatMapMode, selectExpandDocumentationByDefault,
     selectHeatMapMode,
     selectShowStatistics,
     selectSortingMode,
@@ -30,7 +30,7 @@ import {
     setSortingMode,
     SortingMode,
     toggleAnnotationImportDialog,
-    toggleAPIImportDialog,
+    toggleAPIImportDialog, toggleExpandDocumentationByDefault,
     toggleStatisticsView,
     toggleUsageImportDialog,
 } from '../features/ui/uiSlice';
@@ -51,6 +51,7 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
     const heatMapMode = useAppSelector(selectHeatMapMode);
     const showStatistics = useAppSelector(selectShowStatistics);
     const usernameIsValid = useAppSelector(selectUsernameIsValid);
+    const expandDocumentationByDefault = useAppSelector(selectExpandDocumentationByDefault);
 
     const exportAnnotations = () => {
         const a = document.createElement('a');
@@ -68,6 +69,9 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
     }
     if (showStatistics) {
         visualSettings.push('statistics');
+    }
+    if (expandDocumentationByDefault) {
+        visualSettings.push('toggleDocumentationByDefault');
     }
 
     return (
@@ -150,6 +154,12 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
                                         onClick={() => dispatch(toggleStatisticsView())}
                                     >
                                         Show Statistics
+                                    </MenuItemOption>
+                                    <MenuItemOption
+                                        value={'toggleDocumentationByDefault'}
+                                        onClick={() => dispatch(toggleExpandDocumentationByDefault())}
+                                    >
+                                        Expand Documentation by Default
                                     </MenuItemOption>
                                 </MenuOptionGroup>
                             </MenuGroup>

--- a/api-editor/gui/src/common/MenuBar.tsx
+++ b/api-editor/gui/src/common/MenuBar.tsx
@@ -21,7 +21,8 @@ import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { selectAnnotationStore, selectUsernameIsValid } from '../features/annotations/annotationSlice';
 import {
     BatchMode,
-    HeatMapMode, selectExpandDocumentationByDefault,
+    HeatMapMode,
+    selectExpandDocumentationByDefault,
     selectHeatMapMode,
     selectShowStatistics,
     selectSortingMode,
@@ -30,7 +31,8 @@ import {
     setSortingMode,
     SortingMode,
     toggleAnnotationImportDialog,
-    toggleAPIImportDialog, toggleExpandDocumentationByDefault,
+    toggleAPIImportDialog,
+    toggleExpandDocumentationByDefault,
     toggleStatisticsView,
     toggleUsageImportDialog,
 } from '../features/ui/uiSlice';

--- a/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
@@ -7,6 +7,8 @@ import { CodeComponent, ReactMarkdownProps, UnorderedListComponent } from 'react
 import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
+import {useAppSelector} from "../../../app/hooks";
+import {selectExpandDocumentationByDefault} from "../../ui/uiSlice";
 
 interface DocumentationTextProps {
     inputText: string;
@@ -35,6 +37,8 @@ const components = {
 };
 
 export const DocumentationText: React.FC<DocumentationTextProps> = function ({ inputText = '' }) {
+    const expandDocumentationByDefault = useAppSelector(selectExpandDocumentationByDefault)
+
     const preprocessedText = inputText
         // replace single new-lines by spaces
         .replaceAll(/(?<!\n)\n(?!\n)/gu, ' ')
@@ -45,7 +49,7 @@ export const DocumentationText: React.FC<DocumentationTextProps> = function ({ i
 
     const shortenedText = preprocessedText.split('\n\n')[0];
     const hasMultipleLines = shortenedText !== preprocessedText;
-    const [readMore, setReadMore] = useState(false);
+    const [readMore, setReadMore] = useState(expandDocumentationByDefault);
 
     return (
         <Flex justifyContent="flex-start">

--- a/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
@@ -7,8 +7,8 @@ import { CodeComponent, ReactMarkdownProps, UnorderedListComponent } from 'react
 import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
-import {useAppSelector} from "../../../app/hooks";
-import {selectExpandDocumentationByDefault} from "../../ui/uiSlice";
+import { useAppSelector } from '../../../app/hooks';
+import { selectExpandDocumentationByDefault } from '../../ui/uiSlice';
 
 interface DocumentationTextProps {
     inputText: string;
@@ -37,7 +37,7 @@ const components = {
 };
 
 export const DocumentationText: React.FC<DocumentationTextProps> = function ({ inputText = '' }) {
-    const expandDocumentationByDefault = useAppSelector(selectExpandDocumentationByDefault)
+    const expandDocumentationByDefault = useAppSelector(selectExpandDocumentationByDefault);
 
     const preprocessedText = inputText
         // replace single new-lines by spaces

--- a/api-editor/gui/src/features/ui/uiSlice.ts
+++ b/api-editor/gui/src/features/ui/uiSlice.ts
@@ -30,6 +30,7 @@ export interface UIState {
     sortingMode: SortingMode;
     batchMode: BatchMode;
     showStatistics: boolean;
+    expandDocumentationByDefault: boolean;
 }
 
 type UserAction =
@@ -153,6 +154,7 @@ export const initialState: UIState = {
     sortingMode: SortingMode.Default,
     batchMode: BatchMode.None,
     showStatistics: true,
+    expandDocumentationByDefault: false,
 };
 
 // Thunks --------------------------------------------------------------------------------------------------------------
@@ -342,6 +344,9 @@ const uiSlice = createSlice({
         toggleStatisticsView(state) {
             state.showStatistics = !state.showStatistics;
         },
+        toggleExpandDocumentationByDefault(state) {
+            state.expandDocumentationByDefault = !state.expandDocumentationByDefault;
+        },
     },
     extraReducers(builder) {
         builder.addCase(initializeUI.fulfilled, (state, action) => action.payload);
@@ -384,6 +389,7 @@ export const {
     setSortingMode,
     setBatchMode,
     toggleStatisticsView,
+    toggleExpandDocumentationByDefault,
 } = actions;
 export const uiReducer = reducer;
 
@@ -432,6 +438,8 @@ export const selectSorter = (state: RootState): ((a: PythonDeclaration, b: Pytho
 };
 export const selectBatchMode = (state: RootState): BatchMode => selectUI(state).batchMode;
 export const selectShowStatistics = (state: RootState): boolean => selectUI(state).showStatistics;
+export const selectExpandDocumentationByDefault = (state: RootState): boolean =>
+    selectUI(state).expandDocumentationByDefault;
 
 const sortInSameOrder = (_a: PythonDeclaration, _b: PythonDeclaration) => {
     return 1;


### PR DESCRIPTION
Closes #770.

### Summary of Changes

There is a new setting "Expand Documentation by Default" in the menu bar. When this is switched on, all documentation texts are expanded already when a new element is selected. **Important:** This does not affect the selection view that is already opened when the setting is changed.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/175766828-a0a60fcb-6759-4710-b4ee-d9e38fb7ceb6.png)