### PR TITLE
feat(gui): set minWidth for HeatMapTag

### DIFF
--- a/api-editor/gui/src/features/packageData/treeView/HeatMapTag.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/HeatMapTag.tsx
@@ -26,6 +26,7 @@ export const HeatMapTag: React.FC<HeatMapTagProps> = function ({ actualValue, ma
             size="sm"
             variant="solid"
             width={boxWidth}
+            minWidth={boxWidth}
             border="1px solid white"
             boxSizing="border-box"
             fontFamily="monospace"


### PR DESCRIPTION
Closes #930.

### Summary of Changes

Added a minimal width to the HeatMapTag so it doesn't shrink with long qnames or a narrow site.

### Testing Instructions

Open api editor and load api and usages data for sklearn.
Enable a HeatMapMode and see if the HeatMapTag shrinks, when the page shrinks.
