### PR TITLE
fix(gui): `is:done` filter crashes app

### DIFF
--- a/api-editor/gui/src/features/filter/model/DoneFilter.ts
+++ b/api-editor/gui/src/features/filter/model/DoneFilter.ts
@@ -46,13 +46,17 @@ export class DoneFilter extends AbstractPythonFilter {
 
     private getAnnotationsForTarget(target: string, annotationStore: AnnotationStore): Annotation[] {
         return Object.entries(annotationStore).flatMap(([key, value]) => {
+            if (typeof value !== 'object') {
+                return [];
+            }
+
             if (!(target in value)) {
                 return [];
             }
 
-            if (key === 'calledAfters' || key === 'groups') {
+            if (key === 'calledAfterAnnotations' || key === 'groupAnnotations') {
                 return Object.values(value[target]);
-            } else if (key === 'completes') {
+            } else if (key === 'completeAnnotations') {
                 return [];
             } else {
                 return [value[target]];

--- a/api-editor/gui/src/features/menuBar/MenuBar.tsx
+++ b/api-editor/gui/src/features/menuBar/MenuBar.tsx
@@ -99,7 +99,7 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
                 JSON.stringify(
                     {
                         ...annotationStore,
-                        schemaVersion: EXPECTED_ANNOTATION_STORE_SCHEMA_VERSION
+                        schemaVersion: EXPECTED_ANNOTATION_STORE_SCHEMA_VERSION,
                     },
                     null,
                     4,

--- a/api-editor/gui/src/features/menuBar/MenuBar.tsx
+++ b/api-editor/gui/src/features/menuBar/MenuBar.tsx
@@ -64,7 +64,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { SelectionBreadcrumbs } from './SelectionBreadcrumbs';
 import { HelpMenu } from './HelpMenu';
 import { AnnotationStore } from '../annotations/versioning/AnnotationStoreV2';
-import { supportedAnnotationStoreSchemaVersions } from '../annotations/versioning/expectedVersions';
+import { EXPECTED_ANNOTATION_STORE_SCHEMA_VERSION } from '../annotations/versioning/expectedVersions';
 
 interface MenuBarProps {
     displayInferErrors: (errors: string[]) => void;
@@ -99,8 +99,7 @@ export const MenuBar: React.FC<MenuBarProps> = function ({ displayInferErrors })
                 JSON.stringify(
                     {
                         ...annotationStore,
-                        schemaVersion:
-                            supportedAnnotationStoreSchemaVersions[supportedAnnotationStoreSchemaVersions.length - 1],
+                        schemaVersion: EXPECTED_ANNOTATION_STORE_SCHEMA_VERSION
                     },
                     null,
                     4,


### PR DESCRIPTION
Closes #938.

### Summary of Changes

Fix a crash caused by the `is:done` filter.
