### PR TITLE
feat(gui): new filter `is:removed`

### DIFF
--- a/api-editor/gui/src/features/filter/FilterHelpButton.tsx
+++ b/api-editor/gui/src/features/filter/FilterHelpButton.tsx
@@ -139,6 +139,15 @@ export const FilterHelpButton = function () {
                             </ListItem>
                             <ListItem>
                                 <ChakraText>
+                                    <strong>is:removed</strong>
+                                </ChakraText>
+                                <ChakraText>
+                                    Displays only elements that will be removed. These are either annotated with @remove
+                                    directly or have an ancestors with this annotation.
+                                </ChakraText>
+                            </ListItem>
+                            <ListItem>
+                                <ChakraText>
                                     <strong>usages:[operator][expected]</strong>
                                 </ChakraText>
                                 <ChakraText>

--- a/api-editor/gui/src/features/filter/model/RemovedFilter.ts
+++ b/api-editor/gui/src/features/filter/model/RemovedFilter.ts
@@ -1,0 +1,44 @@
+import { PythonClass } from '../../packageData/model/PythonClass';
+import { PythonFunction } from '../../packageData/model/PythonFunction';
+import { PythonModule } from '../../packageData/model/PythonModule';
+import { PythonParameter } from '../../packageData/model/PythonParameter';
+import { PythonDeclaration } from '../../packageData/model/PythonDeclaration';
+import { UsageCountStore } from '../../usages/model/UsageCountStore';
+import { AbstractPythonFilter } from './AbstractPythonFilter';
+import { AnnotationStore, ReviewResult } from '../../annotations/versioning/AnnotationStoreV2';
+
+/**
+ * Keeps only declarations that have the @remove annotation directly or have an ancestor with this annotation.
+ */
+export class RemovedFilter extends AbstractPythonFilter {
+    shouldKeepModule(pythonModule: PythonModule, annotations: AnnotationStore, usages: UsageCountStore): boolean {
+        return this.shouldKeepDeclaration(pythonModule, annotations, usages);
+    }
+
+    shouldKeepClass(pythonClass: PythonClass, annotations: AnnotationStore, usages: UsageCountStore): boolean {
+        return this.shouldKeepDeclaration(pythonClass, annotations, usages);
+    }
+
+    shouldKeepFunction(pythonFunction: PythonFunction, annotations: AnnotationStore, usages: UsageCountStore): boolean {
+        return this.shouldKeepDeclaration(pythonFunction, annotations, usages);
+    }
+
+    shouldKeepParameter(
+        pythonParameter: PythonParameter,
+        annotations: AnnotationStore,
+        usages: UsageCountStore,
+    ): boolean {
+        return this.shouldKeepDeclaration(pythonParameter, annotations, usages);
+    }
+
+    shouldKeepDeclaration(
+        pythonDeclaration: PythonDeclaration,
+        annotations: AnnotationStore,
+        _usages: UsageCountStore,
+    ): boolean {
+        return [...pythonDeclaration.ancestorsOrSelf()].some((ancestor) => {
+            const annotation = annotations.removeAnnotations[ancestor.id];
+            return annotation && !annotation.isRemoved && annotation.reviewResult !== ReviewResult.Wrong;
+        });
+    }
+}

--- a/api-editor/gui/src/features/filter/model/filterFactory.ts
+++ b/api-editor/gui/src/features/filter/model/filterFactory.ts
@@ -16,6 +16,7 @@ import { DoneFilter } from './DoneFilter';
 import { PythonParameterAssignment } from '../../packageData/model/PythonParameter';
 import { QualifiedNameStringFilter } from './QualifiedNameStringFilter';
 import { QualifiedNameRegexFilter } from './QualifiedNameRegexFilter';
+import {RemovedFilter} from "./RemovedFilter";
 
 /**
  * Creates a filter from the given string. This method handles conjunctions, negations, and non-negated tokens.
@@ -92,6 +93,9 @@ const fixedFilters: { [name: string]: AbstractPythonFilter } = {
     'annotation:@rename': new AnnotationFilter(AnnotationType.Rename),
     'annotation:@todo': new AnnotationFilter(AnnotationType.Todo),
     'annotation:@value': new AnnotationFilter(AnnotationType.Value),
+
+    // Removed
+    'is:removed': new RemovedFilter(),
 };
 
 /**

--- a/api-editor/gui/src/features/filter/model/filterFactory.ts
+++ b/api-editor/gui/src/features/filter/model/filterFactory.ts
@@ -16,7 +16,7 @@ import { DoneFilter } from './DoneFilter';
 import { PythonParameterAssignment } from '../../packageData/model/PythonParameter';
 import { QualifiedNameStringFilter } from './QualifiedNameStringFilter';
 import { QualifiedNameRegexFilter } from './QualifiedNameRegexFilter';
-import {RemovedFilter} from "./RemovedFilter";
+import { RemovedFilter } from './RemovedFilter';
 
 /**
  * Creates a filter from the given string. This method handles conjunctions, negations, and non-negated tokens.


### PR DESCRIPTION
Closes #962.

### Summary of Changes

Add a new filter `is:removed`. This only keeps elements that have the annotation `@remove` or that have an ancestor with this annotation. Annotations are only taken into consideration if they are neither removed nor marked as wrong.
