### PR TITLE
feat(gui): Added a user icon for annotations which where added by the current user

### DIFF
--- a/api-editor/gui/src/features/annotations/AnnotationView.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationView.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonGroup, Icon, IconButton, Stack, Text as ChakraText, Tooltip } from '@chakra-ui/react';
 import React from 'react';
-import {FaCheck, FaFlag, FaQuestion, FaTimes, FaTrash, FaUser, FaWrench} from 'react-icons/fa';
+import {FaCheck, FaFlag, FaQuestion, FaRobot, FaTimes, FaTrash, FaUser, FaWrench} from 'react-icons/fa';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import {
     removeBoundaryAnnotation,
@@ -377,7 +377,7 @@ const AnnotationTag: React.FC<AnnotationTagProps> = function ({
             <Tooltip label={`${authorText}Click to change.`}>
                 <Button
                     leftIcon={<FaWrench />}
-                    rightIcon={authors.includes(username) && <FaUser />}
+                    rightIcon={(authors.includes(username) && <FaUser />) || (authors.length === 1 && authors[0] === '$autogen$' && <FaRobot />)}
                     flexGrow={1}
                     borderLeft="none"
                     justifyContent="flex-start"

--- a/api-editor/gui/src/features/annotations/AnnotationView.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationView.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonGroup, Icon, IconButton, Stack, Text as ChakraText, Tooltip } from '@chakra-ui/react';
 import React from 'react';
-import {FaCheck, FaFlag, FaQuestion, FaRobot, FaTimes, FaTrash, FaUser, FaWrench} from 'react-icons/fa';
+import { FaCheck, FaFlag, FaQuestion, FaRobot, FaTimes, FaTrash, FaUser, FaWrench } from 'react-icons/fa';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import {
     removeBoundaryAnnotation,
@@ -377,7 +377,10 @@ const AnnotationTag: React.FC<AnnotationTagProps> = function ({
             <Tooltip label={`${authorText}Click to change.`}>
                 <Button
                     leftIcon={<FaWrench />}
-                    rightIcon={(authors.includes(username) && <FaUser />) || (authors.length === 1 && authors[0] === '$autogen$' && <FaRobot />)}
+                    rightIcon={
+                        (authors.includes(username) && <FaUser />) ||
+                        (authors.length === 1 && authors[0] === '$autogen$' && <FaRobot />)
+                    }
                     flexGrow={1}
                     borderLeft="none"
                     justifyContent="flex-start"

--- a/api-editor/gui/src/features/annotations/AnnotationView.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationView.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonGroup, Icon, IconButton, Stack, Text as ChakraText, Tooltip } from '@chakra-ui/react';
 import React from 'react';
-import { FaCheck, FaFlag, FaQuestion, FaTimes, FaTrash, FaWrench } from 'react-icons/fa';
+import {FaCheck, FaFlag, FaQuestion, FaTimes, FaTrash, FaUser, FaWrench} from 'react-icons/fa';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import {
     removeBoundaryAnnotation,
@@ -35,6 +35,7 @@ import {
     selectRemoveAnnotation,
     selectRenameAnnotation,
     selectTodoAnnotation,
+    selectUsername,
     selectUsernameIsValid,
     selectValueAnnotation,
 } from './annotationSlice';
@@ -332,6 +333,7 @@ const AnnotationTag: React.FC<AnnotationTagProps> = function ({
 
     const authors = annotation.authors ?? [];
     const authorText = createAuthorText(authors);
+    const username = useAppSelector(selectUsername);
 
     const isReportable = reportable && authors.length === 1 && authors.includes('$autogen$');
 
@@ -375,6 +377,7 @@ const AnnotationTag: React.FC<AnnotationTagProps> = function ({
             <Tooltip label={`${authorText}Click to change.`}>
                 <Button
                     leftIcon={<FaWrench />}
+                    rightIcon={authors.includes(username) && <FaUser />}
                     flexGrow={1}
                     borderLeft="none"
                     justifyContent="flex-start"

--- a/api-editor/gui/src/features/annotations/AnnotationView.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationView.tsx
@@ -337,9 +337,9 @@ const AnnotationTag: React.FC<AnnotationTagProps> = function ({
 
     let rightIcon;
     if (authors.includes(username)) {
-        rightIcon = <FaUser />
+        rightIcon = <FaUser />;
     } else if (authors.length === 1 && authors[0] === '$autogen$') {
-        rightIcon = <FaRobot />
+        rightIcon = <FaRobot />;
     }
 
     const isReportable = reportable && authors.length === 1 && authors.includes('$autogen$');

--- a/api-editor/gui/src/features/annotations/AnnotationView.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationView.tsx
@@ -335,6 +335,13 @@ const AnnotationTag: React.FC<AnnotationTagProps> = function ({
     const authorText = createAuthorText(authors);
     const username = useAppSelector(selectUsername);
 
+    let rightIcon;
+    if (authors.includes(username)) {
+        rightIcon = <FaUser />
+    } else if (authors.length === 1 && authors[0] === '$autogen$') {
+        rightIcon = <FaRobot />
+    }
+
     const isReportable = reportable && authors.length === 1 && authors.includes('$autogen$');
 
     // Event Handler
@@ -377,10 +384,7 @@ const AnnotationTag: React.FC<AnnotationTagProps> = function ({
             <Tooltip label={`${authorText}Click to change.`}>
                 <Button
                     leftIcon={<FaWrench />}
-                    rightIcon={
-                        (authors.includes(username) && <FaUser />) ||
-                        (authors.length === 1 && authors[0] === '$autogen$' && <FaRobot />)
-                    }
+                    rightIcon={rightIcon}
                     flexGrow={1}
                     borderLeft="none"
                     justifyContent="flex-start"


### PR DESCRIPTION
Closes #910.
Closes #911.

### Summary of Changes

See these issues.

### Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/2046129/177962979-1ef70287-367e-4e4a-8627-a2124e20ca00.png)
![image](https://user-images.githubusercontent.com/2046129/177963008-2c8cb155-8191-4982-81ce-e459933a1258.png)

### Testing Instructions

Import autogenerated Annotations and create/edit annotations.
View the icons on the right side of the annotation-button.