### PR TITLE
fix(gui): scrollbars on documentation text

### DIFF
--- a/api-editor/gui/src/app/App.tsx
+++ b/api-editor/gui/src/app/App.tsx
@@ -159,7 +159,7 @@ export const App: React.FC = function () {
                     {currentUserAction.type === 'todo' && <TodoForm target={userActionTarget || rawPythonPackage} />}
                 </GridItem>
                 <GridItem gridArea="middlePane" overflow="auto" display="flex">
-                    <Box flexGrow={1} overflowY="auto" width="100%" >
+                    <Box flexGrow={1} overflowY="auto" width="100%">
                         {(batchMode === BatchMode.None || !isValidUsername) && <SelectionView />}
 
                         {batchMode === BatchMode.Constant && isValidUsername && (

--- a/api-editor/gui/src/app/App.tsx
+++ b/api-editor/gui/src/app/App.tsx
@@ -158,8 +158,8 @@ export const App: React.FC = function () {
                     )}
                     {currentUserAction.type === 'todo' && <TodoForm target={userActionTarget || rawPythonPackage} />}
                 </GridItem>
-                <GridItem gridArea="middlePane" overflow="auto">
-                    <Box flexGrow={1} overflowY="auto" width="100%">
+                <GridItem gridArea="middlePane" overflow="auto" display="flex">
+                    <Box flexGrow={1} overflowY="auto" width="100%" >
                         {(batchMode === BatchMode.None || !isValidUsername) && <SelectionView />}
 
                         {batchMode === BatchMode.Constant && isValidUsername && (

--- a/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
@@ -99,6 +99,7 @@ export const DocumentationText: React.FC<DocumentationTextProps> = function ({ d
         <Flex justifyContent="flex-start">
             <HStack
                 alignItems="flex-start"
+                overflow="hidden"
                 cursor={!hasMultipleLines || readMore ? undefined : 'pointer'}
                 onClick={
                     !hasMultipleLines || readMore
@@ -122,7 +123,7 @@ export const DocumentationText: React.FC<DocumentationTextProps> = function ({ d
                     />
                 )}
 
-                <Stack spacing={4}>
+                <Stack spacing={4} overflowX="auto" paddingBottom={4}>
                     <ReactMarkdown
                         components={components}
                         rehypePlugins={[rehypeKatex]}


### PR DESCRIPTION
### Summary of Changes

The documentation text now gets its own scrollbar when the text overflows the middle pane.