### PR TITLE
feat(gui): mark any API element as complete

### DIFF
--- a/api-editor/gui/src/features/packageData/selectionView/ClassView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ClassView.tsx
@@ -22,11 +22,9 @@ export const ClassView: React.FC<ClassViewProps> = function ({ pythonClass }) {
                         {pythonClass.name} {!pythonClass.isPublic && '(private)'}
                     </Heading>
                     {pythonClass.isPublic && (
-                        <>
-                            <AnnotationDropdown target={id} showDescription showMove showRemove showRename showTodo />
-                            <CompleteButton target={id} />
-                        </>
+                        <AnnotationDropdown target={id} showDescription showMove showRemove showRename showTodo />
                     )}
+                    <CompleteButton target={id} />
                 </HStack>
 
                 <AnnotationView target={id} />

--- a/api-editor/gui/src/features/packageData/selectionView/FunctionView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/FunctionView.tsx
@@ -36,21 +36,19 @@ export const FunctionView: React.FC<FunctionViewProps> = function ({ pythonFunct
                         {pythonFunction.name} {!pythonFunction.isPublic && '(private)'}
                     </Heading>
                     {pythonFunction.isPublic && (
-                        <>
-                            <AnnotationDropdown
-                                target={id}
-                                showCalledAfter={hasRemainingCalledAfters}
-                                showDescription
-                                showGroup={pythonFunction.explicitParameters().length >= 2}
-                                showMove={pythonFunction.containingModuleOrClass instanceof PythonModule}
-                                showPure
-                                showRemove
-                                showRename
-                                showTodo
-                            />
-                            <CompleteButton target={id} />
-                        </>
+                        <AnnotationDropdown
+                            target={id}
+                            showCalledAfter={hasRemainingCalledAfters}
+                            showDescription
+                            showGroup={pythonFunction.explicitParameters().length >= 2}
+                            showMove={pythonFunction.containingModuleOrClass instanceof PythonModule}
+                            showPure
+                            showRemove
+                            showRename
+                            showTodo
+                        />
                     )}
+                    <CompleteButton target={id} />
                 </HStack>
 
                 <AnnotationView target={id} />

--- a/api-editor/gui/src/features/packageData/selectionView/ModuleView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ModuleView.tsx
@@ -1,4 +1,4 @@
-import { Box, Code, Heading, Stack, Text, useColorModeValue } from '@chakra-ui/react';
+import { Box, Code, Heading, HStack, Stack, Text, useColorModeValue } from '@chakra-ui/react';
 import React, { useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -8,6 +8,7 @@ import remarkGfm from 'remark-gfm';
 import { groupBy, isEmptyList } from '../../../common/util/listOperations';
 import { PythonModule } from '../model/PythonModule';
 import { CodeComponent } from 'react-markdown/lib/ast-to-react';
+import { CompleteButton } from '../../annotations/CompleteButton';
 
 // See https://github.com/remarkjs/react-markdown#use-custom-components-syntax-highlight
 const CustomCode: CodeComponent = function ({
@@ -65,9 +66,13 @@ export const ModuleView: React.FC<ModuleViewProps> = function ({ pythonModule })
 
     return (
         <Stack spacing={8}>
-            <Heading as="h3" size="lg">
-                {pythonModule.name}
-            </Heading>
+            <HStack>
+                <Heading as="h3" size="lg">
+                    {pythonModule.name} {!pythonModule.isPublic && '(private)'}
+                </Heading>
+                <CompleteButton target={pythonModule.id} />
+            </HStack>
+
             <Stack spacing={4}>
                 <Heading as="h4" size="md">
                     Imports

--- a/api-editor/gui/src/features/packageData/selectionView/ParameterNode.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ParameterNode.tsx
@@ -33,21 +33,19 @@ export const ParameterNode: React.FC<ParameterNodeProps> = function ({ isTitle, 
                     </Heading>
                 )}
                 {pythonParameter.isPublic && isExplicitParameter && (
-                    <>
-                        <AnnotationDropdown
-                            target={id}
-                            showAttribute={isConstructorParameter}
-                            showBoundary
-                            showConstant
-                            showDescription
-                            showEnum
-                            showOptional
-                            showRename
-                            showRequired
-                        />
-                        <CompleteButton target={id} />
-                    </>
+                    <AnnotationDropdown
+                        target={id}
+                        showAttribute={isConstructorParameter}
+                        showBoundary
+                        showConstant
+                        showDescription
+                        showEnum
+                        showOptional
+                        showRename
+                        showRequired
+                    />
                 )}
+                <CompleteButton target={id} />
             </HStack>
 
             <AnnotationView target={id} />


### PR DESCRIPTION
Closes #725.

### Summary of Changes

Any API element can now be marked as complete, even if no annotations can be added to it yet. Compared to before, it is now also possible to mark the following API elements as complete:
* Modules
* Internal classes
* Internal functions
* Internal parameters
* Implicit parameters
