### PR TITLE
fix(gui): when reviewResult is not set, default to "correct" so marker is shown

### DIFF
--- a/api-editor/gui/src/features/annotations/AnnotationView.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationView.tsx
@@ -327,7 +327,7 @@ const AnnotationTag: React.FC<AnnotationTagProps> = function ({
     const currentUserAction = useAppSelector(selectCurrentUserAction);
 
     const reviewer = (annotation.reviewers ?? [])[0];
-    const reviewResult = annotation.reviewResult;
+    const reviewResult = annotation.reviewResult ?? ReviewResult.Correct;
     const isReviewed = reviewer !== undefined;
 
     const authors = annotation.authors ?? [];


### PR DESCRIPTION
### Summary of Changes

The "correct marker is now shown again for older annotations.

### Screenshots (if necessary)

#### Before

![image](https://user-images.githubusercontent.com/2501322/177954177-70061539-eed5-44fe-b3fd-5fc187440ce7.png)

#### After

![image](https://user-images.githubusercontent.com/2501322/177954274-e4144599-1f0b-4405-b034-7e60516300d5.png)

