### PR TITLE
feat(gui): suggest replacement for wrong filter tokens

### DIFF
--- a/api-editor/gui/package-lock.json
+++ b/api-editor/gui/package-lock.json
@@ -17,6 +17,7 @@
                 "@emotion/styled": "^11.9.3",
                 "@reduxjs/toolkit": "^1.8.3",
                 "chart.js": "^3.8.0",
+                "fastest-levenshtein": "^1.0.12",
                 "framer-motion": "^6.3.16",
                 "idb-keyval": "^6.2.0",
                 "katex": "^0.16.0",
@@ -5135,6 +5136,11 @@
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
+        },
+        "node_modules/fastest-levenshtein": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+            "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
         },
         "node_modules/fault": {
             "version": "1.0.4",
@@ -15821,6 +15827,11 @@
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
+        },
+        "fastest-levenshtein": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+            "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
         },
         "fault": {
             "version": "1.0.4",

--- a/api-editor/gui/package.json
+++ b/api-editor/gui/package.json
@@ -21,6 +21,7 @@
         "@emotion/styled": "^11.9.3",
         "@reduxjs/toolkit": "^1.8.3",
         "chart.js": "^3.8.0",
+        "fastest-levenshtein": "^1.0.12",
         "framer-motion": "^6.3.16",
         "idb-keyval": "^6.2.0",
         "katex": "^0.16.0",

--- a/api-editor/gui/src/features/filter/FilterInput.tsx
+++ b/api-editor/gui/src/features/filter/FilterInput.tsx
@@ -72,8 +72,8 @@ const InvalidFilterToken: React.FC<InvalidFilterTokenProps> = function ({ token 
     const dispatch = useAppDispatch();
 
     const alternatives = getFixedFilterNames();
-    const closestAlternative = closest(token, alternatives);
-    const closestDistance = distance(token, closestAlternative);
+    const closestAlternative = closest(token.toLowerCase(), alternatives);
+    const closestDistance = distance(token.toLowerCase(), closestAlternative);
 
     const filterString = useAppSelector(selectFilterString);
 

--- a/api-editor/gui/src/features/filter/model/filterFactory.ts
+++ b/api-editor/gui/src/features/filter/model/filterFactory.ts
@@ -202,4 +202,4 @@ export const isValidFilterToken = function (token: string): boolean {
  */
 export const getFixedFilterNames = function (): string[] {
     return Object.keys(fixedFilters);
-}
+};

--- a/api-editor/gui/src/features/filter/model/filterFactory.ts
+++ b/api-editor/gui/src/features/filter/model/filterFactory.ts
@@ -52,81 +52,58 @@ const parsePotentiallyNegatedToken = function (token: string): Optional<Abstract
     }
 };
 
+const fixedFilters: { [name: string]: AbstractPythonFilter } = {
+    // Declaration type
+    'is:module': new DeclarationTypeFilter(DeclarationType.Module),
+    'is:class': new DeclarationTypeFilter(DeclarationType.Class),
+    'is:function': new DeclarationTypeFilter(DeclarationType.Function),
+    'is:parameter': new DeclarationTypeFilter(DeclarationType.Parameter),
+
+    // Visibility
+    'is:public': new VisibilityFilter(Visibility.Public),
+    'is:internal': new VisibilityFilter(Visibility.Internal),
+
+    // Parameter required or optional
+    'is:required': new RequiredOrOptionalFilter(RequiredOrOptional.Required),
+    'is:optional': new RequiredOrOptionalFilter(RequiredOrOptional.Optional),
+
+    // Parameter assignment
+    'is:implicit': new ParameterAssignmentFilter(PythonParameterAssignment.IMPLICIT),
+    'is:positiononly': new ParameterAssignmentFilter(PythonParameterAssignment.POSITION_ONLY),
+    'is:positionorname': new ParameterAssignmentFilter(PythonParameterAssignment.POSITION_OR_NAME),
+    'is:positionalvararg': new ParameterAssignmentFilter(PythonParameterAssignment.POSITIONAL_VARARG),
+    'is:nameonly': new ParameterAssignmentFilter(PythonParameterAssignment.NAME_ONLY),
+    'is:namedvararg': new ParameterAssignmentFilter(PythonParameterAssignment.NAMED_VARARG),
+
+    // Done
+    'is:done': new DoneFilter(),
+
+    // Annotations
+    'annotation:any': new AnnotationFilter(AnnotationType.Any),
+    'annotation:@boundary': new AnnotationFilter(AnnotationType.Boundary),
+    'annotation:@calledafter': new AnnotationFilter(AnnotationType.CalledAfter),
+    'is:complete': new AnnotationFilter(AnnotationType.Complete), // Deliberate special case. It should be transparent to users it's an annotation.
+    'annotation:@description': new AnnotationFilter(AnnotationType.Description),
+    'annotation:@enum': new AnnotationFilter(AnnotationType.Enum),
+    'annotation:@group': new AnnotationFilter(AnnotationType.Group),
+    'annotation:@move': new AnnotationFilter(AnnotationType.Move),
+    'annotation:@pure': new AnnotationFilter(AnnotationType.Pure),
+    'annotation:@remove': new AnnotationFilter(AnnotationType.Remove),
+    'annotation:@rename': new AnnotationFilter(AnnotationType.Rename),
+    'annotation:@todo': new AnnotationFilter(AnnotationType.Todo),
+    'annotation:@value': new AnnotationFilter(AnnotationType.Value),
+};
+
 /**
  * Handles a singe non-negated token.
  *
  * @param token The text that describes the filter.
  */
 const parsePositiveToken = function (token: string): Optional<AbstractPythonFilter> {
-    // Filters with fixed text
-    switch (token.toLowerCase()) {
-        // Declaration type
-        case 'is:module':
-            return new DeclarationTypeFilter(DeclarationType.Module);
-        case 'is:class':
-            return new DeclarationTypeFilter(DeclarationType.Class);
-        case 'is:function':
-            return new DeclarationTypeFilter(DeclarationType.Function);
-        case 'is:parameter':
-            return new DeclarationTypeFilter(DeclarationType.Parameter);
-
-        // Visibility
-        case 'is:public':
-            return new VisibilityFilter(Visibility.Public);
-        case 'is:internal':
-            return new VisibilityFilter(Visibility.Internal);
-
-        // Parameter required or optional
-        case 'is:required':
-            return new RequiredOrOptionalFilter(RequiredOrOptional.Required);
-        case 'is:optional':
-            return new RequiredOrOptionalFilter(RequiredOrOptional.Optional);
-
-        // Parameter assignment
-        case 'is:implicit':
-            return new ParameterAssignmentFilter(PythonParameterAssignment.IMPLICIT);
-        case 'is:positiononly':
-            return new ParameterAssignmentFilter(PythonParameterAssignment.POSITION_ONLY);
-        case 'is:positionorname':
-            return new ParameterAssignmentFilter(PythonParameterAssignment.POSITION_OR_NAME);
-        case 'is:positionalvararg':
-            return new ParameterAssignmentFilter(PythonParameterAssignment.POSITIONAL_VARARG);
-        case 'is:nameonly':
-            return new ParameterAssignmentFilter(PythonParameterAssignment.NAME_ONLY);
-        case 'is:namedvararg':
-            return new ParameterAssignmentFilter(PythonParameterAssignment.NAMED_VARARG);
-
-        // Done
-        case 'is:done':
-            return new DoneFilter();
-
-        // Annotations
-        case 'annotation:any':
-            return new AnnotationFilter(AnnotationType.Any);
-        case 'annotation:@boundary':
-            return new AnnotationFilter(AnnotationType.Boundary);
-        case 'annotation:@calledafter':
-            return new AnnotationFilter(AnnotationType.CalledAfter);
-        case 'is:complete': // Deliberate special case. It should be transparent to users it's an annotation.
-            return new AnnotationFilter(AnnotationType.Complete);
-        case 'annotation:@description':
-            return new AnnotationFilter(AnnotationType.Description);
-        case 'annotation:@enum':
-            return new AnnotationFilter(AnnotationType.Enum);
-        case 'annotation:@group':
-            return new AnnotationFilter(AnnotationType.Group);
-        case 'annotation:@move':
-            return new AnnotationFilter(AnnotationType.Move);
-        case 'annotation:@pure':
-            return new AnnotationFilter(AnnotationType.Pure);
-        case 'annotation:@remove':
-            return new AnnotationFilter(AnnotationType.Remove);
-        case 'annotation:@rename':
-            return new AnnotationFilter(AnnotationType.Rename);
-        case 'annotation:@todo':
-            return new AnnotationFilter(AnnotationType.Todo);
-        case 'annotation:@value':
-            return new AnnotationFilter(AnnotationType.Value);
+    // Fixed filters
+    const fixedFilter = fixedFilters[token.toLowerCase()];
+    if (fixedFilter) {
+        return fixedFilter;
     }
 
     // Name
@@ -219,3 +196,10 @@ const comparisonFunction = function (comparisonOperator: string): ((a: number, b
 export const isValidFilterToken = function (token: string): boolean {
     return Boolean(parsePotentiallyNegatedToken(token));
 };
+
+/**
+ * Returns the names of all fixed filter like "annotation:any".
+ */
+export const getFixedFilterNames = function (): string[] {
+    return Object.keys(fixedFilters);
+}


### PR DESCRIPTION
Closes #837.

### Summary of Changes

When the user inputs an incorrect filter, a possible replacement gets suggested, provided a fixed filter exists with a Levenshtein distance of at most 3. The user can click on this suggestion to update the filter string.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/177033956-7f42719b-b597-4655-9b17-dc9d34afcaa9.png)
