### PR TITLE
fix(gui): external links in documentation

### DIFF
--- a/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
@@ -41,13 +41,13 @@ type ParagraphComponent = FunctionComponent<
 type LinkComponent = ComponentType<ComponentPropsWithoutRef<'a'> & ReactMarkdownProps>;
 
 const CustomLink: LinkComponent = function ({ className, children, href }) {
-    const to = href ?? "#"
-    if (to.startsWith("http")) {
+    const to = href ?? '#';
+    if (to.startsWith('http')) {
         return (
             <ChakraLink href={to} isExternal>
                 {children} <Icon as={FaExternalLinkAlt} />
             </ChakraLink>
-        )
+        );
     } else {
         return (
             <ChakraLink as={RouterLink} to={to} className={className} textDecoration="underline">
@@ -55,7 +55,6 @@ const CustomLink: LinkComponent = function ({ className, children, href }) {
             </ChakraLink>
         );
     }
-
 };
 
 const CustomCode: CodeComponent = function ({ className, children }) {

--- a/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
@@ -2,6 +2,7 @@ import {
     Code,
     Flex,
     HStack,
+    Icon,
     IconButton,
     Link as ChakraLink,
     Stack,
@@ -10,7 +11,7 @@ import {
 } from '@chakra-ui/react';
 import 'katex/dist/katex.min.css';
 import React, { ClassAttributes, FunctionComponent, HTMLAttributes, useState } from 'react';
-import { FaChevronDown, FaChevronRight } from 'react-icons/fa';
+import { FaChevronDown, FaChevronRight, FaExternalLinkAlt } from 'react-icons/fa';
 import ReactMarkdown from 'react-markdown';
 import {
     CodeComponent,
@@ -40,11 +41,21 @@ type ParagraphComponent = FunctionComponent<
 type LinkComponent = ComponentType<ComponentPropsWithoutRef<'a'> & ReactMarkdownProps>;
 
 const CustomLink: LinkComponent = function ({ className, children, href }) {
-    return (
-        <ChakraLink as={RouterLink} to={href ?? '#'} className={className} textDecoration="underline">
-            {children}
-        </ChakraLink>
-    );
+    const to = href ?? "#"
+    if (to.startsWith("http")) {
+        return (
+            <ChakraLink href={to} isExternal>
+                {children} <Icon as={FaExternalLinkAlt} />
+            </ChakraLink>
+        )
+    } else {
+        return (
+            <ChakraLink as={RouterLink} to={to} className={className} textDecoration="underline">
+                {children}
+            </ChakraLink>
+        );
+    }
+
 };
 
 const CustomCode: CodeComponent = function ({ className, children }) {


### PR DESCRIPTION
Closes #865.

### Summary of Changes

External links in the documentation should now be rendered properly.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/176900888-05602629-b528-4f44-bb64-324f0dedc940.png)

