### PR TITLE
fix(gui): wrong label for relative links in documentation

### DIFF
--- a/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
@@ -148,7 +148,7 @@ const resolveRelativeLink = function (currentDeclaration: PythonDeclaration, lin
         return linkedDeclarationName;
     }
 
-    return `[${currentDeclaration.preferredQualifiedName()}](${sibling.id})`;
+    return `[${sibling.preferredQualifiedName()}](${sibling.id})`;
 };
 
 const resolveAbsoluteLink = function (


### PR DESCRIPTION
### Summary of Changes

The qualified name of the selected declaration was used as the label of relative links in the documentation. Now it's correctly the qualified name of the linked declaration.