### PR TITLE
chore: fields for minimal API data and minimal usage store in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/missing_annotation.yml
+++ b/.github/ISSUE_TEMPLATE/missing_annotation.yml
@@ -34,7 +34,7 @@ body:
       description: Which inputs did you expect the annotation to have? If possible, provide the JSON for the expected annotation.
     validations:
       required: true
-      
+
   - type: textarea
     id: minimal-api-data
     attributes:
@@ -42,7 +42,7 @@ body:
       description: If possible, provide the JSON for a minimal API with the element that should have been annotated, and its ancestors.
     validations:
       required: false
- 
+
   - type: textarea
     id: minimal-usage-store
     attributes:

--- a/.github/ISSUE_TEMPLATE/missing_annotation.yml
+++ b/.github/ISSUE_TEMPLATE/missing_annotation.yml
@@ -31,7 +31,7 @@ body:
     id: expected-annotation-inputs
     attributes:
       label: Expected Annotation Inputs
-      description: Which inputs did you expect the annotation to have?
+      description: Which inputs did you expect the annotation to have? If possible, provide the JSON for the expected annotation.
     validations:
       required: true
       

--- a/.github/ISSUE_TEMPLATE/missing_annotation.yml
+++ b/.github/ISSUE_TEMPLATE/missing_annotation.yml
@@ -34,6 +34,22 @@ body:
       description: Which inputs did you expect the annotation to have?
     validations:
       required: true
+      
+  - type: textarea
+    id: minimal-api-data
+    attributes:
+      label: Minimal API Data (optional)
+      description: If possible, provide the JSON for a minimal API with the element that should have been annotated, and its ancestors.
+    validations:
+      required: false
+ 
+  - type: textarea
+    id: minimal-usage-store
+    attributes:
+      label: Minimal Usage Store (optional)
+      description: If possible, provide the JSON for a minimal usage store with the element that should have been annotated, and its ancestors.
+    validations:
+      required: false
 
   - type: textarea
     id: suggested-solution

--- a/.github/ISSUE_TEMPLATE/wrong_annotation.yml
+++ b/.github/ISSUE_TEMPLATE/wrong_annotation.yml
@@ -31,7 +31,7 @@ body:
     id: actual-annotation-inputs
     attributes:
       label: Actual Annotation Inputs
-      description: Which inputs did the automatically generated annotation have?
+      description: Which inputs did the automatically generated annotation have? If possible, provide the JSON for the actual annotation.
     validations:
       required: true
 
@@ -55,9 +55,25 @@ body:
     id: expected-annotation-inputs
     attributes:
       label: Expected Annotation Inputs
-      description: Which inputs did you expect the annotation to have?
+      description: Which inputs did you expect the annotation to have? If possible, provide the JSON for the expected annotation.
     validations:
       required: true
+      
+  - type: textarea
+    id: minimal-api-data
+    attributes:
+      label: Minimal API Data (optional)
+      description: If possible, provide the JSON for a minimal API with the element that should have been annotated, and its ancestors.
+    validations:
+      required: false
+ 
+  - type: textarea
+    id: minimal-usage-store
+    attributes:
+      label: Minimal Usage Store (optional)
+      description: If possible, provide the JSON for a minimal usage store with the element that should have been annotated, and its ancestors.
+    validations:
+      required: false
 
   - type: textarea
     id: suggested-solution

--- a/.github/ISSUE_TEMPLATE/wrong_annotation.yml
+++ b/.github/ISSUE_TEMPLATE/wrong_annotation.yml
@@ -58,7 +58,7 @@ body:
       description: Which inputs did you expect the annotation to have? If possible, provide the JSON for the expected annotation.
     validations:
       required: true
-      
+
   - type: textarea
     id: minimal-api-data
     attributes:
@@ -66,7 +66,7 @@ body:
       description: If possible, provide the JSON for a minimal API with the element that should have been annotated, and its ancestors.
     validations:
       required: false
- 
+
   - type: textarea
     id: minimal-usage-store
     attributes:


### PR DESCRIPTION
Closes partially #807.

### Summary of Changes

The issue templates for missing/wrong annotations now have to additional optional fields where users can enter contextual information about the API data and the usage data they have loaded.
