### PR TITLE
feat(parser): differentiate between required and optional parameters using statistical hypothesis testing

### DIFF
--- a/data/annotations/sklearn__annotations.json
+++ b/data/annotations/sklearn__annotations.json
@@ -19132,9 +19132,7 @@
             "target": "sklearn/sklearn.cluster._affinity_propagation/AffinityPropagation/__init__/damping",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 0.5
+            "variant": "required"
         },
         "sklearn/sklearn.cluster._affinity_propagation/AffinityPropagation/__init__/max_iter": {
             "target": "sklearn/sklearn.cluster._affinity_propagation/AffinityPropagation/__init__/max_iter",
@@ -19398,9 +19396,7 @@
             "target": "sklearn/sklearn.cluster._agglomerative/FeatureAgglomeration/__init__/connectivity",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.cluster._agglomerative/FeatureAgglomeration/__init__/compute_full_tree": {
             "target": "sklearn/sklearn.cluster._agglomerative/FeatureAgglomeration/__init__/compute_full_tree",
@@ -19520,9 +19516,7 @@
             "target": "sklearn/sklearn.cluster._dbscan/DBSCAN/__init__/min_samples",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 5.0
+            "variant": "required"
         },
         "sklearn/sklearn.cluster._dbscan/DBSCAN/__init__/metric": {
             "target": "sklearn/sklearn.cluster._dbscan/DBSCAN/__init__/metric",
@@ -19826,9 +19820,7 @@
             "target": "sklearn/sklearn.cluster._kmeans/MiniBatchKMeans/__init__/batch_size",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 10000.0
+            "variant": "required"
         },
         "sklearn/sklearn.cluster._kmeans/MiniBatchKMeans/__init__/verbose": {
             "target": "sklearn/sklearn.cluster._kmeans/MiniBatchKMeans/__init__/verbose",
@@ -20130,9 +20122,7 @@
             "target": "sklearn/sklearn.cluster._mean_shift/MeanShift/__init__/bin_seeding",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "boolean",
-            "defaultValue": true
+            "variant": "required"
         },
         "sklearn/sklearn.cluster._mean_shift/MeanShift/__init__/min_bin_freq": {
             "target": "sklearn/sklearn.cluster._mean_shift/MeanShift/__init__/min_bin_freq",
@@ -20286,9 +20276,7 @@
             "target": "sklearn/sklearn.cluster._optics/OPTICS/__init__/min_cluster_size",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.cluster._optics/OPTICS/__init__/algorithm": {
             "target": "sklearn/sklearn.cluster._optics/OPTICS/__init__/algorithm",
@@ -20346,9 +20334,7 @@
             "target": "sklearn/sklearn.cluster._spectral/SpectralClustering/__init__/eigen_solver",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.cluster._spectral/SpectralClustering/__init__/n_components": {
             "target": "sklearn/sklearn.cluster._spectral/SpectralClustering/__init__/n_components",
@@ -20362,9 +20348,7 @@
             "target": "sklearn/sklearn.cluster._spectral/SpectralClustering/__init__/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.cluster._spectral/SpectralClustering/__init__/n_init": {
             "target": "sklearn/sklearn.cluster._spectral/SpectralClustering/__init__/n_init",
@@ -20386,9 +20370,7 @@
             "target": "sklearn/sklearn.cluster._spectral/SpectralClustering/__init__/affinity",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "nearest_neighbors"
+            "variant": "required"
         },
         "sklearn/sklearn.cluster._spectral/SpectralClustering/__init__/n_neighbors": {
             "target": "sklearn/sklearn.cluster._spectral/SpectralClustering/__init__/n_neighbors",
@@ -20410,9 +20392,7 @@
             "target": "sklearn/sklearn.cluster._spectral/SpectralClustering/__init__/assign_labels",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "kmeans"
+            "variant": "required"
         },
         "sklearn/sklearn.cluster._spectral/SpectralClustering/__init__/degree": {
             "target": "sklearn/sklearn.cluster._spectral/SpectralClustering/__init__/degree",
@@ -20492,7 +20472,9 @@
             "target": "sklearn/sklearn.compose._column_transformer/ColumnTransformer/__init__/remainder",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "string",
+            "defaultValue": "drop"
         },
         "sklearn/sklearn.compose._column_transformer/ColumnTransformer/__init__/sparse_threshold": {
             "target": "sklearn/sklearn.compose._column_transformer/ColumnTransformer/__init__/sparse_threshold",
@@ -20660,17 +20642,13 @@
             "target": "sklearn/sklearn.compose._target/TransformedTargetRegressor/__init__/func",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.compose._target/TransformedTargetRegressor/__init__/inverse_func": {
             "target": "sklearn/sklearn.compose._target/TransformedTargetRegressor/__init__/inverse_func",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.compose._target/TransformedTargetRegressor/__init__/check_inverse": {
             "target": "sklearn/sklearn.compose._target/TransformedTargetRegressor/__init__/check_inverse",
@@ -20968,9 +20946,7 @@
             "target": "sklearn/sklearn.covariance._robust_covariance/MinCovDet/__init__/support_fraction",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.covariance._robust_covariance/MinCovDet/__init__/random_state": {
             "target": "sklearn/sklearn.covariance._robust_covariance/MinCovDet/__init__/random_state",
@@ -21066,9 +21042,7 @@
             "target": "sklearn/sklearn.covariance._shrunk_covariance/ShrunkCovariance/__init__/shrinkage",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 0.1
+            "variant": "required"
         },
         "sklearn/sklearn.covariance._shrunk_covariance/ShrunkCovariance/fit/X": {
             "target": "sklearn/sklearn.covariance._shrunk_covariance/ShrunkCovariance/fit/X",
@@ -21172,9 +21146,7 @@
             "target": "sklearn/sklearn.cross_decomposition._pls/PLSRegression/__init__/tol",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 1e-6
+            "variant": "required"
         },
         "sklearn/sklearn.cross_decomposition._pls/PLSRegression/__init__/copy": {
             "target": "sklearn/sklearn.cross_decomposition._pls/PLSRegression/__init__/copy",
@@ -21540,9 +21512,7 @@
             "target": "sklearn/sklearn.datasets._samples_generator/make_blobs/n_features",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 2.0
+            "variant": "required"
         },
         "sklearn/sklearn.datasets._samples_generator/make_blobs/centers": {
             "target": "sklearn/sklearn.datasets._samples_generator/make_blobs/centers",
@@ -21620,9 +21590,7 @@
             "target": "sklearn/sklearn.datasets._samples_generator/make_classification/n_samples",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 100.0
+            "variant": "required"
         },
         "sklearn/sklearn.datasets._samples_generator/make_classification/n_features": {
             "target": "sklearn/sklearn.datasets._samples_generator/make_classification/n_features",
@@ -21666,7 +21634,9 @@
             "target": "sklearn/sklearn.datasets._samples_generator/make_classification/n_clusters_per_class",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "number",
+            "defaultValue": 2.0
         },
         "sklearn/sklearn.datasets._samples_generator/make_classification/weights": {
             "target": "sklearn/sklearn.datasets._samples_generator/make_classification/weights",
@@ -21728,9 +21698,7 @@
             "target": "sklearn/sklearn.datasets._samples_generator/make_classification/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.datasets._samples_generator/make_moons/n_samples": {
             "target": "sklearn/sklearn.datasets._samples_generator/make_moons/n_samples",
@@ -21756,9 +21724,7 @@
             "target": "sklearn/sklearn.datasets._samples_generator/make_moons/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.datasets._samples_generator/make_multilabel_classification/n_samples": {
             "target": "sklearn/sklearn.datasets._samples_generator/make_multilabel_classification/n_samples",
@@ -22486,9 +22452,7 @@
             "target": "sklearn/sklearn.decomposition._incremental_pca/IncrementalPCA/__init__/n_components",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 5.0
+            "variant": "required"
         },
         "sklearn/sklearn.decomposition._incremental_pca/IncrementalPCA/__init__/whiten": {
             "target": "sklearn/sklearn.decomposition._incremental_pca/IncrementalPCA/__init__/whiten",
@@ -22510,9 +22474,7 @@
             "target": "sklearn/sklearn.decomposition._incremental_pca/IncrementalPCA/__init__/batch_size",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.decomposition._incremental_pca/IncrementalPCA/fit/X": {
             "target": "sklearn/sklearn.decomposition._incremental_pca/IncrementalPCA/fit/X",
@@ -22720,9 +22682,7 @@
             "target": "sklearn/sklearn.decomposition._lda/LatentDirichletAllocation/__init__/n_components",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 10.0
+            "variant": "required"
         },
         "sklearn/sklearn.decomposition._lda/LatentDirichletAllocation/__init__/doc_topic_prior": {
             "target": "sklearn/sklearn.decomposition._lda/LatentDirichletAllocation/__init__/doc_topic_prior",
@@ -22744,7 +22704,9 @@
             "target": "sklearn/sklearn.decomposition._lda/LatentDirichletAllocation/__init__/learning_method",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "string",
+            "defaultValue": "online"
         },
         "sklearn/sklearn.decomposition._lda/LatentDirichletAllocation/__init__/learning_decay": {
             "target": "sklearn/sklearn.decomposition._lda/LatentDirichletAllocation/__init__/learning_decay",
@@ -22758,7 +22720,9 @@
             "target": "sklearn/sklearn.decomposition._lda/LatentDirichletAllocation/__init__/learning_offset",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "number",
+            "defaultValue": 10.0
         },
         "sklearn/sklearn.decomposition._lda/LatentDirichletAllocation/__init__/max_iter": {
             "target": "sklearn/sklearn.decomposition._lda/LatentDirichletAllocation/__init__/max_iter",
@@ -23148,9 +23112,7 @@
             "target": "sklearn/sklearn.decomposition._sparse_pca/SparsePCA/__init__/n_components",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 2.0
+            "variant": "required"
         },
         "sklearn/sklearn.decomposition._sparse_pca/SparsePCA/__init__/alpha": {
             "target": "sklearn/sklearn.decomposition._sparse_pca/SparsePCA/__init__/alpha",
@@ -23228,9 +23190,7 @@
             "target": "sklearn/sklearn.decomposition._sparse_pca/SparsePCA/__init__/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 42.0
+            "variant": "required"
         },
         "sklearn/sklearn.decomposition._sparse_pca/SparsePCA/transform/X": {
             "target": "sklearn/sklearn.decomposition._sparse_pca/SparsePCA/transform/X",
@@ -23546,7 +23506,9 @@
             "target": "sklearn/sklearn.dummy/DummyRegressor/__init__/strategy",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "string",
+            "defaultValue": "median"
         },
         "sklearn/sklearn.dummy/DummyRegressor/__init__/constant": {
             "target": "sklearn/sklearn.dummy/DummyRegressor/__init__/constant",
@@ -24494,9 +24456,7 @@
             "target": "sklearn/sklearn.ensemble._forest/RandomTreesEmbedding/__init__/sparse_output",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "boolean",
-            "defaultValue": true
+            "variant": "required"
         },
         "sklearn/sklearn.ensemble._forest/RandomTreesEmbedding/__init__/n_jobs": {
             "target": "sklearn/sklearn.ensemble._forest/RandomTreesEmbedding/__init__/n_jobs",
@@ -24514,9 +24474,7 @@
             "target": "sklearn/sklearn.ensemble._forest/RandomTreesEmbedding/__init__/verbose",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 0.0
+            "variant": "required"
         },
         "sklearn/sklearn.ensemble._forest/RandomTreesEmbedding/__init__/warm_start": {
             "target": "sklearn/sklearn.ensemble._forest/RandomTreesEmbedding/__init__/warm_start",
@@ -25092,9 +25050,7 @@
             "target": "sklearn/sklearn.ensemble._hist_gradient_boosting.gradient_boosting/HistGradientBoostingClassifier/__init__/validation_fraction",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 0.1
+            "variant": "required"
         },
         "sklearn/sklearn.ensemble._hist_gradient_boosting.gradient_boosting/HistGradientBoostingClassifier/__init__/n_iter_no_change": {
             "target": "sklearn/sklearn.ensemble._hist_gradient_boosting.gradient_boosting/HistGradientBoostingClassifier/__init__/n_iter_no_change",
@@ -25350,9 +25306,7 @@
             "target": "sklearn/sklearn.ensemble._iforest/IsolationForest/__init__/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.ensemble._iforest/IsolationForest/__init__/verbose": {
             "target": "sklearn/sklearn.ensemble._iforest/IsolationForest/__init__/verbose",
@@ -25420,9 +25374,7 @@
             "target": "sklearn/sklearn.ensemble._stacking/StackingClassifier/__init__/final_estimator",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.ensemble._stacking/StackingClassifier/__init__/cv": {
             "target": "sklearn/sklearn.ensemble._stacking/StackingClassifier/__init__/cv",
@@ -25578,7 +25530,9 @@
             "target": "sklearn/sklearn.ensemble._voting/VotingClassifier/__init__/voting",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "string",
+            "defaultValue": "soft"
         },
         "sklearn/sklearn.ensemble._voting/VotingClassifier/__init__/weights": {
             "target": "sklearn/sklearn.ensemble._voting/VotingClassifier/__init__/weights",
@@ -26004,17 +25958,13 @@
             "target": "sklearn/sklearn.feature_extraction.image/extract_patches_2d/max_patches",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.feature_extraction.image/extract_patches_2d/random_state": {
             "target": "sklearn/sklearn.feature_extraction.image/extract_patches_2d/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.feature_extraction.text/CountVectorizer/__init__/input": {
             "target": "sklearn/sklearn.feature_extraction.text/CountVectorizer/__init__/input",
@@ -26468,7 +26418,9 @@
             "target": "sklearn/sklearn.feature_extraction.text/TfidfVectorizer/__init__/stop_words",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "none",
+            "defaultValue": null
         },
         "sklearn/sklearn.feature_extraction.text/TfidfVectorizer/__init__/token_pattern": {
             "target": "sklearn/sklearn.feature_extraction.text/TfidfVectorizer/__init__/token_pattern",
@@ -26742,9 +26694,7 @@
             "target": "sklearn/sklearn.feature_selection._mutual_info/mutual_info_classif/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 0.0
+            "variant": "required"
         },
         "sklearn/sklearn.feature_selection._mutual_info/mutual_info_regression/X": {
             "target": "sklearn/sklearn.feature_selection._mutual_info/mutual_info_regression/X",
@@ -27016,17 +26966,13 @@
             "target": "sklearn/sklearn.feature_selection._univariate_selection/GenericUnivariateSelect/__init__/mode",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "fwe"
+            "variant": "required"
         },
         "sklearn/sklearn.feature_selection._univariate_selection/GenericUnivariateSelect/__init__/param": {
             "target": "sklearn/sklearn.feature_selection._univariate_selection/GenericUnivariateSelect/__init__/param",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 0.001
+            "variant": "required"
         },
         "sklearn/sklearn.feature_selection._univariate_selection/SelectFdr/__init__/score_func": {
             "target": "sklearn/sklearn.feature_selection._univariate_selection/SelectFdr/__init__/score_func",
@@ -27272,9 +27218,7 @@
             "target": "sklearn/sklearn.gaussian_process._gpr/GaussianProcessRegressor/__init__/kernel",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.gaussian_process._gpr/GaussianProcessRegressor/__init__/alpha": {
             "target": "sklearn/sklearn.gaussian_process._gpr/GaussianProcessRegressor/__init__/alpha",
@@ -27436,9 +27380,7 @@
             "target": "sklearn/sklearn.gaussian_process.kernels/RBF/__init__/length_scale",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 1.0
+            "variant": "required"
         },
         "sklearn/sklearn.gaussian_process.kernels/RBF/__init__/length_scale_bounds": {
             "target": "sklearn/sklearn.gaussian_process.kernels/RBF/__init__/length_scale_bounds",
@@ -27558,7 +27500,9 @@
             "target": "sklearn/sklearn.impute._base/SimpleImputer/__init__/strategy",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "string",
+            "defaultValue": "mean"
         },
         "sklearn/sklearn.impute._base/SimpleImputer/__init__/fill_value": {
             "target": "sklearn/sklearn.impute._base/SimpleImputer/__init__/fill_value",
@@ -27706,9 +27650,7 @@
             "target": "sklearn/sklearn.impute._iterative/IterativeImputer/__init__/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.impute._iterative/IterativeImputer/__init__/add_indicator": {
             "target": "sklearn/sklearn.impute._iterative/IterativeImputer/__init__/add_indicator",
@@ -27902,9 +27844,7 @@
             "target": "sklearn/sklearn.inspection._permutation_importance/permutation_importance/n_repeats",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 5.0
+            "variant": "required"
         },
         "sklearn/sklearn.inspection._permutation_importance/permutation_importance/n_jobs": {
             "target": "sklearn/sklearn.inspection._permutation_importance/permutation_importance/n_jobs",
@@ -27968,9 +27908,7 @@
             "target": "sklearn/sklearn.inspection._plot.partial_dependence/plot_partial_dependence/target",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.inspection._plot.partial_dependence/plot_partial_dependence/response_method": {
             "target": "sklearn/sklearn.inspection._plot.partial_dependence/plot_partial_dependence/response_method",
@@ -28098,17 +28036,13 @@
             "target": "sklearn/sklearn.isotonic/IsotonicRegression/__init__/y_min",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.isotonic/IsotonicRegression/__init__/y_max": {
             "target": "sklearn/sklearn.isotonic/IsotonicRegression/__init__/y_max",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.isotonic/IsotonicRegression/__init__/increasing": {
             "target": "sklearn/sklearn.isotonic/IsotonicRegression/__init__/increasing",
@@ -29442,9 +29376,7 @@
             "target": "sklearn/sklearn.linear_model._glm.glm/TweedieRegressor/__init__/power",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 0.0
+            "variant": "required"
         },
         "sklearn/sklearn.linear_model._glm.glm/TweedieRegressor/__init__/alpha": {
             "target": "sklearn/sklearn.linear_model._glm.glm/TweedieRegressor/__init__/alpha",
@@ -29602,9 +29534,7 @@
             "target": "sklearn/sklearn.linear_model._least_angle/Lars/__init__/n_nonzero_coefs",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 500.0
+            "variant": "required"
         },
         "sklearn/sklearn.linear_model._least_angle/Lars/__init__/eps": {
             "target": "sklearn/sklearn.linear_model._least_angle/Lars/__init__/eps",
@@ -30356,9 +30286,7 @@
             "target": "sklearn/sklearn.linear_model._omp/OrthogonalMatchingPursuit/__init__/n_nonzero_coefs",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.linear_model._omp/OrthogonalMatchingPursuit/__init__/tol": {
             "target": "sklearn/sklearn.linear_model._omp/OrthogonalMatchingPursuit/__init__/tol",
@@ -30380,17 +30308,13 @@
             "target": "sklearn/sklearn.linear_model._omp/OrthogonalMatchingPursuit/__init__/normalize",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "deprecated"
+            "variant": "required"
         },
         "sklearn/sklearn.linear_model._omp/OrthogonalMatchingPursuit/__init__/precompute": {
             "target": "sklearn/sklearn.linear_model._omp/OrthogonalMatchingPursuit/__init__/precompute",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "auto"
+            "variant": "required"
         },
         "sklearn/sklearn.linear_model._omp/OrthogonalMatchingPursuit/fit/X": {
             "target": "sklearn/sklearn.linear_model._omp/OrthogonalMatchingPursuit/fit/X",
@@ -30684,9 +30608,7 @@
             "target": "sklearn/sklearn.linear_model._passive_aggressive/PassiveAggressiveRegressor/__init__/loss",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "epsilon_insensitive"
+            "variant": "required"
         },
         "sklearn/sklearn.linear_model._passive_aggressive/PassiveAggressiveRegressor/__init__/epsilon": {
             "target": "sklearn/sklearn.linear_model._passive_aggressive/PassiveAggressiveRegressor/__init__/epsilon",
@@ -30698,9 +30620,7 @@
             "target": "sklearn/sklearn.linear_model._passive_aggressive/PassiveAggressiveRegressor/__init__/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.linear_model._passive_aggressive/PassiveAggressiveRegressor/__init__/warm_start": {
             "target": "sklearn/sklearn.linear_model._passive_aggressive/PassiveAggressiveRegressor/__init__/warm_start",
@@ -31470,7 +31390,9 @@
             "target": "sklearn/sklearn.linear_model._stochastic_gradient/SGDClassifier/__init__/loss",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "string",
+            "defaultValue": "log"
         },
         "sklearn/sklearn.linear_model._stochastic_gradient/SGDClassifier/__init__/penalty": {
             "target": "sklearn/sklearn.linear_model._stochastic_gradient/SGDClassifier/__init__/penalty",
@@ -31610,7 +31532,9 @@
             "target": "sklearn/sklearn.linear_model._stochastic_gradient/SGDClassifier/__init__/class_weight",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "none",
+            "defaultValue": null
         },
         "sklearn/sklearn.linear_model._stochastic_gradient/SGDClassifier/__init__/warm_start": {
             "target": "sklearn/sklearn.linear_model._stochastic_gradient/SGDClassifier/__init__/warm_start",
@@ -31894,9 +31818,7 @@
             "target": "sklearn/sklearn.manifold._isomap/Isomap/__init__/n_components",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 2.0
+            "variant": "required"
         },
         "sklearn/sklearn.manifold._isomap/Isomap/__init__/eigen_solver": {
             "target": "sklearn/sklearn.manifold._isomap/Isomap/__init__/eigen_solver",
@@ -32014,9 +31936,7 @@
             "target": "sklearn/sklearn.manifold._locally_linear/LocallyLinearEmbedding/__init__/n_components",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 2.0
+            "variant": "required"
         },
         "sklearn/sklearn.manifold._locally_linear/LocallyLinearEmbedding/__init__/reg": {
             "target": "sklearn/sklearn.manifold._locally_linear/LocallyLinearEmbedding/__init__/reg",
@@ -32030,9 +31950,7 @@
             "target": "sklearn/sklearn.manifold._locally_linear/LocallyLinearEmbedding/__init__/eigen_solver",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "auto"
+            "variant": "required"
         },
         "sklearn/sklearn.manifold._locally_linear/LocallyLinearEmbedding/__init__/tol": {
             "target": "sklearn/sklearn.manifold._locally_linear/LocallyLinearEmbedding/__init__/tol",
@@ -32054,9 +31972,7 @@
             "target": "sklearn/sklearn.manifold._locally_linear/LocallyLinearEmbedding/__init__/method",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "standard"
+            "variant": "required"
         },
         "sklearn/sklearn.manifold._locally_linear/LocallyLinearEmbedding/__init__/hessian_tol": {
             "target": "sklearn/sklearn.manifold._locally_linear/LocallyLinearEmbedding/__init__/hessian_tol",
@@ -32120,9 +32036,7 @@
             "target": "sklearn/sklearn.manifold._mds/MDS/__init__/n_components",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 2.0
+            "variant": "required"
         },
         "sklearn/sklearn.manifold._mds/MDS/__init__/metric": {
             "target": "sklearn/sklearn.manifold._mds/MDS/__init__/metric",
@@ -32172,9 +32086,7 @@
             "target": "sklearn/sklearn.manifold._mds/MDS/__init__/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.manifold._mds/MDS/__init__/dissimilarity": {
             "target": "sklearn/sklearn.manifold._mds/MDS/__init__/dissimilarity",
@@ -32578,9 +32490,7 @@
             "target": "sklearn/sklearn.metrics._classification/brier_score_loss/pos_label",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.metrics._classification/classification_report/y_true": {
             "target": "sklearn/sklearn.metrics._classification/classification_report/y_true",
@@ -32746,7 +32656,9 @@
             "target": "sklearn/sklearn.metrics._classification/f1_score/average",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "string",
+            "defaultValue": "binary"
         },
         "sklearn/sklearn.metrics._classification/f1_score/sample_weight": {
             "target": "sklearn/sklearn.metrics._classification/f1_score/sample_weight",
@@ -33008,9 +32920,7 @@
             "target": "sklearn/sklearn.metrics._classification/multilabel_confusion_matrix/labels",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.metrics._classification/multilabel_confusion_matrix/samplewise": {
             "target": "sklearn/sklearn.metrics._classification/multilabel_confusion_matrix/samplewise",
@@ -33116,7 +33026,9 @@
             "target": "sklearn/sklearn.metrics._classification/precision_score/average",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "string",
+            "defaultValue": "binary"
         },
         "sklearn/sklearn.metrics._classification/precision_score/sample_weight": {
             "target": "sklearn/sklearn.metrics._classification/precision_score/sample_weight",
@@ -33478,9 +33390,7 @@
             "target": "sklearn/sklearn.metrics._plot.precision_recall_curve/plot_precision_recall_curve/ax",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.metrics._plot.precision_recall_curve/plot_precision_recall_curve/pos_label": {
             "target": "sklearn/sklearn.metrics._plot.precision_recall_curve/plot_precision_recall_curve/pos_label",
@@ -33672,9 +33582,7 @@
             "target": "sklearn/sklearn.metrics._ranking/label_ranking_average_precision_score/sample_weight",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.metrics._ranking/ndcg_score/y_true": {
             "target": "sklearn/sklearn.metrics._ranking/ndcg_score/y_true",
@@ -34098,9 +34006,7 @@
             "target": "sklearn/sklearn.metrics._scorer/get_scorer/scoring",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "f1_macro"
+            "variant": "required"
         },
         "sklearn/sklearn.metrics._scorer/make_scorer/score_func": {
             "target": "sklearn/sklearn.metrics._scorer/make_scorer/score_func",
@@ -34196,17 +34102,13 @@
             "target": "sklearn/sklearn.metrics.cluster._supervised/mutual_info_score/labels_pred",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.metrics.cluster._supervised/mutual_info_score/contingency": {
             "target": "sklearn/sklearn.metrics.cluster._supervised/mutual_info_score/contingency",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.metrics.cluster._supervised/normalized_mutual_info_score/labels_true": {
             "target": "sklearn/sklearn.metrics.cluster._supervised/normalized_mutual_info_score/labels_true",
@@ -34362,9 +34264,7 @@
             "target": "sklearn/sklearn.metrics.pairwise/euclidean_distances/Y",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.metrics.pairwise/euclidean_distances/Y_norm_squared": {
             "target": "sklearn/sklearn.metrics.pairwise/euclidean_distances/Y_norm_squared",
@@ -35588,7 +35488,9 @@
             "target": "sklearn/sklearn.model_selection._split/KFold/__init__/shuffle",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "boolean",
+            "defaultValue": true
         },
         "sklearn/sklearn.model_selection._split/KFold/__init__/random_state": {
             "target": "sklearn/sklearn.model_selection._split/KFold/__init__/random_state",
@@ -35746,9 +35648,7 @@
             "target": "sklearn/sklearn.model_selection._split/RepeatedStratifiedKFold/__init__/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 42.0
+            "variant": "required"
         },
         "sklearn/sklearn.model_selection._split/ShuffleSplit/__init__/n_splits": {
             "target": "sklearn/sklearn.model_selection._split/ShuffleSplit/__init__/n_splits",
@@ -35792,15 +35692,15 @@
             "target": "sklearn/sklearn.model_selection._split/StratifiedKFold/__init__/shuffle",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "boolean",
+            "defaultValue": true
         },
         "sklearn/sklearn.model_selection._split/StratifiedKFold/__init__/random_state": {
             "target": "sklearn/sklearn.model_selection._split/StratifiedKFold/__init__/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 42.0
+            "variant": "required"
         },
         "sklearn/sklearn.model_selection._split/StratifiedKFold/split/X": {
             "target": "sklearn/sklearn.model_selection._split/StratifiedKFold/split/X",
@@ -35850,9 +35750,7 @@
             "target": "sklearn/sklearn.model_selection._split/StratifiedShuffleSplit/__init__/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 42.0
+            "variant": "required"
         },
         "sklearn/sklearn.model_selection._split/StratifiedShuffleSplit/split/X": {
             "target": "sklearn/sklearn.model_selection._split/StratifiedShuffleSplit/split/X",
@@ -36000,9 +35898,7 @@
             "target": "sklearn/sklearn.model_selection._split/_RepeatedSplits/split/y",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.model_selection._split/_RepeatedSplits/split/groups": {
             "target": "sklearn/sklearn.model_selection._split/_RepeatedSplits/split/groups",
@@ -36076,9 +35972,7 @@
             "target": "sklearn/sklearn.model_selection._split/train_test_split/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 42.0
+            "variant": "required"
         },
         "sklearn/sklearn.model_selection._split/train_test_split/shuffle": {
             "target": "sklearn/sklearn.model_selection._split/train_test_split/shuffle",
@@ -36238,7 +36132,9 @@
             "target": "sklearn/sklearn.model_selection._validation/cross_val_score/cv",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "number",
+            "defaultValue": 5.0
         },
         "sklearn/sklearn.model_selection._validation/cross_val_score/n_jobs": {
             "target": "sklearn/sklearn.model_selection._validation/cross_val_score/n_jobs",
@@ -36356,7 +36252,9 @@
             "target": "sklearn/sklearn.model_selection._validation/cross_validate/return_train_score",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "boolean",
+            "defaultValue": false
         },
         "sklearn/sklearn.model_selection._validation/cross_validate/return_estimator": {
             "target": "sklearn/sklearn.model_selection._validation/cross_validate/return_estimator",
@@ -36414,9 +36312,7 @@
             "target": "sklearn/sklearn.model_selection._validation/learning_curve/scoring",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.model_selection._validation/learning_curve/exploit_incremental_learning": {
             "target": "sklearn/sklearn.model_selection._validation/learning_curve/exploit_incremental_learning",
@@ -36508,9 +36404,7 @@
             "target": "sklearn/sklearn.model_selection._validation/validation_curve/param_name",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "max_depth"
+            "variant": "required"
         },
         "sklearn/sklearn.model_selection._validation/validation_curve/param_range": {
             "target": "sklearn/sklearn.model_selection._validation/validation_curve/param_range",
@@ -36768,9 +36662,7 @@
             "target": "sklearn/sklearn.multioutput/_BaseChain/__init__/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.multioutput/_BaseChain/predict/X": {
             "target": "sklearn/sklearn.multioutput/_BaseChain/predict/X",
@@ -37038,9 +36930,7 @@
             "target": "sklearn/sklearn.naive_bayes/_BaseDiscreteNB/partial_fit/classes",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.naive_bayes/_BaseDiscreteNB/partial_fit/sample_weight": {
             "target": "sklearn/sklearn.naive_bayes/_BaseDiscreteNB/partial_fit/sample_weight",
@@ -37100,9 +36990,7 @@
             "target": "sklearn/sklearn.neighbors._base/RadiusNeighborsMixin/radius_neighbors/radius",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.neighbors._base/RadiusNeighborsMixin/radius_neighbors/return_distance": {
             "target": "sklearn/sklearn.neighbors._base/RadiusNeighborsMixin/radius_neighbors/return_distance",
@@ -37330,9 +37218,7 @@
             "target": "sklearn/sklearn.neighbors._distance_metric/DistanceMetric/get_metric/metric",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "minkowski"
+            "variant": "required"
         },
         "sklearn/sklearn.neighbors._graph/kneighbors_graph/X": {
             "target": "sklearn/sklearn.neighbors._graph/kneighbors_graph/X",
@@ -37398,9 +37284,7 @@
             "target": "sklearn/sklearn.neighbors._kde/KernelDensity/__init__/bandwidth",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 0.02
+            "variant": "required"
         },
         "sklearn/sklearn.neighbors._kde/KernelDensity/__init__/algorithm": {
             "target": "sklearn/sklearn.neighbors._kde/KernelDensity/__init__/algorithm",
@@ -37514,9 +37398,7 @@
             "target": "sklearn/sklearn.neighbors._lof/LocalOutlierFactor/__init__/n_neighbors",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 20.0
+            "variant": "required"
         },
         "sklearn/sklearn.neighbors._lof/LocalOutlierFactor/__init__/algorithm": {
             "target": "sklearn/sklearn.neighbors._lof/LocalOutlierFactor/__init__/algorithm",
@@ -37798,9 +37680,7 @@
             "target": "sklearn/sklearn.neighbors._regression/RadiusNeighborsRegressor/__init__/weights",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "uniform"
+            "variant": "required"
         },
         "sklearn/sklearn.neighbors._regression/RadiusNeighborsRegressor/__init__/algorithm": {
             "target": "sklearn/sklearn.neighbors._regression/RadiusNeighborsRegressor/__init__/algorithm",
@@ -37822,17 +37702,13 @@
             "target": "sklearn/sklearn.neighbors._regression/RadiusNeighborsRegressor/__init__/p",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 2.0
+            "variant": "required"
         },
         "sklearn/sklearn.neighbors._regression/RadiusNeighborsRegressor/__init__/metric": {
             "target": "sklearn/sklearn.neighbors._regression/RadiusNeighborsRegressor/__init__/metric",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "minkowski"
+            "variant": "required"
         },
         "sklearn/sklearn.neighbors._regression/RadiusNeighborsRegressor/__init__/metric_params": {
             "target": "sklearn/sklearn.neighbors._regression/RadiusNeighborsRegressor/__init__/metric_params",
@@ -38428,7 +38304,9 @@
             "target": "sklearn/sklearn.pipeline/FeatureUnion/__init__/n_jobs",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "none",
+            "defaultValue": null
         },
         "sklearn/sklearn.pipeline/FeatureUnion/__init__/transformer_weights": {
             "target": "sklearn/sklearn.pipeline/FeatureUnion/__init__/transformer_weights",
@@ -39256,7 +39134,9 @@
             "target": "sklearn/sklearn.preprocessing._data/normalize/axis",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "number",
+            "defaultValue": 1.0
         },
         "sklearn/sklearn.preprocessing._data/normalize/copy": {
             "target": "sklearn/sklearn.preprocessing._data/normalize/copy",
@@ -39328,9 +39208,7 @@
             "target": "sklearn/sklearn.preprocessing._data/quantile_transform/output_distribution",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "uniform"
+            "variant": "required"
         },
         "sklearn/sklearn.preprocessing._data/quantile_transform/ignore_implicit_zeros": {
             "target": "sklearn/sklearn.preprocessing._data/quantile_transform/ignore_implicit_zeros",
@@ -39602,9 +39480,7 @@
             "target": "sklearn/sklearn.preprocessing._encoders/OneHotEncoder/get_feature_names/input_features",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.preprocessing._encoders/OneHotEncoder/inverse_transform/X": {
             "target": "sklearn/sklearn.preprocessing._encoders/OneHotEncoder/inverse_transform/X",
@@ -40150,41 +40026,31 @@
             "target": "sklearn/sklearn.semi_supervised._label_propagation/LabelSpreading/__init__/kernel",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "rbf"
+            "variant": "required"
         },
         "sklearn/sklearn.semi_supervised._label_propagation/LabelSpreading/__init__/gamma": {
             "target": "sklearn/sklearn.semi_supervised._label_propagation/LabelSpreading/__init__/gamma",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 0.01
+            "variant": "required"
         },
         "sklearn/sklearn.semi_supervised._label_propagation/LabelSpreading/__init__/n_neighbors": {
             "target": "sklearn/sklearn.semi_supervised._label_propagation/LabelSpreading/__init__/n_neighbors",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 7.0
+            "variant": "required"
         },
         "sklearn/sklearn.semi_supervised._label_propagation/LabelSpreading/__init__/alpha": {
             "target": "sklearn/sklearn.semi_supervised._label_propagation/LabelSpreading/__init__/alpha",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 0.2
+            "variant": "required"
         },
         "sklearn/sklearn.semi_supervised._label_propagation/LabelSpreading/__init__/max_iter": {
             "target": "sklearn/sklearn.semi_supervised._label_propagation/LabelSpreading/__init__/max_iter",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "number",
-            "defaultValue": 10.0
+            "variant": "required"
         },
         "sklearn/sklearn.semi_supervised._label_propagation/LabelSpreading/__init__/tol": {
             "target": "sklearn/sklearn.semi_supervised._label_propagation/LabelSpreading/__init__/tol",
@@ -41388,9 +41254,7 @@
             "target": "sklearn/sklearn.tree._classes/ExtraTreeRegressor/__init__/splitter",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "string",
-            "defaultValue": "random"
+            "variant": "required"
         },
         "sklearn/sklearn.tree._classes/ExtraTreeRegressor/__init__/max_depth": {
             "target": "sklearn/sklearn.tree._classes/ExtraTreeRegressor/__init__/max_depth",
@@ -41436,9 +41300,7 @@
             "target": "sklearn/sklearn.tree._classes/ExtraTreeRegressor/__init__/random_state",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.tree._classes/ExtraTreeRegressor/__init__/min_impurity_decrease": {
             "target": "sklearn/sklearn.tree._classes/ExtraTreeRegressor/__init__/min_impurity_decrease",
@@ -41490,9 +41352,7 @@
             "target": "sklearn/sklearn.tree._export/export_graphviz/feature_names",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.tree._export/export_graphviz/class_names": {
             "target": "sklearn/sklearn.tree._export/export_graphviz/class_names",
@@ -41514,7 +41374,9 @@
             "target": "sklearn/sklearn.tree._export/export_graphviz/filled",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "boolean",
+            "defaultValue": true
         },
         "sklearn/sklearn.tree._export/export_graphviz/leaves_parallel": {
             "target": "sklearn/sklearn.tree._export/export_graphviz/leaves_parallel",
@@ -41566,7 +41428,9 @@
             "target": "sklearn/sklearn.tree._export/export_graphviz/special_characters",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "boolean",
+            "defaultValue": false
         },
         "sklearn/sklearn.tree._export/export_graphviz/precision": {
             "target": "sklearn/sklearn.tree._export/export_graphviz/precision",
@@ -41594,9 +41458,7 @@
             "target": "sklearn/sklearn.tree._export/export_text/feature_names",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.tree._export/export_text/max_depth": {
             "target": "sklearn/sklearn.tree._export/export_text/max_depth",
@@ -41648,9 +41510,7 @@
             "target": "sklearn/sklearn.tree._export/plot_tree/feature_names",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "optional",
-            "defaultValueType": "none",
-            "defaultValue": null
+            "variant": "required"
         },
         "sklearn/sklearn.tree._export/plot_tree/class_names": {
             "target": "sklearn/sklearn.tree._export/plot_tree/class_names",
@@ -41704,7 +41564,9 @@
             "target": "sklearn/sklearn.tree._export/plot_tree/rounded",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "boolean",
+            "defaultValue": false
         },
         "sklearn/sklearn.tree._export/plot_tree/precision": {
             "target": "sklearn/sklearn.tree._export/plot_tree/precision",
@@ -42074,7 +41936,9 @@
             "target": "sklearn/sklearn.utils.validation/check_array/dtype",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "string",
+            "defaultValue": "numeric"
         },
         "sklearn/sklearn.utils.validation/check_array/order": {
             "target": "sklearn/sklearn.utils.validation/check_array/order",
@@ -42204,7 +42068,9 @@
             "target": "sklearn/sklearn.utils/resample/replace",
             "authors": ["$autogen$"],
             "reviewers": [],
-            "variant": "required"
+            "variant": "optional",
+            "defaultValueType": "boolean",
+            "defaultValue": true
         },
         "sklearn/sklearn.utils/resample/n_samples": {
             "target": "sklearn/sklearn.utils/resample/n_samples",

--- a/package-parser/package_parser/processing/annotations/_generate_value_annotations.py
+++ b/package-parser/package_parser/processing/annotations/_generate_value_annotations.py
@@ -1,5 +1,7 @@
 from typing import Any, Optional
 
+from scipy.stats import binom
+
 from package_parser.processing.annotations.model import (
     AnnotationStore,
     ConstantAnnotation,
@@ -84,45 +86,10 @@ def _generate_required_or_optional_annotation(
 
     # Compute metrics
     most_common_value_count = usages.n_value_usages(parameter.id, most_common_values[0])
-
-    # We deliberately don't ensure this is a literal. Otherwise, we might make a parameter optional even though there is
-    # a tie between the most common value and the second most common value if the latter is not a literal. This would
-    # also mean different annotations would be generated depending on the order the values were inserted into the
-    # UsageCountStore since the counts are identical.
-    #
-    # Example:
-    #   Values: "1" used 5 times, "call()" used 5 times
-    #
-    #   If we now treat "1" as the most common value, we would make the parameter optional:
-    #     - most_common_value_count = 5
-    #     - second_most_common_value_count = 0 ("call()" is not a literal, so we would skip it and default to 0)
-    #     - total_literal_value_count = 5
-    #     - n_different_literal_values = 1
-    #     - (5 - 0) >= (5 / 1)
-    #
-    #   However, if we treat "call()" as the most common value, we would make the parameter required since it is not a
-    #   literal.
-    second_most_common_value_count = usages.n_value_usages(
-        parameter.id, most_common_values[1]
-    )
-
-    literal_values = [
-        stringified_value
-        for stringified_value in most_common_values
-        if _is_stringified_literal(stringified_value)
-    ]
-    total_literal_value_count = sum(
-        [usages.n_value_usages(parameter.id, value) for value in literal_values]
-    )
-    n_different_literal_values = len(literal_values)
+    second_most_common_value_count = usages.n_value_usages(parameter.id, most_common_values[1])
 
     # Add appropriate annotation
-    if _should_be_required(
-        most_common_value_count,
-        second_most_common_value_count,
-        total_literal_value_count,
-        n_different_literal_values,
-    ):
+    if _should_be_required(most_common_value_count, second_most_common_value_count):
         annotations.valueAnnotations.append(
             RequiredAnnotation(
                 target=parameter.id, authors=[autogen_author], reviewers=[]
@@ -132,7 +99,7 @@ def _generate_required_or_optional_annotation(
         (
             default_value_type,
             default_value,
-        ) = _get_type_and_value_for_stringified_value(literal_values[0])
+        ) = _get_type_and_value_for_stringified_value(most_common_values[0])
         if default_value_type is not None:  # Just for mypy, always true
             annotations.valueAnnotations.append(
                 OptionalAnnotation(
@@ -147,27 +114,33 @@ def _generate_required_or_optional_annotation(
 
 def _should_be_required(
     most_common_value_count: int,
-    second_most_common_value_count: int,
-    total_literal_value_count: int,
-    n_different_literal_values: int,
+    second_most_common_value_count: int
 ) -> bool:
     """
     This function determines how to differentiate between an optional and a required parameter
-    :param most_common_value_count: The number of times the most common value is used
-    :param second_most_common_value_count: The number of times the second most common value is used
-    :param total_literal_value_count: The total number of times the parameter is set to a literal value
-    :param n_different_literal_values: The number of different literal values that are used
+    :param most_common_value_count: How often the most common value is used
+    :param second_most_common_value_count: How often the second most common value is used
     :return: True means the parameter should be required, False means it should be optional
     """
 
-    # Most common value is the only literal value
-    if n_different_literal_values == 1:
-        return False
+    # Shortcut to speed up the check
+    if most_common_value_count == second_most_common_value_count:
+        return True
 
-    return (
-        most_common_value_count - second_most_common_value_count
-        < total_literal_value_count / n_different_literal_values
-    )
+    # Precaution to ensure proper order of most_common_value_count and second_most_common_value_count
+    if second_most_common_value_count > most_common_value_count:
+        most_common_value_count, second_most_common_value_count = (
+            second_most_common_value_count,
+            most_common_value_count
+        )
+
+    total = most_common_value_count + second_most_common_value_count
+
+    # Our null hypothesis is that the user chooses between the most common and second most common value by a fair coin
+    # toss. Unless this hypothesis is rejected, we make the parameter required. We reject the hypothesis if the p-value
+    # is less than or equal to 5%. The p-value is the probability that we observe results that are at least as extreme
+    # as the values we observed, assuming the null hypothesis is true.
+    return 2 * sum(binom.pmf(i, total, 0.5) for i in range(most_common_value_count, total + 1)) > 0.05
 
 
 def _is_stringified_literal(stringified_value: str) -> bool:

--- a/package-parser/poetry.lock
+++ b/package-parser/poetry.lock
@@ -42,7 +42,7 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "babel"
-version = "2.10.1"
+version = "2.10.3"
 description = "Internationalization utilities"
 category = "main"
 optional = false
@@ -53,7 +53,7 @@ pytz = ">=2015.7"
 
 [[package]]
 name = "blis"
-version = "0.7.7"
+version = "0.7.8"
 description = "The Blis BLAS-like linear algebra library, as a self-contained C-extension."
 category = "main"
 optional = false
@@ -72,7 +72,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "certifi"
-version = "2022.5.18.1"
+version = "2022.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -80,11 +80,11 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.12"
+version = "2.1.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
-python-versions = ">=3.5.0"
+python-versions = ">=3.6.0"
 
 [package.extras]
 unicode_backport = ["unicodedata2"]
@@ -102,7 +102,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.4"
+version = "0.4.5"
 description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
@@ -163,7 +163,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "imagesize"
-version = "1.3.0"
+version = "1.4.1"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
 category = "main"
 optional = false
@@ -228,7 +228,7 @@ python-versions = "*"
 
 [[package]]
 name = "numpy"
-version = "1.22.4"
+version = "1.23.0"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
@@ -262,14 +262,14 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pathy"
-version = "0.6.1"
+version = "0.6.2"
 description = "pathlib.Path subclasses for local and cloud bucket storage"
 category = "main"
 optional = false
 python-versions = ">= 3.6"
 
 [package.dependencies]
-smart-open = ">=5.0.0,<6.0.0"
+smart-open = ">=5.2.1,<6.0.0"
 typer = ">=0.3.0,<1.0.0"
 
 [package.extras]
@@ -390,21 +390,32 @@ python-versions = "*"
 
 [[package]]
 name = "requests"
-version = "2.27.1"
+version = "2.28.1"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7, <4"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
-idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+charset-normalizer = ">=2,<3"
+idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "scipy"
+version = "1.8.1"
+description = "SciPy: Scientific Library for Python"
+category = "main"
+optional = false
+python-versions = ">=3.8,<3.11"
+
+[package.dependencies]
+numpy = ">=1.17.3,<1.25.0"
 
 [[package]]
 name = "smart-open"
@@ -505,7 +516,7 @@ wasabi = ">=0.8.1,<1.1.0"
 
 [[package]]
 name = "sphinx"
-version = "5.0.1"
+version = "5.0.2"
 description = "Python documentation generator"
 category = "main"
 optional = false
@@ -682,7 +693,7 @@ telegram = ["requests"]
 
 [[package]]
 name = "typer"
-version = "0.4.1"
+version = "0.4.2"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 category = "main"
 optional = false
@@ -693,13 +704,13 @@ click = ">=7.1.1,<9.0.0"
 
 [package.extras]
 all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)"]
-dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
 doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "mdx-include (>=1.4.1,<2.0.0)"]
 test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.910)", "black (>=22.3.0,<23.0.0)", "isort (>=5.0.6,<6.0.0)"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.2.0"
+version = "4.3.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -736,8 +747,8 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.10"
-content-hash = "e5f53a14d20db154e1253eff57a18fe5a3c09fe838355ef4b049710716b43123"
+python-versions = "=3.10"
+content-hash = "0d0a5287c5b509a671ebb2b49decb038fc22f2ae12b821e459f36598c7903cfd"
 
 [metadata.files]
 alabaster = [
@@ -757,49 +768,54 @@ attrs = [
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 babel = [
-    {file = "Babel-2.10.1-py3-none-any.whl", hash = "sha256:3f349e85ad3154559ac4930c3918247d319f21910d5ce4b25d439ed8693b98d2"},
-    {file = "Babel-2.10.1.tar.gz", hash = "sha256:98aeaca086133efb3e1e2aad0396987490c8425929ddbcfe0550184fdc54cd13"},
+    {file = "Babel-2.10.3-py3-none-any.whl", hash = "sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb"},
+    {file = "Babel-2.10.3.tar.gz", hash = "sha256:7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51"},
 ]
 blis = [
-    {file = "blis-0.7.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f4109cce38e644e81d923836b34024905d59e88c8fb48b89b420f4d7661cd89f"},
-    {file = "blis-0.7.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ee19fddb5964570d97c2096a9a1e595fa48abdde187b14f99dcea7bb546989a6"},
-    {file = "blis-0.7.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5e0acc760daf5c3b45bce44653943e3a04d81c21c5b92213ed51664525dc24e"},
-    {file = "blis-0.7.7-cp310-cp310-win_amd64.whl", hash = "sha256:bead485e5d79d3eb62a8df55618743878fb3cba606aaf926153db5803270b185"},
-    {file = "blis-0.7.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:1667db8439d9ca41c0c1f0ea954d87462be01b125436c4b264f73603c9fb4e82"},
-    {file = "blis-0.7.7-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e024f103522e72a27019cfcfe14569522a394f5d651565560a18040fdd69a6c"},
-    {file = "blis-0.7.7-cp36-cp36m-win_amd64.whl", hash = "sha256:64bef63b1abd5b41819ea53897bdbc03c631a59c1757a9393e6ae0828692f31c"},
-    {file = "blis-0.7.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cfb7d730fef706f3ea4389196ce5f610f24cc83f828c498a275c12f05f0cf5c4"},
-    {file = "blis-0.7.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:148f59a0a47a38ce82e3afc50c709494d5e5a494bef28ce1519c7a17346c645b"},
-    {file = "blis-0.7.7-cp37-cp37m-win_amd64.whl", hash = "sha256:a0183760604b14e8eb671a431d06606594def03c36aaaa2a2e7b7f88382dac76"},
-    {file = "blis-0.7.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:680480dfa16b354f2e4d584edb8d36f0505ed8df12939beee2d161aea7bb3609"},
-    {file = "blis-0.7.7-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b1e0567cde024e6ef677fe825d934baa7362cd71450c98e5198538026a86e896"},
-    {file = "blis-0.7.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a48eeaa506f176bcac306378f5e8063697c93e26d2418fcbe053e8912019090"},
-    {file = "blis-0.7.7-cp38-cp38-win_amd64.whl", hash = "sha256:7865e39cac4e10506afc49213938fb7e13bf73ca980c9c20ffad2de4ef858f43"},
-    {file = "blis-0.7.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:76d13dbcd648ca33dfc83569bb219d0696e4f6e5ad00b9f538332a3bdb28ff30"},
-    {file = "blis-0.7.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:929a6e70b800f9df505f08ed3e863bf5fd0a209aed45fb38a0fd2b8342c04981"},
-    {file = "blis-0.7.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e22145110864bcffb1d52cb57050b67b8a8ecd43c7c0a1ac0bcdb2c85c8bf416"},
-    {file = "blis-0.7.7-cp39-cp39-win_amd64.whl", hash = "sha256:d6055ced65d6581ab4f1da0d3f6ec14c60512474c5c9b3210c9f30dd7dd1447d"},
-    {file = "blis-0.7.7.tar.gz", hash = "sha256:5d4a81f9438db7a19ac8e64ad41331f65a659ea8f3bb1889a9c2088cfd9fe104"},
+    {file = "blis-0.7.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ae5b06fe3b94645ac5d93cbc7c0129639cc3e0d50b4efb361a20a9e160277a92"},
+    {file = "blis-0.7.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:294421b720c2de904908de841464c667e1a5c5e9f3db6931dfa29cf369d3653a"},
+    {file = "blis-0.7.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:354cadff661a1452c886f541b84018770ddb4c134844c56e7c1a30aa4bcc473d"},
+    {file = "blis-0.7.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2778fe0ba0e25c157839fdd19ed66b9a340c92d4e92e707b7fa9aa21c51cb254"},
+    {file = "blis-0.7.8-cp310-cp310-win_amd64.whl", hash = "sha256:0f7bfdee74ac695c35360ace00f2630c1b47406dc0b99ba9211bfa8588bfbed9"},
+    {file = "blis-0.7.8-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:159a1a9b32213d99d1415789ac66ed8d23442a696d9d376c66d7b791d3eae575"},
+    {file = "blis-0.7.8-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25cdb9775699c1b926df514a5d4c28016c11722a66211f1024b2f21373f50de2"},
+    {file = "blis-0.7.8-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f5fa330ab66d0e92a845b1db361ec8bf3dc4bc7e0dc0ded94f36b8e9f731650"},
+    {file = "blis-0.7.8-cp36-cp36m-win_amd64.whl", hash = "sha256:90f17543e0aa3bc379d139867467df2c365ffaf5b61988de12dbba6dbbc9fab4"},
+    {file = "blis-0.7.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bfa56e7ef14ae607d8444eb344d22f252a2e0b0f9bfa4bdc9b0c48a9f96b5461"},
+    {file = "blis-0.7.8-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c3245e42c7c6ba0d68d7dff4171d11bb08174e639bc8edd52a1fd831de1d903"},
+    {file = "blis-0.7.8-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17df5ac7d9a9dbbf0415f8f8392fbdf1790fa394f89d695bae5e2e7e361c852b"},
+    {file = "blis-0.7.8-cp37-cp37m-win_amd64.whl", hash = "sha256:95d22d3007cb454d11a478331690629861f7d40b4668f9fccfd13b6507ed099b"},
+    {file = "blis-0.7.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:96ff4c0c1ceab9f94c14b3281f3cef82f593c48c3b5f6169bd51cdcd315e0a6e"},
+    {file = "blis-0.7.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2db369a4f95927be37e11790dd1ccbf99fd6201eaffbcf408546db847b7b5740"},
+    {file = "blis-0.7.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cac120e3c0517095d3c39278e8b6b1102b1add0e1f4e161a87f313d8ee7c12e1"},
+    {file = "blis-0.7.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63735128c9cae44dc6cbf7557327385df0c4ed2dc2c45a00dabfde1e4d00802d"},
+    {file = "blis-0.7.8-cp38-cp38-win_amd64.whl", hash = "sha256:1e970ba1eb12ca38fb5d57f379472125bc3f5106c8214dc847fe79b027212135"},
+    {file = "blis-0.7.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f576ad64b772b6fd7df6ef94986235f321983dc870d0f76d78c931bafc41cfa4"},
+    {file = "blis-0.7.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4e7b7b8bc8cf5e82958bbc393e0167318a930d394cbbf04c1ba18cfabaef5818"},
+    {file = "blis-0.7.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2056b0d9722f5505cfa94904c6248021197c63ecf45804dcf117f8f1c6160ab6"},
+    {file = "blis-0.7.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66b8ca1a2eb8f1e0563a592aae4b8682b66189ad560e3b8221d93eab0cb76582"},
+    {file = "blis-0.7.8-cp39-cp39-win_amd64.whl", hash = "sha256:bf60f634481c3d0faf831ac4f2d1c75343e98f714dc88e3fb3c329758577e772"},
+    {file = "blis-0.7.8.tar.gz", hash = "sha256:f7d541bb06323aa350163ba4a3ad00e8effb3b53d4c58ee6228224f3928b6c57"},
 ]
 catalogue = [
     {file = "catalogue-2.0.7-py3-none-any.whl", hash = "sha256:cab4feda641fe05da1e6a1a9d123b0869d5ca324dcd93d4a5c384408ab62e7fb"},
     {file = "catalogue-2.0.7.tar.gz", hash = "sha256:535d33ae79ebd21ca298551d85da186ae8b8e1df36b0fb0246da774163ec2d6b"},
 ]
 certifi = [
-    {file = "certifi-2022.5.18.1-py3-none-any.whl", hash = "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"},
-    {file = "certifi-2022.5.18.1.tar.gz", hash = "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7"},
+    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
+    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
-    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
+    {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
+    {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
 ]
 click = [
     {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
     {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
 ]
 colorama = [
-    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
-    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
 coverage = [
     {file = "coverage-6.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f1d5aa2703e1dab4ae6cf416eb0095304f49d004c39e9db1d86f57924f43006b"},
@@ -872,8 +888,8 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 imagesize = [
-    {file = "imagesize-1.3.0-py2.py3-none-any.whl", hash = "sha256:1db2f82529e53c3e929e8926a1fa9235aa82d0bd0c580359c67ec31b2fddaa8c"},
-    {file = "imagesize-1.3.0.tar.gz", hash = "sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d"},
+    {file = "imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"},
+    {file = "imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -990,28 +1006,28 @@ murmurhash = [
     {file = "murmurhash-1.0.7.tar.gz", hash = "sha256:630a396ebd31ca44d89b4eca36fa74ea8aae724adf0afaa2de7680c350b2936f"},
 ]
 numpy = [
-    {file = "numpy-1.22.4-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:ba9ead61dfb5d971d77b6c131a9dbee62294a932bf6a356e48c75ae684e635b3"},
-    {file = "numpy-1.22.4-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:1ce7ab2053e36c0a71e7a13a7475bd3b1f54750b4b433adc96313e127b870887"},
-    {file = "numpy-1.22.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7228ad13744f63575b3a972d7ee4fd61815b2879998e70930d4ccf9ec721dce0"},
-    {file = "numpy-1.22.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43a8ca7391b626b4c4fe20aefe79fec683279e31e7c79716863b4b25021e0e74"},
-    {file = "numpy-1.22.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a911e317e8c826ea632205e63ed8507e0dc877dcdc49744584dfc363df9ca08c"},
-    {file = "numpy-1.22.4-cp310-cp310-win32.whl", hash = "sha256:9ce7df0abeabe7fbd8ccbf343dc0db72f68549856b863ae3dd580255d009648e"},
-    {file = "numpy-1.22.4-cp310-cp310-win_amd64.whl", hash = "sha256:3e1ffa4748168e1cc8d3cde93f006fe92b5421396221a02f2274aab6ac83b077"},
-    {file = "numpy-1.22.4-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:59d55e634968b8f77d3fd674a3cf0b96e85147cd6556ec64ade018f27e9479e1"},
-    {file = "numpy-1.22.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c1d937820db6e43bec43e8d016b9b3165dcb42892ea9f106c70fb13d430ffe72"},
-    {file = "numpy-1.22.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4c5d5eb2ec8da0b4f50c9a843393971f31f1d60be87e0fb0917a49133d257d6"},
-    {file = "numpy-1.22.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64f56fc53a2d18b1924abd15745e30d82a5782b2cab3429aceecc6875bd5add0"},
-    {file = "numpy-1.22.4-cp38-cp38-win32.whl", hash = "sha256:fb7a980c81dd932381f8228a426df8aeb70d59bbcda2af075b627bbc50207cba"},
-    {file = "numpy-1.22.4-cp38-cp38-win_amd64.whl", hash = "sha256:e96d7f3096a36c8754207ab89d4b3282ba7b49ea140e4973591852c77d09eb76"},
-    {file = "numpy-1.22.4-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:4c6036521f11a731ce0648f10c18ae66d7143865f19f7299943c985cdc95afb5"},
-    {file = "numpy-1.22.4-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:b89bf9b94b3d624e7bb480344e91f68c1c6c75f026ed6755955117de00917a7c"},
-    {file = "numpy-1.22.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2d487e06ecbf1dc2f18e7efce82ded4f705f4bd0cd02677ffccfb39e5c284c7e"},
-    {file = "numpy-1.22.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3eb268dbd5cfaffd9448113539e44e2dd1c5ca9ce25576f7c04a5453edc26fa"},
-    {file = "numpy-1.22.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37431a77ceb9307c28382c9773da9f306435135fae6b80b62a11c53cfedd8802"},
-    {file = "numpy-1.22.4-cp39-cp39-win32.whl", hash = "sha256:cc7f00008eb7d3f2489fca6f334ec19ca63e31371be28fd5dad955b16ec285bd"},
-    {file = "numpy-1.22.4-cp39-cp39-win_amd64.whl", hash = "sha256:f0725df166cf4785c0bc4cbfb320203182b1ecd30fee6e541c8752a92df6aa32"},
-    {file = "numpy-1.22.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0791fbd1e43bf74b3502133207e378901272f3c156c4df4954cad833b1380207"},
-    {file = "numpy-1.22.4.zip", hash = "sha256:425b390e4619f58d8526b3dcf656dde069133ae5c240229821f01b5f44ea07af"},
+    {file = "numpy-1.23.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:58bfd40eb478f54ff7a5710dd61c8097e169bc36cc68333d00a9bcd8def53b38"},
+    {file = "numpy-1.23.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:196cd074c3f97c4121601790955f915187736f9cf458d3ee1f1b46aff2b1ade0"},
+    {file = "numpy-1.23.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1d88ef79e0a7fa631bb2c3dda1ea46b32b1fe614e10fedd611d3d5398447f2f"},
+    {file = "numpy-1.23.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d54b3b828d618a19779a84c3ad952e96e2c2311b16384e973e671aa5be1f6187"},
+    {file = "numpy-1.23.0-cp310-cp310-win32.whl", hash = "sha256:2b2da66582f3a69c8ce25ed7921dcd8010d05e59ac8d89d126a299be60421171"},
+    {file = "numpy-1.23.0-cp310-cp310-win_amd64.whl", hash = "sha256:97a76604d9b0e79f59baeca16593c711fddb44936e40310f78bfef79ee9a835f"},
+    {file = "numpy-1.23.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d8cc87bed09de55477dba9da370c1679bd534df9baa171dd01accbb09687dac3"},
+    {file = "numpy-1.23.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f0f18804df7370571fb65db9b98bf1378172bd4e962482b857e612d1fec0f53e"},
+    {file = "numpy-1.23.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac86f407873b952679f5f9e6c0612687e51547af0e14ddea1eedfcb22466babd"},
+    {file = "numpy-1.23.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae8adff4172692ce56233db04b7ce5792186f179c415c37d539c25de7298d25d"},
+    {file = "numpy-1.23.0-cp38-cp38-win32.whl", hash = "sha256:fe8b9683eb26d2c4d5db32cd29b38fdcf8381324ab48313b5b69088e0e355379"},
+    {file = "numpy-1.23.0-cp38-cp38-win_amd64.whl", hash = "sha256:5043bcd71fcc458dfb8a0fc5509bbc979da0131b9d08e3d5f50fb0bbb36f169a"},
+    {file = "numpy-1.23.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1c29b44905af288b3919803aceb6ec7fec77406d8b08aaa2e8b9e63d0fe2f160"},
+    {file = "numpy-1.23.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:98e8e0d8d69ff4d3fa63e6c61e8cfe2d03c29b16b58dbef1f9baa175bbed7860"},
+    {file = "numpy-1.23.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79a506cacf2be3a74ead5467aee97b81fca00c9c4c8b3ba16dbab488cd99ba10"},
+    {file = "numpy-1.23.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:092f5e6025813e64ad6d1b52b519165d08c730d099c114a9247c9bb635a2a450"},
+    {file = "numpy-1.23.0-cp39-cp39-win32.whl", hash = "sha256:d6ca8dabe696c2785d0c8c9b0d8a9b6e5fdbe4f922bde70d57fa1a2848134f95"},
+    {file = "numpy-1.23.0-cp39-cp39-win_amd64.whl", hash = "sha256:fc431493df245f3c627c0c05c2bd134535e7929dbe2e602b80e42bf52ff760bc"},
+    {file = "numpy-1.23.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:f9c3fc2adf67762c9fe1849c859942d23f8d3e0bee7b5ed3d4a9c3eeb50a2f07"},
+    {file = "numpy-1.23.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0d2094e8f4d760500394d77b383a1b06d3663e8892cdf5df3c592f55f3bff66"},
+    {file = "numpy-1.23.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:94b170b4fa0168cd6be4becf37cb5b127bd12a795123984385b8cd4aca9857e5"},
+    {file = "numpy-1.23.0.tar.gz", hash = "sha256:bd3fa4fe2e38533d5336e1272fc4e765cabbbde144309ccee8675509d5cd7b05"},
 ]
 numpydoc = [
     {file = "numpydoc-1.4.0-py3-none-any.whl", hash = "sha256:fd26258868ebcc75c816fe68e1d41e3b55bd410941acfb969dee3eef6e5cf260"},
@@ -1022,8 +1038,8 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pathy = [
-    {file = "pathy-0.6.1-py3-none-any.whl", hash = "sha256:25fd04cec6393661113086730ce69c789d121bea83ab1aa18452e8fd42faf29a"},
-    {file = "pathy-0.6.1.tar.gz", hash = "sha256:838624441f799a06b446a657e4ecc9ebc3fdd05234397e044a7c87e8f6e76b1c"},
+    {file = "pathy-0.6.2-py3-none-any.whl", hash = "sha256:a7aa9794fade161bb4c28a33c5bc2c6bf41f61ec5eee51cfa8914f0a433447e1"},
+    {file = "pathy-0.6.2.tar.gz", hash = "sha256:3178215bdadf3741107d987020be0fb5b59888f60f96de43cce5fe45d9d4b64a"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -1096,8 +1112,33 @@ pytz = [
     {file = "pytz-2022.1.tar.gz", hash = "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"},
 ]
 requests = [
-    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
-    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+]
+scipy = [
+    {file = "scipy-1.8.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:65b77f20202599c51eb2771d11a6b899b97989159b7975e9b5259594f1d35ef4"},
+    {file = "scipy-1.8.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:e013aed00ed776d790be4cb32826adb72799c61e318676172495383ba4570aa4"},
+    {file = "scipy-1.8.1-cp310-cp310-macosx_12_0_universal2.macosx_10_9_x86_64.whl", hash = "sha256:02b567e722d62bddd4ac253dafb01ce7ed8742cf8031aea030a41414b86c1125"},
+    {file = "scipy-1.8.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1da52b45ce1a24a4a22db6c157c38b39885a990a566748fc904ec9f03ed8c6ba"},
+    {file = "scipy-1.8.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0aa8220b89b2e3748a2836fbfa116194378910f1a6e78e4675a095bcd2c762d"},
+    {file = "scipy-1.8.1-cp310-cp310-win_amd64.whl", hash = "sha256:4e53a55f6a4f22de01ffe1d2f016e30adedb67a699a310cdcac312806807ca81"},
+    {file = "scipy-1.8.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:28d2cab0c6ac5aa131cc5071a3a1d8e1366dad82288d9ec2ca44df78fb50e649"},
+    {file = "scipy-1.8.1-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:6311e3ae9cc75f77c33076cb2794fb0606f14c8f1b1c9ff8ce6005ba2c283621"},
+    {file = "scipy-1.8.1-cp38-cp38-macosx_12_0_universal2.macosx_10_9_x86_64.whl", hash = "sha256:3b69b90c9419884efeffaac2c38376d6ef566e6e730a231e15722b0ab58f0328"},
+    {file = "scipy-1.8.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6cc6b33139eb63f30725d5f7fa175763dc2df6a8f38ddf8df971f7c345b652dc"},
+    {file = "scipy-1.8.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c4e3ae8a716c8b3151e16c05edb1daf4cb4d866caa385e861556aff41300c14"},
+    {file = "scipy-1.8.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:23b22fbeef3807966ea42d8163322366dd89da9bebdc075da7034cee3a1441ca"},
+    {file = "scipy-1.8.1-cp38-cp38-win32.whl", hash = "sha256:4b93ec6f4c3c4d041b26b5f179a6aab8f5045423117ae7a45ba9710301d7e462"},
+    {file = "scipy-1.8.1-cp38-cp38-win_amd64.whl", hash = "sha256:70ebc84134cf0c504ce6a5f12d6db92cb2a8a53a49437a6bb4edca0bc101f11c"},
+    {file = "scipy-1.8.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f3e7a8867f307e3359cc0ed2c63b61a1e33a19080f92fe377bc7d49f646f2ec1"},
+    {file = "scipy-1.8.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:2ef0fbc8bcf102c1998c1f16f15befe7cffba90895d6e84861cd6c6a33fb54f6"},
+    {file = "scipy-1.8.1-cp39-cp39-macosx_12_0_universal2.macosx_10_9_x86_64.whl", hash = "sha256:83606129247e7610b58d0e1e93d2c5133959e9cf93555d3c27e536892f1ba1f2"},
+    {file = "scipy-1.8.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:93d07494a8900d55492401917a119948ed330b8c3f1d700e0b904a578f10ead4"},
+    {file = "scipy-1.8.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3b3c8924252caaffc54d4a99f1360aeec001e61267595561089f8b5900821bb"},
+    {file = "scipy-1.8.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70de2f11bf64ca9921fda018864c78af7147025e467ce9f4a11bc877266900a6"},
+    {file = "scipy-1.8.1-cp39-cp39-win32.whl", hash = "sha256:1166514aa3bbf04cb5941027c6e294a000bba0cf00f5cdac6c77f2dad479b434"},
+    {file = "scipy-1.8.1-cp39-cp39-win_amd64.whl", hash = "sha256:9dd4012ac599a1e7eb63c114d1eee1bcfc6dc75a29b589ff0ad0bb3d9412034f"},
+    {file = "scipy-1.8.1.tar.gz", hash = "sha256:9e3fb1b0e896f14a85aa9a28d5f755daaeeb54c897b746df7a55ccb02b340f33"},
 ]
 smart-open = [
     {file = "smart_open-5.2.1-py3-none-any.whl", hash = "sha256:71d14489da58b60ce12fc3ecb823facc59a8b23cd1b58edb97175640350d3a62"},
@@ -1134,8 +1175,8 @@ spacy-loggers = [
     {file = "spacy_loggers-1.0.2-py3-none-any.whl", hash = "sha256:d48c9313a577ad1818da961cf6db71a73fd1e556ae47e6e68d7e28b541d11e18"},
 ]
 sphinx = [
-    {file = "Sphinx-5.0.1-py3-none-any.whl", hash = "sha256:36aa2a3c2f6d5230be94585bc5d74badd5f9ed8f3388b8eedc1726fe45b1ad30"},
-    {file = "Sphinx-5.0.1.tar.gz", hash = "sha256:f4da1187785a5bc7312cc271b0e867a93946c319d106363e102936a3d9857306"},
+    {file = "Sphinx-5.0.2-py3-none-any.whl", hash = "sha256:d3e57663eed1d7c5c50895d191fdeda0b54ded6f44d5621b50709466c338d1e8"},
+    {file = "Sphinx-5.0.2.tar.gz", hash = "sha256:b18e978ea7565720f26019c702cd85c84376e948370f1cd43d60265010e1c7b0"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
@@ -1212,12 +1253,12 @@ tqdm = [
     {file = "tqdm-4.64.0.tar.gz", hash = "sha256:40be55d30e200777a307a7585aee69e4eabb46b4ec6a4b4a5f2d9f11e7d5408d"},
 ]
 typer = [
-    {file = "typer-0.4.1-py3-none-any.whl", hash = "sha256:e8467f0ebac0c81366c2168d6ad9f888efdfb6d4e1d3d5b4a004f46fa444b5c3"},
-    {file = "typer-0.4.1.tar.gz", hash = "sha256:5646aef0d936b2c761a10393f0384ee6b5c7fe0bb3e5cd710b17134ca1d99cff"},
+    {file = "typer-0.4.2-py3-none-any.whl", hash = "sha256:023bae00d1baf358a6cc7cea45851639360bb716de687b42b0a4641cd99173f1"},
+    {file = "typer-0.4.2.tar.gz", hash = "sha256:b8261c6c0152dd73478b5ba96ba677e5d6948c715c310f7c91079f311f62ec03"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
-    {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},

--- a/package-parser/pyproject.toml
+++ b/package-parser/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 parse-package = "package_parser.main:main"
 
 [tool.poetry.dependencies]
-python = "=3.10"
+python = "^3.10,<3.11"
 astroid = "^2.11.6"
 numpydoc = "^1.4"
 spacy = "^3.2.1"

--- a/package-parser/pyproject.toml
+++ b/package-parser/pyproject.toml
@@ -9,10 +9,11 @@ license = "MIT"
 parse-package = "package_parser.main:main"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "=3.10"
 astroid = "^2.11.6"
 numpydoc = "^1.4"
 spacy = "^3.2.1"
+scipy = "^1.8.1"
 
 [tool.poetry.dependencies.en_core_web_sm]
 url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl"

--- a/package-parser/tests/data/valueAnnotations/annotation_data.json
+++ b/package-parser/tests/data/valueAnnotations/annotation_data.json
@@ -95,6 +95,22 @@
         "defaultValueType": "number",
         "defaultValue": 1.0
     },
+    "sklearn/sklearn.utils.validation/check_array/dtype": {
+        "target": "sklearn/sklearn.utils.validation/check_array/dtype",
+        "authors": ["$autogen$"],
+        "reviewers": [],
+        "variant": "optional",
+        "defaultValueType": "string",
+        "defaultValue": "numeric"
+    },
+    "sklearn/sklearn.tree._export/export_graphviz/special_characters": {
+        "target": "sklearn/sklearn.tree._export/export_graphviz/special_characters",
+        "authors": ["$autogen$"],
+        "reviewers": [],
+        "variant": "optional",
+        "defaultValueType": "boolean",
+        "defaultValue": false
+    },
     "test/test/some_global_function/required_parameter_that_should_be_required": {
         "target": "test/test/some_global_function/required_parameter_that_should_be_required",
         "authors": ["$autogen$"],
@@ -175,6 +191,12 @@
     },
     "test/test/UsedClass/used_method/variable_optional_parameter": {
         "target": "test/test/UsedClass/used_method/variable_optional_parameter",
+        "authors": ["$autogen$"],
+        "reviewers": [],
+        "variant": "required"
+    },
+    "sklearn/sklearn.metrics.cluster._supervised/mutual_info_score/labels_pred": {
+        "target": "sklearn/sklearn.metrics.cluster._supervised/mutual_info_score/labels_pred",
         "authors": ["$autogen$"],
         "reviewers": [],
         "variant": "required"

--- a/package-parser/tests/data/valueAnnotations/api_data.json
+++ b/package-parser/tests/data/valueAnnotations/api_data.json
@@ -12,6 +12,30 @@
                 "test/test/used_global_function",
                 "test/test/some_global_function"
             ]
+        },
+        {
+            "id": "sklearn/sklearn.utils",
+            "name": "sklearn.utils",
+            "imports": [],
+            "from_imports": [],
+            "classes": [],
+            "functions": ["sklearn/sklearn.utils.validation/check_array"]
+        },
+        {
+            "id": "sklearn/sklearn.metrics",
+            "name": "sklearn.metrics",
+            "imports": [],
+            "from_imports": [],
+            "classes": [],
+            "functions": ["sklearn/sklearn.metrics.cluster._supervised/mutual_info_score"]
+        },
+        {
+            "id": "sklearn/sklearn.tree",
+            "name": "sklearn.tree",
+            "imports": [],
+            "from_imports": [],
+            "classes": [],
+            "functions": ["sklearn/sklearn.tree._export/export_graphviz"]
         }
     ],
     "classes": [
@@ -250,6 +274,51 @@
                     "name": "kwargs",
                     "qname": "test.test.some_global_function.kwargs",
                     "assigned_by": "NAMED_VARARG"
+                }
+            ]
+        },
+        {
+            "issue": "https://github.com/lars-reimann/api-editor/issues/842",
+            "id": "sklearn/sklearn.utils.validation/check_array",
+            "name": "check_array",
+            "qname": "sklearn.utils.validation.check_array",
+            "parameters": [
+                {
+                    "id": "sklearn/sklearn.utils.validation/check_array/dtype",
+                    "name": "dtype",
+                    "qname": "sklearn.utils.validation.check_array.dtype",
+                    "default_value": "'numeric'",
+                    "assigned_by": "NAME_ONLY"
+                }
+            ]
+        },
+        {
+            "issue": "https://github.com/lars-reimann/api-editor/issues/828",
+            "id": "sklearn/sklearn.metrics.cluster._supervised/mutual_info_score",
+            "name": "mutual_info_score",
+            "qname": "sklearn.metrics.cluster._supervised.mutual_info_score",
+            "parameters": [
+                {
+                    "id": "sklearn/sklearn.metrics.cluster._supervised/mutual_info_score/labels_pred",
+                    "name": "labels_pred",
+                    "qname": "sklearn.metrics.cluster._supervised.mutual_info_score.labels_pred",
+                    "default_value": null,
+                    "assigned_by": "POSITION_OR_NAME"
+                }
+            ]
+        },
+        {
+            "issue": "https://github.com/lars-reimann/api-editor/issues/822",
+            "id": "sklearn/sklearn.tree._export/export_graphviz",
+            "name": "export_graphviz",
+            "qname": "sklearn.tree._export.export_graphviz",
+            "parameters": [
+                {
+                    "id": "sklearn/sklearn.tree._export/export_graphviz/special_characters",
+                    "name": "special_characters",
+                    "qname": "sklearn.tree._export.export_graphviz.special_characters",
+                    "default_value": "False",
+                    "assigned_by": "NAME_ONLY"
                 }
             ]
         }

--- a/package-parser/tests/data/valueAnnotations/usage_data.json
+++ b/package-parser/tests/data/valueAnnotations/usage_data.json
@@ -5,7 +5,10 @@
     "function_counts": {
         "test/test/used_global_function": 5,
         "test/test/UsedClass/used_method": 5,
-        "test/test/some_global_function": 10
+        "test/test/some_global_function": 10,
+        "sklearn/sklearn.utils.validation/check_array": 59,
+        "sklearn/sklearn.metrics.cluster._supervised/mutual_info_score": 8,
+        "sklearn/sklearn.tree._export/export_graphviz": 202
     },
     "parameter_counts": {
         "test/test/used_global_function/constant_required_parameter": 5,
@@ -33,7 +36,10 @@
         "test/test/some_global_function/optional_parameter_that_should_be_optional_with_same_default": 2,
         "test/test/some_global_function/optional_parameter_that_should_be_optional_with_different_default": 8,
         "test/test/some_global_function/optional_parameter_that_should_be_optional_with_non_string": 8,
-        "test/test/some_global_function/issue_715": 10
+        "test/test/some_global_function/issue_715": 10,
+        "sklearn/sklearn.utils.validation/check_array/dtype": 59,
+        "sklearn/sklearn.metrics.cluster._supervised/mutual_info_score/labels_pred": 8,
+        "sklearn/sklearn.tree._export/export_graphviz/special_characters": 202
     },
     "value_counts": {
         "test/test/used_global_function/constant_required_parameter": {
@@ -122,6 +128,26 @@
             "1": 8,
             "non_string": 1,
             "non_string_2": 1
+        },
+        "sklearn/sklearn.utils.validation/check_array/dtype": {
+            "None": 13,
+            "'numeric'": 37,
+            "FLOAT_DTYPES": 7,
+            "np.object": 2
+        },
+        "sklearn/sklearn.metrics.cluster._supervised/mutual_info_score/labels_pred": {
+            "None": 1,
+            "verySimpleLearner.predict_proba(trainInputFeature)[:, 1]": 1,
+            "verySimpleLearner.predict_proba(validInputFeature)[:, 1]": 1,
+            "verySimpleLearner.predict_proba(trainInputFeatures)[:, 1]": 1,
+            "verySimpleLearner.predict_proba(validInputFeatures)[:, 1]": 1,
+            "test['lee_a_coref']": 1,
+            "test['lee_b_coref']": 1,
+            "col_corr": 1
+        },
+        "sklearn/sklearn.tree._export/export_graphviz/special_characters": {
+            "True": 52,
+            "False": 150
         }
     }
 }

--- a/package-parser/tests/data/valueAnnotations/usage_data.json
+++ b/package-parser/tests/data/valueAnnotations/usage_data.json
@@ -5,7 +5,7 @@
     "function_counts": {
         "test/test/used_global_function": 5,
         "test/test/UsedClass/used_method": 5,
-        "test/test/some_global_function": 10,
+        "test/test/some_global_function": 20,
         "sklearn/sklearn.utils.validation/check_array": 59,
         "sklearn/sklearn.metrics.cluster._supervised/mutual_info_score": 8,
         "sklearn/sklearn.tree._export/export_graphviz": 202
@@ -25,18 +25,18 @@
         "test/test/UsedClass/used_method/should_not_be_constant_four": 5,
         "test/test/UsedClass/used_method/should_not_be_constant_five": 5,
         "test/test/UsedClass/used_method/should_not_be_constant_six": 5,
-        "test/test/some_global_function/required_parameter_that_should_be_constant": 10,
-        "test/test/some_global_function/required_parameter_that_should_be_required": 10,
-        "test/test/some_global_function/required_parameter_that_should_be_required_with_non_string": 10,
-        "test/test/some_global_function/required_parameter_that_should_be_optional": 10,
-        "test/test/some_global_function/required_parameter_that_should_be_optional_with_non_string": 10,
+        "test/test/some_global_function/required_parameter_that_should_be_constant": 20,
+        "test/test/some_global_function/required_parameter_that_should_be_required": 20,
+        "test/test/some_global_function/required_parameter_that_should_be_required_with_non_string": 20,
+        "test/test/some_global_function/required_parameter_that_should_be_optional": 20,
+        "test/test/some_global_function/required_parameter_that_should_be_optional_with_non_string": 20,
         "test/test/some_global_function/optional_parameter_that_should_be_constant": 0,
-        "test/test/some_global_function/optional_parameter_that_should_be_required": 4,
-        "test/test/some_global_function/optional_parameter_that_should_be_required_with_non_string": 9,
-        "test/test/some_global_function/optional_parameter_that_should_be_optional_with_same_default": 2,
-        "test/test/some_global_function/optional_parameter_that_should_be_optional_with_different_default": 8,
-        "test/test/some_global_function/optional_parameter_that_should_be_optional_with_non_string": 8,
-        "test/test/some_global_function/issue_715": 10,
+        "test/test/some_global_function/optional_parameter_that_should_be_required": 8,
+        "test/test/some_global_function/optional_parameter_that_should_be_required_with_non_string": 18,
+        "test/test/some_global_function/optional_parameter_that_should_be_optional_with_same_default": 4,
+        "test/test/some_global_function/optional_parameter_that_should_be_optional_with_different_default": 16,
+        "test/test/some_global_function/optional_parameter_that_should_be_optional_with_non_string": 16,
+        "test/test/some_global_function/issue_715": 20,
         "sklearn/sklearn.utils.validation/check_array/dtype": 59,
         "sklearn/sklearn.metrics.cluster._supervised/mutual_info_score/labels_pred": 8,
         "sklearn/sklearn.tree._export/export_graphviz/special_characters": 202
@@ -86,48 +86,48 @@
             "'test": 5
         },
         "test/test/some_global_function/required_parameter_that_should_be_constant": {
-            "'test'": 10
+            "'test'": 20
         },
         "test/test/some_global_function/required_parameter_that_should_be_required": {
-            "'test'": 4,
-            "'test2'": 6
+            "'test'": 8,
+            "'test2'": 12
         },
         "test/test/some_global_function/required_parameter_that_should_be_required_with_non_string": {
-            "'test'": 1,
-            "'test2'": 4,
-            "non_string": 5
+            "'test'": 2,
+            "'test2'": 8,
+            "non_string": 10
         },
         "test/test/some_global_function/required_parameter_that_should_be_optional": {
-            "'test'": 2,
-            "'test2'": 8
+            "'test'": 4,
+            "'test2'": 16
         },
         "test/test/some_global_function/required_parameter_that_should_be_optional_with_non_string": {
-            "'test'": 2,
-            "non_string": 2,
-            "'test2'": 6
+            "'test'": 3,
+            "non_string": 4,
+            "'test2'": 13
         },
         "test/test/some_global_function/optional_parameter_that_should_be_constant": {},
         "test/test/some_global_function/optional_parameter_that_should_be_required": {
-            "'test2'": 4
-        },
-        "test/test/some_global_function/optional_parameter_that_should_be_required_with_non_string": {
-            "'test2'": 4,
-            "non_string": 5
-        },
-        "test/test/some_global_function/optional_parameter_that_should_be_optional_with_same_default": {
-            "'test2'": 2
-        },
-        "test/test/some_global_function/optional_parameter_that_should_be_optional_with_different_default": {
             "'test2'": 8
         },
+        "test/test/some_global_function/optional_parameter_that_should_be_required_with_non_string": {
+            "'test2'": 8,
+            "non_string": 10
+        },
+        "test/test/some_global_function/optional_parameter_that_should_be_optional_with_same_default": {
+            "'test2'": 4
+        },
+        "test/test/some_global_function/optional_parameter_that_should_be_optional_with_different_default": {
+            "'test2'": 16
+        },
         "test/test/some_global_function/optional_parameter_that_should_be_optional_with_non_string": {
-            "non_string": 2,
-            "'test2'": 6
+            "non_string": 4,
+            "'test2'": 13
         },
         "test/test/some_global_function/issue_715": {
-            "1": 8,
-            "non_string": 1,
-            "non_string_2": 1
+            "1": 16,
+            "non_string": 2,
+            "non_string_2": 2
         },
         "sklearn/sklearn.utils.validation/check_array/dtype": {
             "None": 13,


### PR DESCRIPTION
Closes #912.
Closes #842.
Closes #828.
Closes #822.

### Summary of Changes

By default we want to make a parameter constant, provided there is only one value and it's a literal. This part is unchanged.

If we cannot make the parameter constant, we now try to make a parameter required. If the most common value is not a literal, we always do so. Otherwise, we check how often the most common and the second most common value occur. Our null hypothesis is that they are equally likely to be chosen. Unless this hypothesis is rejected, we make the parameter required. If the hypothesis is rejected, we make the parameter optional. We reject the hypothesis if the probability that the observed values or even more extreme differences are produced, assuming our null hypothesis is true, is at most 5%.

On the `sklearn` data this produces only slightly different results than the previous approach:

|Variant|Old Count|New Count|
|-|-|-|
|constant|1038|1038|
|required|1024|1091|
|optional|1121|1054|

Compared to the previous approach we now make a few very rarely used parameters (on very rarely used functions) required.

The new approach is quite a bit slower than the old one. Generating annotations for `sklearn` now takes around 17s compared to the previous 8s. However, we now have a scientific basis compared to the ad-hoc approach we had previously.

The significance level (currently 5%) might be adjusted later after more practical testing.