### PR TITLE
feat(gui): only add author when annotation was actually changed

### DIFF
--- a/api-editor/gui/package-lock.json
+++ b/api-editor/gui/package-lock.json
@@ -21,6 +21,7 @@
                 "framer-motion": "^6.3.16",
                 "idb-keyval": "^6.2.0",
                 "katex": "^0.16.0",
+                "lodash": "^4.17.21",
                 "react": "^18.2.0",
                 "react-chartjs-2": "^4.2.0",
                 "react-dom": "^18.2.0",
@@ -8154,8 +8155,7 @@
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
@@ -18045,8 +18045,7 @@
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash.memoize": {
             "version": "4.1.2",

--- a/api-editor/gui/package.json
+++ b/api-editor/gui/package.json
@@ -25,6 +25,7 @@
         "framer-motion": "^6.3.16",
         "idb-keyval": "^6.2.0",
         "katex": "^0.16.0",
+        "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-chartjs-2": "^4.2.0",
         "react-dom": "^18.2.0",

--- a/api-editor/gui/src/features/annotations/annotationSlice.ts
+++ b/api-editor/gui/src/features/annotations/annotationSlice.ts
@@ -745,7 +745,7 @@ const withAuthorAndReviewers = function <T extends Annotation>(
     let authors = oldAnnotation?.authors ?? [];
     const reviewers = oldAnnotation?.reviewers ?? [];
 
-    if (annotationWasChanged(oldAnnotation, newAnnotation)) {
+    if (!oldAnnotation || annotationWasChanged(oldAnnotation, newAnnotation)) {
         authors = [...authors.filter((it) => it !== author), author];
     }
 
@@ -756,15 +756,12 @@ const withAuthorAndReviewers = function <T extends Annotation>(
     };
 };
 
-const annotationWasChanged = function <T extends Annotation>(oldAnnotation: T | void, newAnnotation: T): boolean {
-    // A new annotation was created
-    if (!oldAnnotation) {
-        return true;
-    }
+const annotationWasChanged = function <T extends Annotation>(oldAnnotation: T, newAnnotation: T): boolean {
 
     // Unify the metadata, so we only compare the actual annotation data
     const oldAnnotationWithoutMetadata = annotationWithoutMetadata(oldAnnotation);
     const newAnnotationWithoutMetadata = annotationWithoutMetadata(newAnnotation);
+
     return !isEqual(oldAnnotationWithoutMetadata, newAnnotationWithoutMetadata);
 };
 

--- a/api-editor/gui/src/features/annotations/annotationSlice.ts
+++ b/api-editor/gui/src/features/annotations/annotationSlice.ts
@@ -757,7 +757,6 @@ const withAuthorAndReviewers = function <T extends Annotation>(
 };
 
 const annotationWasChanged = function <T extends Annotation>(oldAnnotation: T, newAnnotation: T): boolean {
-
     // Unify the metadata, so we only compare the actual annotation data
     const oldAnnotationWithoutMetadata = annotationWithoutMetadata(oldAnnotation);
     const newAnnotationWithoutMetadata = annotationWithoutMetadata(newAnnotation);

--- a/api-editor/gui/src/features/annotations/annotationSlice.ts
+++ b/api-editor/gui/src/features/annotations/annotationSlice.ts
@@ -168,7 +168,11 @@ const annotationsSlice = createSlice({
             updateQueue(state);
         },
         upsertBoundaryAnnotation(state, action: PayloadAction<BoundaryAnnotation>) {
-            updateCreationOrChangedCount(state, state.annotations.boundaryAnnotations[action.payload.target]);
+            updateCreationOrChangedCount(
+                state,
+                state.annotations.boundaryAnnotations[action.payload.target],
+                action.payload,
+            );
 
             state.annotations.boundaryAnnotations[action.payload.target] = withAuthorAndReviewers(
                 state.annotations.boundaryAnnotations[action.payload.target],
@@ -205,7 +209,7 @@ const annotationsSlice = createSlice({
                 state.annotations.calledAfterAnnotations[action.payload.annotation.target] = {};
             }
 
-            updateCreationOrChangedCount(state, oldAnnotation);
+            updateCreationOrChangedCount(state, oldAnnotation, action.payload.annotation);
 
             state.annotations.calledAfterAnnotations[action.payload.annotation.target][
                 action.payload.annotation.calledAfterName
@@ -283,7 +287,11 @@ const annotationsSlice = createSlice({
         },
         // Cannot review complete annotations
         upsertDescriptionAnnotation(state, action: PayloadAction<DescriptionAnnotation>) {
-            updateCreationOrChangedCount(state, state.annotations.descriptionAnnotations[action.payload.target]);
+            updateCreationOrChangedCount(
+                state,
+                state.annotations.descriptionAnnotations[action.payload.target],
+                action.payload,
+            );
 
             state.annotations.descriptionAnnotations[action.payload.target] = withAuthorAndReviewers(
                 state.annotations.descriptionAnnotations[action.payload.target],
@@ -308,7 +316,11 @@ const annotationsSlice = createSlice({
             updateQueue(state);
         },
         upsertEnumAnnotation(state, action: PayloadAction<EnumAnnotation>) {
-            updateCreationOrChangedCount(state, state.annotations.enumAnnotations[action.payload.target]);
+            updateCreationOrChangedCount(
+                state,
+                state.annotations.enumAnnotations[action.payload.target],
+                action.payload,
+            );
 
             state.annotations.enumAnnotations[action.payload.target] = withAuthorAndReviewers(
                 state.annotations.enumAnnotations[action.payload.target],
@@ -380,7 +392,7 @@ const annotationsSlice = createSlice({
                 }
             }
 
-            updateCreationOrChangedCount(state, oldAnnotation);
+            updateCreationOrChangedCount(state, oldAnnotation, action.payload.annotation);
 
             state.annotations.groupAnnotations[action.payload.annotation.target][action.payload.annotation.groupName] =
                 withAuthorAndReviewers(oldAnnotation, action.payload.annotation, state.username);
@@ -420,7 +432,11 @@ const annotationsSlice = createSlice({
             updateQueue(state);
         },
         upsertMoveAnnotation(state, action: PayloadAction<MoveAnnotation>) {
-            updateCreationOrChangedCount(state, state.annotations.moveAnnotations[action.payload.target]);
+            updateCreationOrChangedCount(
+                state,
+                state.annotations.moveAnnotations[action.payload.target],
+                action.payload,
+            );
 
             state.annotations.moveAnnotations[action.payload.target] = withAuthorAndReviewers(
                 state.annotations.moveAnnotations[action.payload.target],
@@ -432,7 +448,7 @@ const annotationsSlice = createSlice({
         },
         upsertMoveAnnotations(state, action: PayloadAction<MoveAnnotation[]>) {
             action.payload.forEach((annotation) => {
-                updateCreationOrChangedCount(state, state.annotations.moveAnnotations[annotation.target]);
+                updateCreationOrChangedCount(state, state.annotations.moveAnnotations[annotation.target], annotation);
 
                 state.annotations.moveAnnotations[annotation.target] = withAuthorAndReviewers(
                     state.annotations.moveAnnotations[annotation.target],
@@ -458,7 +474,11 @@ const annotationsSlice = createSlice({
             updateQueue(state);
         },
         upsertPureAnnotation(state, action: PayloadAction<PureAnnotation>) {
-            updateCreationOrChangedCount(state, state.annotations.pureAnnotations[action.payload.target]);
+            updateCreationOrChangedCount(
+                state,
+                state.annotations.pureAnnotations[action.payload.target],
+                action.payload,
+            );
 
             state.annotations.pureAnnotations[action.payload.target] = withAuthorAndReviewers(
                 state.annotations.pureAnnotations[action.payload.target],
@@ -483,7 +503,11 @@ const annotationsSlice = createSlice({
             updateQueue(state);
         },
         upsertRemoveAnnotation(state, action: PayloadAction<RemoveAnnotation>) {
-            updateCreationOrChangedCount(state, state.annotations.removeAnnotations[action.payload.target]);
+            updateCreationOrChangedCount(
+                state,
+                state.annotations.removeAnnotations[action.payload.target],
+                action.payload,
+            );
 
             state.annotations.removeAnnotations[action.payload.target] = withAuthorAndReviewers(
                 state.annotations.removeAnnotations[action.payload.target],
@@ -495,7 +519,7 @@ const annotationsSlice = createSlice({
         },
         upsertRemoveAnnotations(state, action: PayloadAction<RemoveAnnotation[]>) {
             action.payload.forEach((annotation) => {
-                updateCreationOrChangedCount(state, state.annotations.removeAnnotations[annotation.target]);
+                updateCreationOrChangedCount(state, state.annotations.removeAnnotations[annotation.target], annotation);
 
                 state.annotations.removeAnnotations[annotation.target] = withAuthorAndReviewers(
                     state.annotations.removeAnnotations[annotation.target],
@@ -521,7 +545,11 @@ const annotationsSlice = createSlice({
             updateQueue(state);
         },
         upsertRenameAnnotation(state, action: PayloadAction<RenameAnnotation>) {
-            updateCreationOrChangedCount(state, state.annotations.renameAnnotations[action.payload.target]);
+            updateCreationOrChangedCount(
+                state,
+                state.annotations.renameAnnotations[action.payload.target],
+                action.payload,
+            );
 
             state.annotations.renameAnnotations[action.payload.target] = withAuthorAndReviewers(
                 state.annotations.renameAnnotations[action.payload.target],
@@ -533,7 +561,7 @@ const annotationsSlice = createSlice({
         },
         upsertRenameAnnotations(state, action: PayloadAction<RenameAnnotation[]>) {
             action.payload.forEach((annotation) => {
-                updateCreationOrChangedCount(state, state.annotations.renameAnnotations[annotation.target]);
+                updateCreationOrChangedCount(state, state.annotations.renameAnnotations[annotation.target], annotation);
 
                 state.annotations.renameAnnotations[annotation.target] = withAuthorAndReviewers(
                     state.annotations.renameAnnotations[annotation.target],
@@ -559,7 +587,11 @@ const annotationsSlice = createSlice({
             updateQueue(state);
         },
         upsertTodoAnnotation(state, action: PayloadAction<TodoAnnotation>) {
-            updateCreationOrChangedCount(state, state.annotations.todoAnnotations[action.payload.target]);
+            updateCreationOrChangedCount(
+                state,
+                state.annotations.todoAnnotations[action.payload.target],
+                action.payload,
+            );
 
             state.annotations.todoAnnotations[action.payload.target] = withAuthorAndReviewers(
                 state.annotations.todoAnnotations[action.payload.target],
@@ -584,7 +616,11 @@ const annotationsSlice = createSlice({
             updateQueue(state);
         },
         upsertValueAnnotation(state, action: PayloadAction<ValueAnnotation>) {
-            updateCreationOrChangedCount(state, state.annotations.valueAnnotations[action.payload.target]);
+            updateCreationOrChangedCount(
+                state,
+                state.annotations.valueAnnotations[action.payload.target],
+                action.payload,
+            );
 
             if (action.payload.variant === 'required' || action.payload.variant === 'omitted') {
                 // @ts-ignore
@@ -608,7 +644,7 @@ const annotationsSlice = createSlice({
         },
         upsertValueAnnotations(state, action: PayloadAction<ValueAnnotation[]>) {
             action.payload.forEach((annotation) => {
-                updateCreationOrChangedCount(state, state.annotations.valueAnnotations[annotation.target]);
+                updateCreationOrChangedCount(state, state.annotations.valueAnnotations[annotation.target], annotation);
 
                 if (annotation.variant === 'required' || annotation.variant === 'omitted') {
                     // @ts-ignore
@@ -687,9 +723,15 @@ const updateQueue = function (state: AnnotationSlice) {
     state.queueIndex = state.queueIndex + 1;
 };
 
-const updateCreationOrChangedCount = function (state: AnnotationSlice, annotationOrNull: Annotation | null) {
-    if (annotationOrNull) {
-        state.numberOfAnnotationsChanged++;
+const updateCreationOrChangedCount = function (
+    state: AnnotationSlice,
+    oldAnnotation: Annotation | null,
+    newAnnotation: Annotation,
+) {
+    if (oldAnnotation) {
+        if (annotationWasChanged(oldAnnotation, newAnnotation)) {
+            state.numberOfAnnotationsChanged++;
+        }
     } else {
         state.numberOfAnnotationsCreated++;
     }
@@ -703,7 +745,7 @@ const withAuthorAndReviewers = function <T extends Annotation>(
     let authors = oldAnnotation?.authors ?? [];
     const reviewers = oldAnnotation?.reviewers ?? [];
 
-    if (shouldUpdateAuthor(oldAnnotation, newAnnotation)) {
+    if (annotationWasChanged(oldAnnotation, newAnnotation)) {
         authors = [...authors.filter((it) => it !== author), author];
     }
 
@@ -714,7 +756,7 @@ const withAuthorAndReviewers = function <T extends Annotation>(
     };
 };
 
-const shouldUpdateAuthor = function <T extends Annotation>(oldAnnotation: T | void, newAnnotation: T): boolean {
+const annotationWasChanged = function <T extends Annotation>(oldAnnotation: T | void, newAnnotation: T): boolean {
     // A new annotation was created
     if (!oldAnnotation) {
         return true;


### PR DESCRIPTION
Closes #967.

### Summary of Changes

When a user clicks on "Save" in an annotation form he is now only added as an author when the annotation was actually changed. Changing the comment is not enough. This is relevant for the quality view to detect annotations that were changed.
