### PR TITLE
chore(backend): override children() on PythonNamedSpread and PythonPositionalSpread

### DIFF
--- a/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/mutable_model/PythonAst.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/api_editor/mutable_model/PythonAst.kt
@@ -271,10 +271,18 @@ class PythonMemberAccess(
 
 class PythonNamedSpread(argument: PythonExpression) : PythonExpression() {
     var argument by ContainmentReference(argument)
+
+    override fun children() = sequence {
+        argument?.let { yield(it) }
+    }
 }
 
 class PythonPositionalSpread(argument: PythonExpression) : PythonExpression() {
     var argument by ContainmentReference(argument)
+
+    override fun children() = sequence {
+        argument?.let { yield(it) }
+    }
 }
 
 class PythonReference(declaration: PythonDeclaration) : PythonExpression() {


### PR DESCRIPTION
### Summary of Changes

The implementation was missing previously. Since it's never used yet anyway, this PR is not marked as a fix.