### PR TITLE
feat(parser): replace dots with underscores for enum instance names

### DIFF
--- a/package-parser/package_parser/processing/annotations/_generate_enum_annotations.py
+++ b/package-parser/package_parser/processing/annotations/_generate_enum_annotations.py
@@ -65,7 +65,7 @@ def _enum_name(parameter_name: str) -> str:
 
 
 def _enum_instance_name(string_value: str) -> str:
-    segments = re.split(r"[_-]", string_value)
+    segments = re.split(r"[_\-.]", string_value)
 
     result = "_".join(
         re.sub(r"\W", "", segment).upper()

--- a/package-parser/tests/data/enums/annotation_data.json
+++ b/package-parser/tests/data/enums/annotation_data.json
@@ -54,5 +54,17 @@
                 "stringValue": "l2"
             }
         ]
+    },
+    "test/test/some_global_function/issue_858": {
+        "target": "test/test/some_global_function/issue_858",
+        "authors": ["$autogen$"],
+        "reviewers": [],
+        "enumName": "Issue858",
+        "pairs": [
+            {
+                "instanceName": "SAMME_R",
+                "stringValue": "SAMME.R"
+            }
+        ]
     }
 }

--- a/package-parser/tests/data/enums/api_data.json
+++ b/package-parser/tests/data/enums/api_data.json
@@ -52,11 +52,22 @@
                     }
                 },
                 {
+                    "issue": "https://github.com/lars-reimann/api-editor/issues/760",
                     "id": "test/test/some_global_function/issue_760",
                     "name": "issue_760",
                     "qname": "test.some_global_function.issue_760",
                     "docstring": {
                         "type": "{'l1', 'l2'}, default=None",
+                        "description": ""
+                    }
+                },
+                {
+                    "issue": "https://github.com/lars-reimann/api-editor/issues/858",
+                    "id": "test/test/some_global_function/issue_858",
+                    "name": "issue_858",
+                    "qname": "test.some_global_function.issue_858",
+                    "docstring": {
+                        "type": "{'SAMME.R'}",
                         "description": ""
                     }
                 }


### PR DESCRIPTION
Closes #858.

### Summary of Changes

For string values like "SAMME.R" we now create the enum instance name "SAMME_R" rather than "SAMMER".