### PR TITLE
feat(gui): toggle tree nodes by double-clicking

### DIFF
--- a/api-editor/gui/src/features/packageData/treeView/TreeNode.tsx
+++ b/api-editor/gui/src/features/packageData/treeView/TreeNode.tsx
@@ -69,11 +69,20 @@ export const TreeNode: React.FC<TreeNodeProps> = function ({
         }
     };
 
+    const [timeoutId, setTimeoutId] = React.useState<NodeJS.Timeout>();
     const handleNodeClick = (event: MouseEvent) => {
-        if (event.shiftKey) {
+        if (event.detail === 1) {
+            // Handle single click
+            const newTimeoutId = setTimeout(() => {
+                navigate(`/${declaration.id}`);
+            }, 200);
+            setTimeoutId(newTimeoutId);
+        } else if (event.detail === 2) {
+            // Handle double click
+            if (timeoutId) {
+                clearTimeout(timeoutId);
+            }
             toggleExpanded();
-        } else {
-            navigate(`/${declaration.id}`);
         }
     };
 


### PR DESCRIPTION
Closes #984.

### Summary of Changes

Tree nodes can now be toggled by double clicking instead of using `Shift+Click`. While this is more intuitive, it also introduces a slight delay before an item is selected, since we need to make sure the user does not double click the node. We'll see how this works out and potentially revert this change.