### PR TITLE
fix(gui): show tooltips on bar charts even when cursor does not intersect bar

### DIFF
--- a/api-editor/gui/src/features/packageData/selectionView/ParameterView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ParameterView.tsx
@@ -77,10 +77,10 @@ const createBarChart = function (parameterUsages: Map<string, number>): React.Re
             },
             tooltip: {
                 interaction: {
-                    axis: 'y'
+                    axis: 'y',
                 },
                 intersect: false,
-            }
+            },
         },
     };
 

--- a/api-editor/gui/src/features/packageData/selectionView/ParameterView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ParameterView.tsx
@@ -73,8 +73,14 @@ const createBarChart = function (parameterUsages: Map<string, number>): React.Re
         responsive: true,
         plugins: {
             legend: {
-                display: false as const,
+                display: false,
             },
+            tooltip: {
+                interaction: {
+                    axis: 'y'
+                },
+                intersect: false,
+            }
         },
     };
 

--- a/api-editor/gui/src/features/statistics/ChartWrappers.tsx
+++ b/api-editor/gui/src/features/statistics/ChartWrappers.tsx
@@ -35,10 +35,10 @@ export const createBarChart = function (labels: string[], values: number[], titl
             },
             tooltip: {
                 interaction: {
-                    axis: 'y'
+                    axis: 'y',
                 },
                 intersect: false,
-            }
+            },
         },
     };
 

--- a/api-editor/gui/src/features/statistics/ChartWrappers.tsx
+++ b/api-editor/gui/src/features/statistics/ChartWrappers.tsx
@@ -33,6 +33,12 @@ export const createBarChart = function (labels: string[], values: number[], titl
                 display: true,
                 text: title,
             },
+            tooltip: {
+                interaction: {
+                    axis: 'y'
+                },
+                intersect: false,
+            }
         },
     };
 


### PR DESCRIPTION
Closes #720.

### Summary of Changes

When the cursor hovers over a bar chart the tooltip of the bar with the closest y-coordinate is now always shown. This allows to view the tooltip easily even for tiny bars without having to be pixel-perfect with the mouse.
