### PR TITLE
perf(gui): only change global filter string if user stops typing for 1s

### DIFF
--- a/api-editor/gui/src/features/filter/FilterControls.tsx
+++ b/api-editor/gui/src/features/filter/FilterControls.tsx
@@ -1,15 +1,25 @@
 import { FilterInput } from './FilterInput';
 import { FilterHelpButton } from './FilterHelpButton';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { HStack } from '@chakra-ui/react';
 import { MatchCount } from './FilterMatchCount';
 import { FilterPersistence } from './FilterPersistence';
+import { useAppSelector } from '../../app/hooks';
+import { selectFilterString } from '../ui/uiSlice';
 
 export const FilterControls = function () {
+    const filterString = useAppSelector(selectFilterString);
+    const [localFilterString, setLocalFilterString] = React.useState(filterString);
+
+    // The filter can be changed via other means as well and the local filter needs to reflect this
+    useEffect(() => {
+        setLocalFilterString(filterString);
+    }, [filterString]);
+
     return (
         <HStack>
-            <FilterPersistence />
-            <FilterInput />
+            <FilterPersistence localFilterString={localFilterString} />
+            <FilterInput localFilterString={localFilterString} setLocalFilterString={setLocalFilterString} />
             <FilterHelpButton />
             <MatchCount />
         </HStack>

--- a/api-editor/gui/src/features/filter/FilterControls.tsx
+++ b/api-editor/gui/src/features/filter/FilterControls.tsx
@@ -6,10 +6,12 @@ import { MatchCount } from './FilterMatchCount';
 import { FilterPersistence } from './FilterPersistence';
 import { useAppSelector } from '../../app/hooks';
 import { selectFilterString } from '../ui/uiSlice';
+import { isValidFilterToken } from './model/filterFactory';
 
 export const FilterControls = function () {
     const filterString = useAppSelector(selectFilterString);
     const [localFilterString, setLocalFilterString] = React.useState(filterString);
+    const invalidTokens = localFilterString.split(' ').filter((token) => token !== '' && !isValidFilterToken(token));
 
     // The filter can be changed via other means as well and the local filter needs to reflect this
     useEffect(() => {
@@ -18,8 +20,12 @@ export const FilterControls = function () {
 
     return (
         <HStack>
-            <FilterPersistence localFilterString={localFilterString} />
-            <FilterInput localFilterString={localFilterString} setLocalFilterString={setLocalFilterString} />
+            <FilterPersistence localFilterString={localFilterString} invalidTokens={invalidTokens} />
+            <FilterInput
+                localFilterString={localFilterString}
+                setLocalFilterString={setLocalFilterString}
+                invalidTokens={invalidTokens}
+            />
             <FilterHelpButton />
             <MatchCount />
         </HStack>

--- a/api-editor/gui/src/features/filter/FilterInput.tsx
+++ b/api-editor/gui/src/features/filter/FilterInput.tsx
@@ -37,8 +37,8 @@ export const FilterInput: React.FC = function () {
         }
 
         const newTimeoutId = setTimeout(() => {
-            dispatch(setFilterString(event.target.value))
-        }, 1000)
+            dispatch(setFilterString(event.target.value));
+        }, 1000);
 
         setTimeoutId(newTimeoutId);
     };

--- a/api-editor/gui/src/features/filter/FilterInput.tsx
+++ b/api-editor/gui/src/features/filter/FilterInput.tsx
@@ -13,25 +13,23 @@ import {
     UnorderedList,
 } from '@chakra-ui/react';
 import { closest, distance } from 'fastest-levenshtein';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { selectFilterString, setFilterString } from '../ui/uiSlice';
 import { getFixedFilterNames, isValidFilterToken } from './model/filterFactory';
 
-export const FilterInput: React.FC = function () {
+interface FilterInputProps {
+    localFilterString: string;
+    setLocalFilterString: (newLocalFilterString: string) => void;
+}
+
+export const FilterInput: React.FC<FilterInputProps> = function ({localFilterString, setLocalFilterString}) {
     const dispatch = useAppDispatch();
 
-    const filterString = useAppSelector(selectFilterString);
-    const [localFilterString, setLocalFilterString] = React.useState(filterString);
-    const [timeoutId, setTimeoutId] = React.useState<NodeJS.Timeout>();
-
-    const invalidTokens = filterString.split(' ').filter((token) => token !== '' && !isValidFilterToken(token));
+    const invalidTokens = localFilterString.split(' ').filter((token) => token !== '' && !isValidFilterToken(token));
     const filterIsValid = invalidTokens.length === 0;
 
-    // The filter can be changed via by other means as well and the local filter needs to reflect this
-    useEffect(() => {
-        setLocalFilterString(filterString);
-    }, [filterString]);
+    const [timeoutId, setTimeoutId] = React.useState<NodeJS.Timeout>();
 
     const onChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
         setLocalFilterString(event.target.value);

--- a/api-editor/gui/src/features/filter/FilterInput.tsx
+++ b/api-editor/gui/src/features/filter/FilterInput.tsx
@@ -22,8 +22,26 @@ export const FilterInput: React.FC = function () {
     const dispatch = useAppDispatch();
 
     const filterString = useAppSelector(selectFilterString);
+    const [localFilterString, setLocalFilterString] = React.useState(filterString);
+    const [timeoutId, setTimeoutId] = React.useState<NodeJS.Timeout>();
+
     const invalidTokens = filterString.split(' ').filter((token) => token !== '' && !isValidFilterToken(token));
     const filterIsValid = invalidTokens.length === 0;
+
+    const onChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+        setLocalFilterString(event.target.value);
+
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+            setTimeoutId(undefined);
+        }
+
+        const newTimeoutId = setTimeout(() => {
+            dispatch(setFilterString(event.target.value))
+        }, 1000)
+
+        setTimeoutId(newTimeoutId);
+    };
 
     return (
         <Box zIndex={50}>
@@ -39,8 +57,8 @@ export const FilterInput: React.FC = function () {
                         <Input
                             type="text"
                             placeholder="Filter..."
-                            value={useAppSelector(selectFilterString)}
-                            onChange={(event) => dispatch(setFilterString(event.target.value))}
+                            value={localFilterString}
+                            onChange={onChange}
                             spellCheck={false}
                             minWidth="400px"
                         />

--- a/api-editor/gui/src/features/filter/FilterInput.tsx
+++ b/api-editor/gui/src/features/filter/FilterInput.tsx
@@ -13,7 +13,7 @@ import {
     UnorderedList,
 } from '@chakra-ui/react';
 import { closest, distance } from 'fastest-levenshtein';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { selectFilterString, setFilterString } from '../ui/uiSlice';
 import { getFixedFilterNames, isValidFilterToken } from './model/filterFactory';
@@ -27,6 +27,11 @@ export const FilterInput: React.FC = function () {
 
     const invalidTokens = filterString.split(' ').filter((token) => token !== '' && !isValidFilterToken(token));
     const filterIsValid = invalidTokens.length === 0;
+
+    // The filter can be changed via by other means as well and the local filter needs to reflect this
+    useEffect(() => {
+        setLocalFilterString(filterString);
+    }, [filterString]);
 
     const onChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
         setLocalFilterString(event.target.value);

--- a/api-editor/gui/src/features/filter/FilterInput.tsx
+++ b/api-editor/gui/src/features/filter/FilterInput.tsx
@@ -16,20 +16,22 @@ import { closest, distance } from 'fastest-levenshtein';
 import React from 'react';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { selectFilterString, setFilterString } from '../ui/uiSlice';
-import { getFixedFilterNames, isValidFilterToken } from './model/filterFactory';
+import { getFixedFilterNames } from './model/filterFactory';
 
 interface FilterInputProps {
     localFilterString: string;
     setLocalFilterString: (newLocalFilterString: string) => void;
+    invalidTokens: string[];
 }
 
-export const FilterInput: React.FC<FilterInputProps> = function ({localFilterString, setLocalFilterString}) {
+export const FilterInput: React.FC<FilterInputProps> = function ({
+    localFilterString,
+    setLocalFilterString,
+    invalidTokens,
+}) {
     const dispatch = useAppDispatch();
-
-    const invalidTokens = localFilterString.split(' ').filter((token) => token !== '' && !isValidFilterToken(token));
-    const filterIsValid = invalidTokens.length === 0;
-
     const [timeoutId, setTimeoutId] = React.useState<NodeJS.Timeout>();
+    const filterIsValid = invalidTokens.length === 0;
 
     const onChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
         setLocalFilterString(event.target.value);

--- a/api-editor/gui/src/features/filter/FilterInput.tsx
+++ b/api-editor/gui/src/features/filter/FilterInput.tsx
@@ -38,7 +38,6 @@ export const FilterInput: React.FC<FilterInputProps> = function ({
 
         if (timeoutId) {
             clearTimeout(timeoutId);
-            setTimeoutId(undefined);
         }
 
         const newTimeoutId = setTimeout(() => {

--- a/api-editor/gui/src/features/filter/FilterPersistence.tsx
+++ b/api-editor/gui/src/features/filter/FilterPersistence.tsx
@@ -10,7 +10,7 @@ interface FilterPersistenceProps {
     invalidTokens: string[];
 }
 
-export const FilterPersistence: React.FC<FilterPersistenceProps> = function ({localFilterString, invalidTokens}) {
+export const FilterPersistence: React.FC<FilterPersistenceProps> = function ({ localFilterString, invalidTokens }) {
     const dispatch = useAppDispatch();
 
     const filterIsValid = invalidTokens.length === 0;

--- a/api-editor/gui/src/features/filter/FilterPersistence.tsx
+++ b/api-editor/gui/src/features/filter/FilterPersistence.tsx
@@ -2,32 +2,29 @@ import React from 'react';
 import { Box, Button, Icon, Menu, MenuButton, MenuGroup, MenuItem, MenuList } from '@chakra-ui/react';
 import { FaChevronUp } from 'react-icons/fa';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
-import {
-    removeFilter,
-    selectFilterList,
-    selectFilterString,
-    setFilterString,
-    toggleAddFilterDialog,
-} from '../ui/uiSlice';
+import { removeFilter, selectFilterList, setFilterString, toggleAddFilterDialog } from '../ui/uiSlice';
 import { isValidFilterToken } from './model/filterFactory';
 import { isEmptyList } from '../../common/util/listOperations';
 
-export const FilterPersistence = function () {
+interface FilterPersistenceProps {
+    localFilterString: string;
+}
+
+export const FilterPersistence: React.FC<FilterPersistenceProps> = function ({localFilterString}) {
     const dispatch = useAppDispatch();
 
-    const currentFilterString = useAppSelector(selectFilterString);
     const savedFilters = useAppSelector(selectFilterList);
 
-    const filterIsValid = currentFilterString.split(' ').every((token) => token === '' || isValidFilterToken(token));
+    const filterIsValid = localFilterString.split(' ').every((token) => token === '' || isValidFilterToken(token));
     const alreadyIncluded = savedFilters.some((it) => {
-        return it.filter === currentFilterString;
+        return it.filter === localFilterString;
     });
 
     return (
         <>
             {alreadyIncluded ? (
                 <Button
-                    onClick={() => dispatch(removeFilter(currentFilterString))}
+                    onClick={() => dispatch(removeFilter(localFilterString))}
                     isDisabled={!filterIsValid || !alreadyIncluded}
                 >
                     Remove Filter

--- a/api-editor/gui/src/features/filter/FilterPersistence.tsx
+++ b/api-editor/gui/src/features/filter/FilterPersistence.tsx
@@ -3,19 +3,19 @@ import { Box, Button, Icon, Menu, MenuButton, MenuGroup, MenuItem, MenuList } fr
 import { FaChevronUp } from 'react-icons/fa';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { removeFilter, selectFilterList, setFilterString, toggleAddFilterDialog } from '../ui/uiSlice';
-import { isValidFilterToken } from './model/filterFactory';
 import { isEmptyList } from '../../common/util/listOperations';
 
 interface FilterPersistenceProps {
     localFilterString: string;
+    invalidTokens: string[];
 }
 
-export const FilterPersistence: React.FC<FilterPersistenceProps> = function ({localFilterString}) {
+export const FilterPersistence: React.FC<FilterPersistenceProps> = function ({localFilterString, invalidTokens}) {
     const dispatch = useAppDispatch();
 
-    const savedFilters = useAppSelector(selectFilterList);
+    const filterIsValid = invalidTokens.length === 0;
 
-    const filterIsValid = localFilterString.split(' ').every((token) => token === '' || isValidFilterToken(token));
+    const savedFilters = useAppSelector(selectFilterList);
     const alreadyIncluded = savedFilters.some((it) => {
         return it.filter === localFilterString;
     });


### PR DESCRIPTION
Closes #958.

### Summary of Changes

We no longer update the global filter string after each keystroke in the filter input box. Instead, we only do so if the user stops typing for at least 1s. This drastically improves the responsiveness of the application while using the filter. Filter validation now happens on the local filter string, so the user still gets instant feedback about incorrect tokens.