### PR TITLE
feat(gui): descriptions of annotations

### DIFF
--- a/api-editor/gui/src/features/annotations/AnnotationView.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationView.tsx
@@ -65,7 +65,7 @@ import {
     showTodoAnnotationForm,
 } from '../ui/uiSlice';
 import { truncate } from '../../common/util/stringOperations';
-import { wrongAnnotationURL } from '../reporting/issueURLBuilder';
+import { wrongAnnotationURL } from '../externalLinks/urlBuilder';
 
 interface AnnotationViewProps {
     target: string;

--- a/api-editor/gui/src/features/annotations/MissingAnnotationButton.tsx
+++ b/api-editor/gui/src/features/annotations/MissingAnnotationButton.tsx
@@ -1,7 +1,7 @@
 import { IconButton } from '@chakra-ui/react';
 import React from 'react';
 import { FaFlag } from 'react-icons/fa';
-import { missingAnnotationURL } from '../reporting/issueURLBuilder';
+import { missingAnnotationURL } from '../externalLinks/urlBuilder';
 
 interface MissingAnnotationButtonProps {
     target: string;

--- a/api-editor/gui/src/features/annotations/batchforms/AnnotationBatchForm.tsx
+++ b/api-editor/gui/src/features/annotations/batchforms/AnnotationBatchForm.tsx
@@ -1,8 +1,9 @@
-import { Button, Heading, HStack, Stack } from '@chakra-ui/react';
+import { Button, Heading, HStack, Stack, Text as ChakraText } from '@chakra-ui/react';
 import React from 'react';
 
 interface AnnotationFormProps {
     heading: string;
+    description: string;
     onConfirm: React.MouseEventHandler<HTMLButtonElement>;
     onCancel: React.MouseEventHandler<HTMLButtonElement>;
     children: React.ReactNode;
@@ -10,15 +11,20 @@ interface AnnotationFormProps {
 
 export const AnnotationBatchForm: React.FC<AnnotationFormProps> = function ({
     heading,
+    description,
     onCancel,
     onConfirm,
     children,
 }) {
     return (
         <Stack spacing={8} p={4}>
-            <Heading as="h3" size="lg">
-                {heading}
-            </Heading>
+            <Stack spacing={4}>
+                <Heading as="h3" size="lg">
+                    {heading}
+                </Heading>
+
+                <ChakraText fontStyle="italic">{description}</ChakraText>
+            </Stack>
 
             <Stack spacing={4}>{children}</Stack>
 

--- a/api-editor/gui/src/features/annotations/batchforms/ConstantBatchForm.tsx
+++ b/api-editor/gui/src/features/annotations/batchforms/ConstantBatchForm.tsx
@@ -37,6 +37,7 @@ export const ConstantBatchForm: React.FC<ConstantBatchFormProps> = function ({ t
         <TypeValueBatchForm
             targets={filteredTargets}
             annotationType="constant"
+            description="Delete matched parameters and replace references to them with a constant value."
             onUpsertAnnotation={handleUpsertAnnotation}
         />
     );

--- a/api-editor/gui/src/features/annotations/batchforms/DestinationBatchForm.tsx
+++ b/api-editor/gui/src/features/annotations/batchforms/DestinationBatchForm.tsx
@@ -10,6 +10,7 @@ import { ConfirmAnnotations } from './ConfirmAnnotations';
 interface DestinationBatchFormProps {
     targets: PythonDeclaration[];
     annotationType: string;
+    description: string;
     onUpsertAnnotation: (data: DestinationBatchFormState) => void;
 }
 
@@ -20,6 +21,7 @@ export interface DestinationBatchFormState {
 export const DestinationBatchForm: React.FC<DestinationBatchFormProps> = function ({
     targets,
     annotationType,
+    description,
     onUpsertAnnotation,
 }) {
     const dispatch = useAppDispatch();
@@ -60,6 +62,7 @@ export const DestinationBatchForm: React.FC<DestinationBatchFormProps> = functio
         <>
             <AnnotationBatchForm
                 heading={`Add @${annotationType} Annotations`}
+                description={description}
                 onConfirm={handleSubmit(handleConfirm)}
                 onCancel={handleCancel}
             >

--- a/api-editor/gui/src/features/annotations/batchforms/EmptyBatchForm.tsx
+++ b/api-editor/gui/src/features/annotations/batchforms/EmptyBatchForm.tsx
@@ -9,6 +9,7 @@ import { ConfirmAnnotations } from './ConfirmAnnotations';
 interface EmptyBatchFormProps {
     targets: PythonDeclaration[];
     annotationType: string;
+    description: string;
     onUpsertAnnotation: () => void;
     targetLabel: string;
 }
@@ -16,6 +17,7 @@ interface EmptyBatchFormProps {
 export const EmptyBatchForm: React.FC<EmptyBatchFormProps> = function ({
     targets,
     annotationType,
+    description,
     onUpsertAnnotation,
     targetLabel,
 }) {
@@ -45,6 +47,7 @@ export const EmptyBatchForm: React.FC<EmptyBatchFormProps> = function ({
         <>
             <AnnotationBatchForm
                 heading={`Add @${annotationType} Annotations`}
+                description={description}
                 onConfirm={handleConfirm}
                 onCancel={handleCancel}
             >

--- a/api-editor/gui/src/features/annotations/batchforms/MoveBatchForm.tsx
+++ b/api-editor/gui/src/features/annotations/batchforms/MoveBatchForm.tsx
@@ -38,6 +38,7 @@ export const MoveBatchForm: React.FC<MoveBatchFormProps> = function ({ targets }
         <DestinationBatchForm
             targets={filteredTargets}
             annotationType="move"
+            description="Move matched global declarations to another module."
             onUpsertAnnotation={handleUpsertAnnotation}
         />
     );

--- a/api-editor/gui/src/features/annotations/batchforms/OldNewBatchForm.tsx
+++ b/api-editor/gui/src/features/annotations/batchforms/OldNewBatchForm.tsx
@@ -10,6 +10,7 @@ import { ConfirmAnnotations } from './ConfirmAnnotations';
 interface OldNewBatchFormProps {
     targets: PythonDeclaration[];
     annotationType: string;
+    description: string;
     onUpsertAnnotation: (data: OldNewBatchFormState) => void;
 }
 
@@ -21,6 +22,7 @@ export interface OldNewBatchFormState {
 export const OldNewBatchForm: React.FC<OldNewBatchFormProps> = function ({
     targets,
     annotationType,
+    description,
     onUpsertAnnotation,
 }) {
     const dispatch = useAppDispatch();
@@ -65,6 +67,7 @@ export const OldNewBatchForm: React.FC<OldNewBatchFormProps> = function ({
         <>
             <AnnotationBatchForm
                 heading={`Add @${annotationType} Annotations`}
+                description={description}
                 onConfirm={handleSubmit(handleConfirm)}
                 onCancel={handleCancel}
             >

--- a/api-editor/gui/src/features/annotations/batchforms/OptionalBatchForm.tsx
+++ b/api-editor/gui/src/features/annotations/batchforms/OptionalBatchForm.tsx
@@ -37,6 +37,7 @@ export const OptionalBatchForm: React.FC<OptionalBatchFormProps> = function ({ t
         <TypeValueBatchForm
             targets={filteredTargets}
             annotationType="optional"
+            description="Make matched parameters optional and set their default value."
             onUpsertAnnotation={handleUpsertAnnotation}
         />
     );

--- a/api-editor/gui/src/features/annotations/batchforms/RemoveBatchForm.tsx
+++ b/api-editor/gui/src/features/annotations/batchforms/RemoveBatchForm.tsx
@@ -35,6 +35,7 @@ export const RemoveBatchForm: React.FC<RemoveBatchFormProps> = function ({ targe
         <EmptyBatchForm
             targets={filteredTargets}
             annotationType="remove"
+            description="Remove matched classes and functions."
             onUpsertAnnotation={handleUpsertAnnotation}
             targetLabel="This will annotate classes and functions."
         />

--- a/api-editor/gui/src/features/annotations/batchforms/RenameBatchForm.tsx
+++ b/api-editor/gui/src/features/annotations/batchforms/RenameBatchForm.tsx
@@ -40,6 +40,7 @@ export const RenameBatchForm: React.FC<RenameBatchFormProps> = function ({ targe
         <OldNewBatchForm
             targets={filteredTargets}
             annotationType="rename"
+            description="Substitute parts of the names of matched declarations."
             onUpsertAnnotation={handleUpsertAnnotation}
         />
     );

--- a/api-editor/gui/src/features/annotations/batchforms/RequiredBatchForm.tsx
+++ b/api-editor/gui/src/features/annotations/batchforms/RequiredBatchForm.tsx
@@ -35,6 +35,7 @@ export const RequiredBatchForm: React.FC<RequiredBatchFormProps> = function ({ t
         <EmptyBatchForm
             targets={filteredTargets}
             annotationType="required"
+            description="Make matched parameters required."
             onUpsertAnnotation={handleUpsertAnnotation}
             targetLabel="This will annotate parameters."
         />

--- a/api-editor/gui/src/features/annotations/batchforms/TypeValueBatchForm.tsx
+++ b/api-editor/gui/src/features/annotations/batchforms/TypeValueBatchForm.tsx
@@ -28,6 +28,7 @@ import { ConfirmAnnotations } from './ConfirmAnnotations';
 interface TypeValueBatchFormProps {
     targets: PythonDeclaration[];
     annotationType: string;
+    description: string;
     onUpsertAnnotation: (data: TypeValueBatchFormState) => void;
 }
 
@@ -39,6 +40,7 @@ export interface TypeValueBatchFormState {
 export const TypeValueBatchForm: React.FC<TypeValueBatchFormProps> = function ({
     targets,
     annotationType,
+    description,
     onUpsertAnnotation,
 }) {
     const dispatch = useAppDispatch();
@@ -99,6 +101,7 @@ export const TypeValueBatchForm: React.FC<TypeValueBatchFormProps> = function ({
         <>
             <AnnotationBatchForm
                 heading={`Add @${annotationType} Annotations`}
+                description={description}
                 onConfirm={handleSubmit(handleConfirm)}
                 onCancel={handleCancel}
             >

--- a/api-editor/gui/src/features/annotations/forms/AnnotationForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/AnnotationForm.tsx
@@ -1,19 +1,30 @@
-import { Button, Heading, HStack, Stack } from '@chakra-ui/react';
+import { Button, Heading, HStack, Stack, Text as ChakraText } from '@chakra-ui/react';
 import React from 'react';
 
 interface AnnotationFormProps {
     heading: string;
+    description: string;
     onSave: React.MouseEventHandler<HTMLButtonElement>;
     onCancel: React.MouseEventHandler<HTMLButtonElement>;
     children: React.ReactNode;
 }
 
-export const AnnotationForm: React.FC<AnnotationFormProps> = function ({ heading, onCancel, onSave, children }) {
+export const AnnotationForm: React.FC<AnnotationFormProps> = function ({
+    heading,
+    description,
+    onCancel,
+    onSave,
+    children,
+}) {
     return (
         <Stack spacing={8} p={4}>
-            <Heading as="h3" size="lg">
-                {heading}
-            </Heading>
+            <Stack spacing={4}>
+                <Heading as="h3" size="lg">
+                    {heading}
+                </Heading>
+
+                <ChakraText fontStyle="italic">{description}</ChakraText>
+            </Stack>
 
             <Stack spacing={4}>{children}</Stack>
 

--- a/api-editor/gui/src/features/annotations/forms/AttributeForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/AttributeForm.tsx
@@ -34,6 +34,7 @@ export const AttributeForm: React.FC<AttributeFormProps> = function ({ target })
         <TypeValueForm
             target={target}
             annotationType="attribute"
+            description="Delete this constructor parameter (but keep the related attribute)."
             previousDefaultType={previousDefaultType}
             previousDefaultValue={previousDefaultValue}
             onUpsertAnnotation={handleUpsertAnnotation}

--- a/api-editor/gui/src/features/annotations/forms/BoundaryForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/BoundaryForm.tsx
@@ -142,6 +142,7 @@ export const BoundaryForm: React.FC<BoundaryFormProps> = function ({ target }) {
     return (
         <AnnotationForm
             heading={`${prevInterval ? 'Edit' : 'Add'} @boundary Annotation`}
+            description="Specify the interval of valid values of this numeric parameter."
             onSave={handleSubmit(onSave)}
             onCancel={onCancel}
         >

--- a/api-editor/gui/src/features/annotations/forms/CalledAfterForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/CalledAfterForm.tsx
@@ -73,9 +73,11 @@ export const CalledAfterForm: React.FC<CalledAfterFormProps> = function ({ targe
 
     return (
         <AnnotationForm
-            heading='@calledAfter Annotation'
+            heading="@calledAfter Annotation"
             description="Specify that this function must be called after another function."
-            onSave={handleSubmit(onSave)} onCancel={onCancel}>
+            onSave={handleSubmit(onSave)}
+            onCancel={onCancel}
+        >
             <FormControl isInvalid={Boolean(errors?.calledAfterName)}>
                 <FormLabel>Name of the callable to be called before:</FormLabel>
                 <Select

--- a/api-editor/gui/src/features/annotations/forms/CalledAfterForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/CalledAfterForm.tsx
@@ -72,7 +72,10 @@ export const CalledAfterForm: React.FC<CalledAfterFormProps> = function ({ targe
     // Rendering -------------------------------------------------------------------------------------------------------
 
     return (
-        <AnnotationForm heading={`@calledAfter Annotation`} onSave={handleSubmit(onSave)} onCancel={onCancel}>
+        <AnnotationForm
+            heading='@calledAfter Annotation'
+            description="Specify that this function must be called after another function."
+            onSave={handleSubmit(onSave)} onCancel={onCancel}>
             <FormControl isInvalid={Boolean(errors?.calledAfterName)}>
                 <FormLabel>Name of the callable to be called before:</FormLabel>
                 <Select

--- a/api-editor/gui/src/features/annotations/forms/ConstantForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/ConstantForm.tsx
@@ -34,6 +34,7 @@ export const ConstantForm: React.FC<ConstantFormProps> = function ({ target }) {
         <TypeValueForm
             target={target}
             annotationType="constant"
+            description="Delete this parameter and replace references to it with a constant value."
             previousDefaultType={previousDefaultType}
             previousDefaultValue={previousDefaultValue}
             onUpsertAnnotation={handleUpsertAnnotation}

--- a/api-editor/gui/src/features/annotations/forms/DescriptionForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/DescriptionForm.tsx
@@ -66,6 +66,7 @@ export const DescriptionForm: React.FC<DescriptionFormProps> = function ({ targe
     return (
         <AnnotationForm
             heading={`${prevNewDescription ? 'Edit' : 'Add'} @description Annotation`}
+            description="Change the description of this declaration."
             onSave={handleSubmit(onSave)}
             onCancel={onCancel}
         >

--- a/api-editor/gui/src/features/annotations/forms/EnumForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/EnumForm.tsx
@@ -114,6 +114,7 @@ export const EnumForm: React.FC<EnumFormProps> = function ({ target }) {
     return (
         <AnnotationForm
             heading={`${enumDefinition ? 'Edit' : 'Add'} @enum Annotation`}
+            description="Replace this string parameter with an enum parameter."
             onSave={handleSubmit(onSave)}
             onCancel={onCancel}
         >

--- a/api-editor/gui/src/features/annotations/forms/GroupForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/GroupForm.tsx
@@ -126,6 +126,7 @@ export const GroupForm: React.FC<GroupFormProps> = function ({ target, groupName
     return (
         <AnnotationForm
             heading={`${prevGroupAnnotation ? 'Edit' : 'Add'} @group Annotation`}
+            description="Replace multiple parameters of this function with a parameter object."
             onSave={handleSubmit(onSave)}
             onCancel={onCancel}
         >

--- a/api-editor/gui/src/features/annotations/forms/MoveForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/MoveForm.tsx
@@ -71,6 +71,7 @@ export const MoveForm: React.FC<MoveFormProps> = function ({ target }) {
     return (
         <AnnotationForm
             heading={`${prevDestination ? 'Edit' : 'Add'} @move Annotation`}
+            description="Move this global declaration to another module."
             onSave={handleSubmit(onSave)}
             onCancel={onCancel}
         >

--- a/api-editor/gui/src/features/annotations/forms/OptionalForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/OptionalForm.tsx
@@ -34,6 +34,7 @@ export const OptionalForm: React.FC<OptionalFormProps> = function ({ target }) {
         <TypeValueForm
             target={target}
             annotationType="optional"
+            description="Make this parameter optional and set its default value."
             previousDefaultType={previousDefaultType}
             previousDefaultValue={previousDefaultValue}
             onUpsertAnnotation={handleUpsertAnnotation}

--- a/api-editor/gui/src/features/annotations/forms/RenameForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/RenameForm.tsx
@@ -71,6 +71,7 @@ export const RenameForm: React.FC<RenameFormProps> = function ({ target }) {
     return (
         <AnnotationForm
             heading={`${prevNewName ? 'Edit' : 'Add'} @rename Annotation`}
+            description="Change the name of this declaration."
             onSave={handleSubmit(onSave)}
             onCancel={onCancel}
         >

--- a/api-editor/gui/src/features/annotations/forms/TodoForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/TodoForm.tsx
@@ -69,6 +69,7 @@ export const TodoForm: React.FC<TodoFormProps> = function ({ target }) {
     return (
         <AnnotationForm
             heading={`${prevNewTodo ? 'Edit' : 'Add'} @todo Annotation`}
+            description="Take a note about additional (manual) changes you need to make to this declaration."
             onSave={handleSubmit(onSave)}
             onCancel={onCancel}
         >

--- a/api-editor/gui/src/features/annotations/forms/TodoForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/TodoForm.tsx
@@ -69,7 +69,7 @@ export const TodoForm: React.FC<TodoFormProps> = function ({ target }) {
     return (
         <AnnotationForm
             heading={`${prevNewTodo ? 'Edit' : 'Add'} @todo Annotation`}
-            description="Take a note about additional (manual) changes you need to make to this declaration."
+            description="Note additional (manual) changes you need to make to this declaration."
             onSave={handleSubmit(onSave)}
             onCancel={onCancel}
         >

--- a/api-editor/gui/src/features/annotations/forms/TypeValueForm.tsx
+++ b/api-editor/gui/src/features/annotations/forms/TypeValueForm.tsx
@@ -27,6 +27,7 @@ import { hideAnnotationForm } from '../../ui/uiSlice';
 interface TypeValueFormProps {
     target: PythonDeclaration;
     annotationType: string;
+    description: string;
     previousDefaultType: Optional<DefaultType>;
     previousDefaultValue: Optional<DefaultValue>;
     onUpsertAnnotation: (data: TypeValueFormState) => void;
@@ -40,6 +41,7 @@ export interface TypeValueFormState {
 export const TypeValueForm: React.FC<TypeValueFormProps> = function ({
     target,
     annotationType,
+    description,
     previousDefaultType,
     previousDefaultValue,
     onUpsertAnnotation,
@@ -99,6 +101,7 @@ export const TypeValueForm: React.FC<TypeValueFormProps> = function ({
     return (
         <AnnotationForm
             heading={`${previousDefaultType ? 'Edit' : 'Add'} @${annotationType} Annotation`}
+            description={description}
             onSave={handleSubmit(handleSave)}
             onCancel={handleCancel}
         >

--- a/api-editor/gui/src/features/externalLinks/urlBuilder.test.ts
+++ b/api-editor/gui/src/features/externalLinks/urlBuilder.test.ts
@@ -1,5 +1,10 @@
-import { bugReportURL, featureRequestURL, missingAnnotationURL, wrongAnnotationURL } from './issueURLBuilder';
+import { bugReportURL, featureRequestURL, missingAnnotationURL, userGuideURL, wrongAnnotationURL } from './urlBuilder';
 import fetch from 'node-fetch';
+
+test('user guide URL should be correct', async () => {
+    const response = await fetch(userGuideURL);
+    expect(response.status).toBe(200);
+});
 
 test('bug report URL should be correct', async () => {
     const response = await fetch(bugReportURL);

--- a/api-editor/gui/src/features/externalLinks/urlBuilder.ts
+++ b/api-editor/gui/src/features/externalLinks/urlBuilder.ts
@@ -1,18 +1,28 @@
 import { Annotation } from '../annotations/annotationSlice';
 
-const baseURL = 'https://github.com/lars-reimann/api-editor/issues/new';
+const baseURL = 'https://github.com/lars-reimann/api-editor';
 
-export const bugReportURL = `${baseURL}?assignees=&labels=bug&template=bug_report.yml`;
-export const featureRequestURL = `${baseURL}?assignees=&labels=enhancement&template=feature_request.yml`;
+// Documentation
 
-const baseMissingAnnotationURL = `${baseURL}?assignees=&labels=bug%2Cmissing+annotation&template=missing_annotation.yml`;
+const documentationBaseURL = `${baseURL}/blob/main/docs`;
+
+export const userGuideURL = `${documentationBaseURL}/api-editor.md`;
+
+// Issues
+
+const issueBaseURL = `${baseURL}/issues/new`;
+
+export const bugReportURL = `${issueBaseURL}?assignees=&labels=bug&template=bug_report.yml`;
+export const featureRequestURL = `${issueBaseURL}?assignees=&labels=enhancement&template=feature_request.yml`;
+
+const baseMissingAnnotationURL = `${issueBaseURL}?assignees=&labels=bug%2Cmissing+annotation&template=missing_annotation.yml`;
 
 export const missingAnnotationURL = function (target: string): string {
     const urlHash = encodeURIComponent(`\`#/${target}\``);
     return `${baseMissingAnnotationURL}&url-hash=${urlHash}`;
 };
 
-const baseWrongAnnotationURL = `${baseURL}?assignees=&template=wrong_annotation.yml&labels=bug%2Cwrong+annotation%2C`;
+const baseWrongAnnotationURL = `${issueBaseURL}?assignees=&template=wrong_annotation.yml&labels=bug%2Cwrong+annotation%2C`;
 
 export const wrongAnnotationURL = function (annotationType: string, annotation: Annotation): string {
     const minimalAnnotation = { ...annotation };

--- a/api-editor/gui/src/features/menuBar/HelpMenu.tsx
+++ b/api-editor/gui/src/features/menuBar/HelpMenu.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Icon, Menu, MenuButton, MenuGroup, MenuItem, MenuList } from '@chakra-ui/react';
 import React from 'react';
 import { FaBug, FaChevronDown, FaLightbulb } from 'react-icons/fa';
-import {bugReportURL, featureRequestURL, userGuideURL} from '../externalLinks/urlBuilder';
+import { bugReportURL, featureRequestURL, userGuideURL } from '../externalLinks/urlBuilder';
 
 export const HelpMenu = function () {
     return (

--- a/api-editor/gui/src/features/menuBar/HelpMenu.tsx
+++ b/api-editor/gui/src/features/menuBar/HelpMenu.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Icon, Menu, MenuButton, MenuGroup, MenuItem, MenuList } from '@chakra-ui/react';
 import React from 'react';
 import { FaBug, FaChevronDown, FaLightbulb } from 'react-icons/fa';
-import { bugReportURL, featureRequestURL } from '../reporting/issueURLBuilder';
+import {bugReportURL, featureRequestURL, userGuideURL} from '../externalLinks/urlBuilder';
 
 export const HelpMenu = function () {
     return (
@@ -11,6 +11,16 @@ export const HelpMenu = function () {
                     Help
                 </MenuButton>
                 <MenuList>
+                    <MenuGroup title="Documentation">
+                        <MenuItem
+                            paddingLeft={8}
+                            onClick={() => {
+                                window.open(userGuideURL, '_blank');
+                            }}
+                        >
+                            User Guide
+                        </MenuItem>
+                    </MenuGroup>
                     <MenuGroup title="Feedback">
                         <MenuItem
                             paddingLeft={8}

--- a/api-editor/gui/src/features/menuBar/MenuBar.tsx
+++ b/api-editor/gui/src/features/menuBar/MenuBar.tsx
@@ -399,16 +399,18 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
                         <MenuList>
                             <MenuGroup title="Visual">
                                 <MenuOptionGroup type="checkbox" value={visualSettings}>
-                                    <MenuItemOption value={'darkMode'} onClick={toggleColorMode}>
+                                    <MenuItemOption paddingLeft={8} value={'darkMode'} onClick={toggleColorMode}>
                                         Dark Mode
                                     </MenuItemOption>
                                     <MenuItemOption
+                                        paddingLeft={8}
                                         value={'statistics'}
                                         onClick={() => dispatch(toggleStatisticsView())}
                                     >
                                         Show Statistics
                                     </MenuItemOption>
                                     <MenuItemOption
+                                        paddingLeft={8}
                                         value={'toggleDocumentationByDefault'}
                                         onClick={() => dispatch(toggleExpandDocumentationByDefault())}
                                     >


### PR DESCRIPTION
Closes #745.

### Summary of Changes

* Link to user guide (thanks to @Aclrian) on GitHub
* Add short help texts to annotation forms that describe the effect of annotations

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/175810711-9de114c4-67ad-4cff-9639-96c8e20e17c2.png)

![image](https://user-images.githubusercontent.com/2501322/175810754-a19f33e4-c872-488c-b858-17cb32be8dca.png)

### Additional Context

I'm still looking for a good place to add help texts to annotations that don't require further inputs and, thus, don't have an accompanying form.