### PR TITLE
fix(gui): tooltips for disabled buttons in annotation view

### DIFF
--- a/api-editor/gui/src/features/annotations/AnnotationView.tsx
+++ b/api-editor/gui/src/features/annotations/AnnotationView.tsx
@@ -390,22 +390,32 @@ const AnnotationTag: React.FC<AnnotationTagProps> = function ({
     return (
         <>
             <ButtonGroup size="sm" variant="outline" isAttached>
-                <Tooltip label={`${authorText}Click to delete.`}>
+                <Tooltip
+                    label={!isValidUsername || isReviewed ? authorText : `${authorText}Click to delete.`}
+                    shouldWrapChildren
+                    mt="3"
+                >
                     <IconButton
                         icon={<FaTrash />}
                         aria-label="Delete annotation"
                         colorScheme="red"
+                        borderRadius="var(--chakra-radii-md) 0 0 var(--chakra-radii-md)"
                         disabled={!isValidUsername || isReviewed}
                         onClick={onDelete}
                     />
                 </Tooltip>
-                <Tooltip label={`${authorText}Click to change.`}>
+                <Tooltip
+                    label={!onEdit || !isValidUsername || isReviewed ? authorText : `${authorText}Click to change.`}
+                    shouldWrapChildren
+                    mt="3"
+                >
                     <Button
                         leftIcon={<FaWrench />}
                         rightIcon={rightIcon}
                         flexGrow={1}
                         borderLeft="none"
                         justifyContent="flex-start"
+                        borderRadius="0 var(--chakra-radii-md) var(--chakra-radii-md) 0"
                         disabled={!onEdit || !isValidUsername || isReviewed}
                         onClick={onEdit}
                     >
@@ -420,7 +430,11 @@ const AnnotationTag: React.FC<AnnotationTagProps> = function ({
             </ButtonGroup>
             <ButtonGroup size="sm" variant="outline" isAttached>
                 {(reviewResult === ReviewResult.Correct || (isReviewed && !reviewResult)) && (
-                    <Tooltip label={`Marked as correct by ${reviewer}. Click to undo.`}>
+                    <Tooltip
+                        label={`Marked as correct by ${reviewer}.${!isValidUsername ? '' : ' Click to undo.'}`}
+                        shouldWrapChildren
+                        mt="3"
+                    >
                         <Button
                             size="sm"
                             variant="solid"
@@ -434,7 +448,11 @@ const AnnotationTag: React.FC<AnnotationTagProps> = function ({
                     </Tooltip>
                 )}
                 {reviewResult === ReviewResult.Unsure && (
-                    <Tooltip label={`Marked as unsure by ${reviewer}. Click to undo.`}>
+                    <Tooltip
+                        label={`Marked as unsure by ${reviewer}.${!isValidUsername ? '' : ' Click to undo.'}`}
+                        shouldWrapChildren
+                        mt="3"
+                    >
                         <Button
                             size="sm"
                             variant="solid"
@@ -448,7 +466,11 @@ const AnnotationTag: React.FC<AnnotationTagProps> = function ({
                     </Tooltip>
                 )}
                 {reviewResult === ReviewResult.Wrong && (
-                    <Tooltip label={`Marked as wrong by ${reviewer}. Click to undo.`}>
+                    <Tooltip
+                        label={`Marked as wrong by ${reviewer}.${!isValidUsername ? '' : ' Click to undo.'}`}
+                        shouldWrapChildren
+                        mt="3"
+                    >
                         <Button
                             size="sm"
                             variant="solid"
@@ -463,18 +485,50 @@ const AnnotationTag: React.FC<AnnotationTagProps> = function ({
                 )}
                 {!isReviewed && (
                     <>
-                        <Tooltip label={`${authorText}Click to mark as correct.`}>
-                            <Button size="sm" variant="outline" disabled={!isValidUsername} onClick={onMarkAsCorrect}>
+                        <Tooltip
+                            label={`${authorText}${!isValidUsername ? '' : ' Click to mark as correct.'}`}
+                            shouldWrapChildren
+                            mt="3"
+                        >
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                borderRadius="var(--chakra-radii-md) 0 0 var(--chakra-radii-md)"
+                                disabled={!isValidUsername}
+                                onClick={onMarkAsCorrect}
+                            >
                                 Mark as Correct
                             </Button>
                         </Tooltip>
-                        <Tooltip label={`${authorText}Click to mark as unsure.`}>
-                            <Button size="sm" variant="outline" disabled={!isValidUsername} onClick={onMarkAsUnsure}>
+                        <Tooltip
+                            label={`${authorText}${!isValidUsername ? '' : ' Click to mark as unsure.'}`}
+                            shouldWrapChildren
+                            mt="3"
+                        >
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                borderRadius="0"
+                                borderLeft="none"
+                                borderRight="none"
+                                disabled={!isValidUsername}
+                                onClick={onMarkAsUnsure}
+                            >
                                 Mark as Unsure
                             </Button>
                         </Tooltip>
-                        <Tooltip label={`${authorText}Click to mark as wrong.`}>
-                            <Button size="sm" variant="outline" disabled={!isValidUsername} onClick={onMarkAsWrong}>
+                        <Tooltip
+                            label={`${authorText}${!isValidUsername ? '' : ' Click to mark as wrong.'}`}
+                            shouldWrapChildren
+                            mt="3"
+                        >
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                borderRadius="0 var(--chakra-radii-md) var(--chakra-radii-md) 0"
+                                disabled={!isValidUsername}
+                                onClick={onMarkAsWrong}
+                            >
                                 Mark as Wrong
                             </Button>
                         </Tooltip>

--- a/api-editor/gui/src/features/annotations/CompleteButton.tsx
+++ b/api-editor/gui/src/features/annotations/CompleteButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon } from '@chakra-ui/react';
+import { Button, Icon, Tooltip } from '@chakra-ui/react';
 import React from 'react';
 import { FaCheck } from 'react-icons/fa';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
@@ -10,22 +10,41 @@ interface CompleteButtonProps {
 
 export const CompleteButton: React.FC<CompleteButtonProps> = function ({ target }) {
     const dispatch = useAppDispatch();
-    const isComplete = useAppSelector(selectComplete(target));
+    const completeAnnotation = useAppSelector(selectComplete(target));
     const isDisabled = !useAppSelector(selectUsernameIsValid);
 
-    if (isComplete) {
-        return (
-            <Button
-                size="sm"
-                variant="solid"
-                colorScheme="green"
-                rightIcon={<Icon as={FaCheck} />}
-                disabled={isDisabled}
-                onClick={() => dispatch(removeComplete(target))}
-            >
-                Complete
-            </Button>
-        );
+    const completeButton = (
+        <Button
+            size="sm"
+            variant="solid"
+            colorScheme="green"
+            rightIcon={<Icon as={FaCheck} />}
+            disabled={isDisabled}
+            onClick={() => dispatch(removeComplete(target))}
+        >
+            Complete
+        </Button>
+    );
+
+    let completeButtonTooltipLabel = '';
+    if ((completeAnnotation?.authors?.length ?? 0) > 0) {
+        completeButtonTooltipLabel += `Marked as complete by ${completeAnnotation!.authors![0]}.`;
+    }
+    if (!isDisabled) {
+        completeButtonTooltipLabel += ` Click to undo.`;
+    }
+
+    if (completeAnnotation) {
+        if (completeButtonTooltipLabel) {
+            return (
+                <Tooltip label={completeButtonTooltipLabel} shouldWrapChildren mt="3">
+                    {completeButton}
+                </Tooltip>
+            );
+        } else {
+            // eslint-disable-next-line react/jsx-no-useless-fragment
+            return <>{completeButton}</>;
+        }
     } else {
         return (
             <Button size="sm" variant="outline" disabled={isDisabled} onClick={() => dispatch(addComplete({ target }))}>


### PR DESCRIPTION
Closes #988.

### Summary of Changes

Tooltips are now also shown on the following buttons when they are disabled:
* Complete
* Remove annotation
* Edit annotation
* Mark as Correct
* Mark as Unsure
* Mark as Wrong
* Correct
* Unsure
* Wrong

### Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/2501322/178685879-570c30dd-4970-4953-8ed5-d751621ab09e.png)
