### PR TITLE
fix(gui): import of annotation files without schema version

### DIFF
--- a/api-editor/gui/src/features/annotations/AnnotationImportDialog.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationImportDialog.tsx
@@ -42,7 +42,7 @@ export const AnnotationImportDialog: React.FC = function () {
             return false;
         }
 
-        if (!supportedAnnotationStoreSchemaVersions.includes(newAnnotationStore.schemaVersion)) {
+        if (!supportedAnnotationStoreSchemaVersions.includes(newAnnotationStore.schemaVersion ?? 1)) {
             toast({
                 title: 'Incompatible Annotation File',
                 description: 'This file is not compatible with the current version of the API Editor.',

--- a/api-editor/gui/src/features/annotations/versioning/migrations.ts
+++ b/api-editor/gui/src/features/annotations/versioning/migrations.ts
@@ -5,7 +5,7 @@ import { VersionedAnnotationStore } from './VersionedAnnotationStore';
 export const migrateAnnotationStoreToCurrentVersion = function <OldAnnotationStore extends VersionedAnnotationStore>(
     oldAnnotationStore: OldAnnotationStore,
 ): AnnotationStoreV2 {
-    switch (oldAnnotationStore.schemaVersion) {
+    switch (oldAnnotationStore.schemaVersion ?? 1) {
         case 1:
             return migrateAnnotationStoreV1ToV2(oldAnnotationStore as unknown as AnnotationStoreV1);
         case 2:

--- a/api-editor/gui/src/features/menuBar/MenuBar.tsx
+++ b/api-editor/gui/src/features/menuBar/MenuBar.tsx
@@ -64,6 +64,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { SelectionBreadcrumbs } from './SelectionBreadcrumbs';
 import { HelpMenu } from './HelpMenu';
 import { AnnotationStore } from '../annotations/versioning/AnnotationStoreV2';
+import {supportedAnnotationStoreSchemaVersions} from "../annotations/versioning/expectedVersions";
 
 interface MenuBarProps {
     displayInferErrors: (errors: string[]) => void;
@@ -93,7 +94,10 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
 
     const exportAnnotations = () => {
         const a = document.createElement('a');
-        const file = new Blob([JSON.stringify(annotationStore, null, 4)], {
+        const file = new Blob([JSON.stringify({
+            ...annotationStore,
+            schemaVersion: supportedAnnotationStoreSchemaVersions[supportedAnnotationStoreSchemaVersions.length - 1],
+        }, null, 4)], {
             type: 'application/json',
         });
         a.href = URL.createObjectURL(file);

--- a/api-editor/gui/src/features/menuBar/MenuBar.tsx
+++ b/api-editor/gui/src/features/menuBar/MenuBar.tsx
@@ -64,7 +64,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { SelectionBreadcrumbs } from './SelectionBreadcrumbs';
 import { HelpMenu } from './HelpMenu';
 import { AnnotationStore } from '../annotations/versioning/AnnotationStoreV2';
-import {supportedAnnotationStoreSchemaVersions} from "../annotations/versioning/expectedVersions";
+import { supportedAnnotationStoreSchemaVersions } from '../annotations/versioning/expectedVersions';
 
 interface MenuBarProps {
     displayInferErrors: (errors: string[]) => void;
@@ -94,12 +94,22 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
 
     const exportAnnotations = () => {
         const a = document.createElement('a');
-        const file = new Blob([JSON.stringify({
-            ...annotationStore,
-            schemaVersion: supportedAnnotationStoreSchemaVersions[supportedAnnotationStoreSchemaVersions.length - 1],
-        }, null, 4)], {
-            type: 'application/json',
-        });
+        const file = new Blob(
+            [
+                JSON.stringify(
+                    {
+                        ...annotationStore,
+                        schemaVersion:
+                            supportedAnnotationStoreSchemaVersions[supportedAnnotationStoreSchemaVersions.length - 1],
+                    },
+                    null,
+                    4,
+                ),
+            ],
+            {
+                type: 'application/json',
+            },
+        );
         a.href = URL.createObjectURL(file);
         a.download = 'annotations.json';
         a.click();


### PR DESCRIPTION
### Summary of Changes

* Store schema version in exported annotation file
* Default schema version to 1 if it's not specified in the annotation file
