### PR TITLE
fix(gui): statistics view can now no longer be resized

### DIFF
--- a/api-editor/gui/src/app/App.tsx
+++ b/api-editor/gui/src/app/App.tsx
@@ -194,13 +194,7 @@ export const App: React.FC = function () {
                     </Box>
                 </GridItem>
                 {showStatistics && (
-                    <GridItem
-                        gridArea="rightPane"
-                        overflow="auto"
-                        w="20vw"
-                        borderLeft={1}
-                        layerStyle="subtleBorder"
-                    >
+                    <GridItem gridArea="rightPane" overflow="auto" w="20vw" borderLeft={1} layerStyle="subtleBorder">
                         <Box padding={4}>
                             <StatisticsView />
                         </Box>

--- a/api-editor/gui/src/app/App.tsx
+++ b/api-editor/gui/src/app/App.tsx
@@ -200,7 +200,6 @@ export const App: React.FC = function () {
                         w="20vw"
                         borderLeft={1}
                         layerStyle="subtleBorder"
-                        resize="horizontal"
                     >
                         <Box padding={4}>
                             <StatisticsView />


### PR DESCRIPTION
### Summary of Changes

The statistics view can no longer be resized. This interaction was not intended initially and was hard to use and buggy.