### PR TITLE
fix(parser): indentation of description

### DIFF
--- a/package-parser/package_parser/processing/api/documentation_parsing/_NumpyDocParser.py
+++ b/package-parser/package_parser/processing/api/documentation_parsing/_NumpyDocParser.py
@@ -64,8 +64,7 @@ class NumpyDocParser(AbstractDocumentationParser):
         else:
             docstring = get_full_docstring(function_node)
 
-        # Find matching parameter docstrings. Numpydoc allows multiple parameters to be documented at once. See
-        # https://numpydoc.readthedocs.io/en/latest/format.html#parameters for more information.
+        # Find matching parameter docstrings
         function_numpydoc = self.__get_cached_function_numpydoc_string(
             function_node, docstring
         )
@@ -89,7 +88,7 @@ class NumpyDocParser(AbstractDocumentationParser):
             type=type_,
             default_value=default_value,
             description="\n".join(
-                [line.strip() for line in last_parameter_numpydoc.desc]
+                [line.rstrip() for line in last_parameter_numpydoc.desc]
             ),
         )
 
@@ -122,9 +121,9 @@ def _get_description(numpydoc_string: NumpyDocString) -> str:
     extended_summary: list[str] = numpydoc_string.get("Extended Summary", [])
 
     result = ""
-    result += "\n".join([line.strip() for line in summary])
+    result += "\n".join([line.rstrip() for line in summary])
     result += "\n\n"
-    result += "\n".join([line.strip() for line in extended_summary])
+    result += "\n".join([line.rstrip() for line in extended_summary])
     return result.strip()
 
 
@@ -144,6 +143,8 @@ def _is_matching_parameter_numpydoc(
     else:
         lookup_name = parameter_name
 
+    # Numpydoc allows multiple parameters to be documented at once. See
+    # https://numpydoc.readthedocs.io/en/latest/format.html#parameters for more information.
     return any(
         name.strip() == lookup_name for name in parameter_numpydoc.name.split(",")
     )

--- a/package-parser/tests/processing/api/documentation/test_NumpyDocParser.py
+++ b/package-parser/tests/processing/api/documentation/test_NumpyDocParser.py
@@ -18,7 +18,9 @@ def numpydoc_parser() -> NumpyDocParser:
 class_with_documentation = '''
 class C:
     """
-    Lorem ipsum.
+    Lorem ipsum. Code::
+
+        pass
 
     Dolor sit amet.
     """
@@ -37,8 +39,8 @@ class C:
         (
             class_with_documentation,
             ClassDocumentation(
-                description="Lorem ipsum.\n\nDolor sit amet.",
-                full_docstring="Lorem ipsum.\n\nDolor sit amet.",
+                description="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
+                full_docstring="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
             ),
         ),
         (
@@ -66,7 +68,9 @@ def test_get_class_documentation(
 function_with_documentation = '''
 def f():
     """
-    Lorem ipsum.
+    Lorem ipsum. Code::
+
+        pass
 
     Dolor sit amet.
     """
@@ -87,8 +91,8 @@ def f():
         (
             function_with_documentation,
             FunctionDocumentation(
-                description="Lorem ipsum.\n\nDolor sit amet.",
-                full_docstring="Lorem ipsum.\n\nDolor sit amet.",
+                description="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
+                full_docstring="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
             ),
         ),
         (
@@ -146,7 +150,9 @@ def f():
     Parameters
     ----------
     no_type_no_default
-        foo: no_type_no_default
+        foo: no_type_no_default. Code::
+
+            pass
     type_no_default : int
         foo: type_no_default
     optional_unknown_default : int, optional
@@ -199,7 +205,7 @@ def f():
             ParameterDocumentation(
                 type="",
                 default_value="",
-                description="foo: no_type_no_default",
+                description="foo: no_type_no_default. Code::\n\n    pass",
             ),
         ),
         (


### PR DESCRIPTION
### Summary of Changes

Previously, whitespace was removed from start and end of each line if the description. This removed any indentation, which is needed to detect code blocks (#827). Now only whitespace at the end of a line is removed.
