### PR TITLE
feat(gui): implements links to methods in element description

### DIFF
--- a/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/DocumentationText.tsx
@@ -28,11 +28,11 @@ import { selectExpandDocumentationByDefault } from '../../ui/uiSlice';
 import { Link as RouterLink } from 'react-router-dom';
 import { PythonDeclaration } from '../model/PythonDeclaration';
 import { PythonPackage } from '../model/PythonPackage';
-import {Optional} from "../../../common/util/types";
-import {PythonFunction} from "../model/PythonFunction";
-import {PythonClass} from "../model/PythonClass";
-import {PythonParameter} from "../model/PythonParameter";
-import {PythonModule} from "../model/PythonModule";
+import { Optional } from '../../../common/util/types';
+import { PythonFunction } from '../model/PythonFunction';
+import { PythonClass } from '../model/PythonClass';
+import { PythonParameter } from '../model/PythonParameter';
+import { PythonModule } from '../model/PythonModule';
 
 interface DocumentationTextProps {
     declaration: PythonDeclaration;
@@ -92,10 +92,16 @@ export const DocumentationText: React.FC<DocumentationTextProps> = function ({ d
         // replace double colons with single colon
         .replaceAll(/::/gu, ':')
         // replace relative links to classes
-        .replaceAll(/:class:`(\w*)`/gu, (_match, name) => resolveRelativeLink(declaration, name, DeclarationLevel.CLASS))
+        .replaceAll(/:class:`(\w*)`/gu, (_match, name) =>
+            resolveRelativeLink(declaration, name, DeclarationLevel.CLASS),
+        )
         // replace relative links to functions
-        .replaceAll(/:func:`(\w*)`/gu, (_match, name) => resolveRelativeLink(declaration, name, DeclarationLevel.FUNCTION))
-        .replaceAll(/:meth:`(\w*)`/gu, (_match, name) => resolveRelativeLink(declaration, name, DeclarationLevel.FUNCTION))
+        .replaceAll(/:func:`(\w*)`/gu, (_match, name) =>
+            resolveRelativeLink(declaration, name, DeclarationLevel.FUNCTION),
+        )
+        .replaceAll(/:meth:`(\w*)`/gu, (_match, name) =>
+            resolveRelativeLink(declaration, name, DeclarationLevel.FUNCTION),
+        )
         // replace absolute links to modules
         .replaceAll(/:mod:`([\w.]*)`/gu, (_match, qualifiedName) => resolveAbsoluteLink(declaration, qualifiedName, 1))
         // replace absolute links to classes
@@ -156,13 +162,15 @@ export const DocumentationText: React.FC<DocumentationTextProps> = function ({ d
 const resolveRelativeLink = function (
     currentDeclaration: PythonDeclaration,
     linkedDeclarationName: string,
-    targetLevel: DeclarationLevel
+    targetLevel: DeclarationLevel,
 ): string {
-
-    let parent: Optional<PythonDeclaration>  = currentDeclaration;
+    let parent: Optional<PythonDeclaration> = currentDeclaration;
     do {
         parent = parent.parent();
-    } while (parent && Object.keys(DeclarationLevel)[getDeclarationLevel(parent)] >= Object.keys(DeclarationLevel)[targetLevel])
+    } while (
+        parent &&
+        Object.keys(DeclarationLevel)[getDeclarationLevel(parent)] >= Object.keys(DeclarationLevel)[targetLevel]
+    );
 
     if (!parent) {
         return linkedDeclarationName;
@@ -220,20 +228,19 @@ const resolveAbsoluteLink = function (
 
 const getDeclarationLevel = function (element: PythonDeclaration): DeclarationLevel {
     if (element instanceof PythonPackage) {
-        return DeclarationLevel.PACKAGE
+        return DeclarationLevel.PACKAGE;
     } else if (element instanceof PythonModule) {
-        return DeclarationLevel.MODULE
+        return DeclarationLevel.MODULE;
     } else if (element instanceof PythonClass) {
-        return DeclarationLevel.CLASS
+        return DeclarationLevel.CLASS;
     } else if (element instanceof PythonFunction) {
-        return DeclarationLevel.FUNCTION
+        return DeclarationLevel.FUNCTION;
     } else if (element instanceof PythonParameter) {
-        return DeclarationLevel.PARAMETER
+        return DeclarationLevel.PARAMETER;
     } else {
-        return DeclarationLevel.DEFAULT
+        return DeclarationLevel.DEFAULT;
     }
-}
-
+};
 
 enum DeclarationLevel {
     DEFAULT,
@@ -241,5 +248,5 @@ enum DeclarationLevel {
     MODULE,
     CLASS,
     FUNCTION,
-    PARAMETER
+    PARAMETER,
 }


### PR DESCRIPTION
Closes #903.

### Summary of Changes

Links to Methods are now being properly displayed as actual links instead of :meth:<name>.

### Testing Instructions

Open api-editor with api and usage data for sklearn.
Open #/sklearn/sklearn.decomposition._pca/PCA and click on the link in the description (for class test).
Open #/sklearn/sklearn.preprocessing._encoders/OneHotEncoder/__init__/handle_unknown (for method test).