### PR TITLE
fix(gui): deletion of all annotations when user selects API file in import dialog

### DIFF
--- a/api-editor/gui/src/features/packageData/PackageDataImportDialog.tsx
+++ b/api-editor/gui/src/features/packageData/PackageDataImportDialog.tsx
@@ -79,7 +79,6 @@ export const PackageDataImportDialog: React.FC = function () {
             reader.onload = () => {
                 if (typeof reader.result === 'string') {
                     setNewPythonPackageString(reader.result);
-                    dispatch(resetAnnotationStore());
                 }
             };
             reader.readAsText(acceptedFiles[0]);


### PR DESCRIPTION
### Summary of Changes

Previously, simply selecting an API file in the import dialog for package data would delete all annotations. Now this only happens when the user actually clicks on submit.