### PR TITLE
fix(backend): rename modules after annotations are processed

### DIFF
--- a/api-editor/backend/src/main/kotlin/com/larsreimann/apiEditor/transformation/TransformationPlan.kt
+++ b/api-editor/backend/src/main/kotlin/com/larsreimann/apiEditor/transformation/TransformationPlan.kt
@@ -6,18 +6,17 @@ import com.larsreimann.apiEditor.mutableModel.PythonPackage
  * Processes all annotations and updates the AST to create adapters.
  */
 fun PythonPackage.transform(newPackageName: String = "new_package") {
-    preprocess(newPackageName)
+    preprocess()
     processAnnotations()
-    postprocess()
+    postprocess(newPackageName)
 }
 
 /**
  * Transformation steps that have to be run before annotations can be processed.
  */
-private fun PythonPackage.preprocess(newPackageName: String) {
+private fun PythonPackage.preprocess() {
     removePrivateDeclarations()
     addOriginalDeclarations()
-    changeModulePrefix(newPackageName)
     replaceClassMethodsWithStaticMethods()
     updateParameterAssignment()
     normalizeNamesOfImplicitParameters()
@@ -43,8 +42,9 @@ private fun PythonPackage.processAnnotations() {
 /**
  * Transformation steps that have to be run after annotations were processed.
  */
-private fun PythonPackage.postprocess() {
+private fun PythonPackage.postprocess(newPackageName: String) {
     removeEmptyModules()
+    changeModulePrefix(newPackageName)
     reorderParameters()
     extractConstructors()
     createAttributesForParametersOfConstructor()


### PR DESCRIPTION
### Summary of Changes

Rename modules after annotations are processed rather than before. This is necessary, so `@Move` annotations, which can add new modules, have the desired effect.