### PR TITLE
fix(gui): parameter value histogram is now transparent again

### DIFF
--- a/api-editor/gui/src/features/packageData/selectionView/ParameterView.tsx
+++ b/api-editor/gui/src/features/packageData/selectionView/ParameterView.tsx
@@ -150,8 +150,12 @@ const CustomBarChart: React.FC<CustomBarChartProps> = function ({ parameterUsage
         datasets: [
             {
                 data: labels.map((key) => sortedParameterUsages.get(key)),
-                borderColor: labels.map((key) => (isStringifiedLiteral(key) ? '#871F78' : '#888888')),
-                backgroundColor: labels.map((key) => (isStringifiedLiteral(key) ? '#871F78' : '#888888')),
+                borderColor: labels.map((key) =>
+                    isStringifiedLiteral(key) ? 'rgba(137, 87, 229, 1)' : 'rgba(136, 136, 136, 1)',
+                ),
+                backgroundColor: labels.map((key) =>
+                    isStringifiedLiteral(key) ? 'rgba(137, 87, 229, 0.2)' : 'rgba(136, 136, 136, 0.2)',
+                ),
             },
         ],
     };


### PR DESCRIPTION
### Summary of Changes

Restore the colors for the parameter value histogram that were introduced in #937 and overwritten in #947.

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/178013418-1aa373ef-6eac-44ba-9382-8ec001d06a4b.png)