### PR TITLE
feat(gui): shortcut to toggle completion of selected element

### DIFF
--- a/api-editor/gui/src/features/annotations/annotationSlice.ts
+++ b/api-editor/gui/src/features/annotations/annotationSlice.ts
@@ -468,6 +468,19 @@ const annotationsSlice = createSlice({
 
             updateQueue(state);
         },
+        toggleComplete(state, action: PayloadAction<string>) {
+            if (state.annotations.completes[action.payload]) {
+                delete state.annotations.completes[action.payload];
+            } else {
+                state.annotations.completes[action.payload] = withAuthorAndReviewers(
+                    state.annotations.completes[action.payload],
+                    { target: action.payload },
+                    state.username,
+                );
+            }
+
+            updateQueue(state);
+        },
         // Cannot review complete annotations
         upsertConstant(state, action: PayloadAction<ConstantAnnotation>) {
             state.annotations.constants[action.payload.target] = withAuthorAndReviewers(
@@ -888,6 +901,7 @@ export const {
     reviewCalledAfter,
     addComplete,
     removeComplete,
+    toggleComplete,
     upsertConstant,
     upsertConstants,
     removeConstant,

--- a/api-editor/gui/src/features/menuBar/MenuBar.tsx
+++ b/api-editor/gui/src/features/menuBar/MenuBar.tsx
@@ -23,6 +23,7 @@ import {
     redo,
     selectAnnotationStore,
     selectUsernameIsValid,
+    toggleComplete,
     undo,
 } from '../annotations/annotationSlice';
 import {
@@ -106,6 +107,13 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
     }
 
     // Event handlers
+    const markSelectedElementAsComplete = () => {
+        if (!declaration || declaration instanceof PythonPackage || !usernameIsValid) {
+            return;
+        }
+
+        dispatch(toggleComplete(declaration.id));
+    };
     const goToPreviousMatch = () => {
         if (!declaration) {
             return;
@@ -162,6 +170,7 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
     // Keyboard shortcuts
     useKeyboardShortcut(false, true, false, 'z', () => dispatch(undo()));
     useKeyboardShortcut(false, true, false, 'y', () => dispatch(redo()));
+    useKeyboardShortcut(false, true, true, 'c', markSelectedElementAsComplete);
     useKeyboardShortcut(false, true, false, 'ArrowLeft', goToPreviousMatch);
     useKeyboardShortcut(false, true, false, 'ArrowRight', goToNextMatch);
     useKeyboardShortcut(false, true, false, 'ArrowUp', goToParent);
@@ -224,6 +233,15 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
                                 command="Ctrl+Y"
                             >
                                 Redo
+                            </MenuItem>
+                            <MenuDivider />
+                            <MenuItem
+                                paddingLeft={8}
+                                onClick={markSelectedElementAsComplete}
+                                isDisabled={!declaration || declaration instanceof PythonPackage || !usernameIsValid}
+                                command="Ctrl+Alt+C"
+                            >
+                                Toggle Completion of Selected Element
                             </MenuItem>
                             <MenuDivider />
                             <MenuGroup title={'Batch Annotate'}>


### PR DESCRIPTION
Closes #737.

### Summary of Changes

The completion status of the selected API element can now be toggled by `Ctrl+Alt+C`. When a function is selected only its own completion status is affected, not the one of its parameters.