### PR TITLE
fix(gui): crash when importing incomplete annotation files

### DIFF
--- a/api-editor/gui/src/features/annotations/annotationSlice.ts
+++ b/api-editor/gui/src/features/annotations/annotationSlice.ts
@@ -384,7 +384,10 @@ const annotationsSlice = createSlice({
             updateQueue(state);
         },
         mergeAnnotationStore(state, action: PayloadAction<AnnotationStore>) {
-            state.annotations = mergeAnnotationStores(state.annotations, action.payload);
+            state.annotations = mergeAnnotationStores(state.annotations, {
+                ...initialAnnotationStore,
+                ...action.payload,
+            });
 
             updateQueue(state);
         },

--- a/api-editor/gui/src/features/menuBar/DeleteAllAnnotations.tsx
+++ b/api-editor/gui/src/features/menuBar/DeleteAllAnnotations.tsx
@@ -53,7 +53,7 @@ export const DeleteAllAnnotations = function () {
                                     <strong>Are you sure?</strong>
                                 </ChakraText>
                                 <ChakraText>
-                                    Hint: Consider exporting your work first selecting "File &gt; Export &gt;
+                                    Hint: Consider exporting your work first by selecting "File &gt; Export &gt;
                                     Annotations" in the menu bar.
                                 </ChakraText>
                             </VStack>


### PR DESCRIPTION
### Summary of Changes

Importing and merging an incomplete annotation file no longer crashes the application.