### PR TITLE
fix(gui): only click once to undo annotation review

### DIFF
--- a/api-editor/gui/src/features/annotations/annotationSlice.ts
+++ b/api-editor/gui/src/features/annotations/annotationSlice.ts
@@ -693,7 +693,7 @@ const withToggledReviewer = function <T extends Annotation>(
     reviewer: string,
     reviewResult: ReviewResult,
 ): T {
-    if (oldAnnotation.reviewers?.includes(reviewer) ?? false) {
+    if ((oldAnnotation.reviewers?.length ?? 0) > 0 || oldAnnotation.reviewResult) {
         return {
             ...oldAnnotation,
             reviewers: [],


### PR DESCRIPTION
Closes #964.

### Summary of Changes

A review from someone else can now be undone by a single click instead of two click.
