### PR TITLE
fix(gui): missing start/end of list message for last/first element in unfiltered list

### DIFF
--- a/api-editor/gui/src/features/menuBar/MenuBar.tsx
+++ b/api-editor/gui/src/features/menuBar/MenuBar.tsx
@@ -500,7 +500,7 @@ const getPreviousElementPath = function (
     annotations: AnnotationStore,
     usages: UsageCountStore,
 ): { id: string; wrappedAround: boolean } {
-    const startIndex = getIndex(declarations, start)
+    const startIndex = getIndex(declarations, start);
     let currentIndex = getPreviousIndex(declarations, startIndex);
     let current = getElementAtIndex(declarations, currentIndex);
     let wrappedAround = startIndex !== null && currentIndex !== null && currentIndex >= startIndex;
@@ -526,7 +526,7 @@ const getNextElementPath = function (
     annotations: AnnotationStore,
     usages: UsageCountStore,
 ): { id: string; wrappedAround: boolean } {
-    const startIndex = getIndex(declarations, start)
+    const startIndex = getIndex(declarations, start);
     let currentIndex = getNextIndex(declarations, startIndex);
     let current = getElementAtIndex(declarations, currentIndex);
     let wrappedAround = startIndex !== null && currentIndex !== null && currentIndex <= startIndex;


### PR DESCRIPTION
### Summary of Changes

The start/end of list messages now appear properly when going past the very last/first element in the unfiltered list respectively.