### PR TITLE
feat: Create command line interface for a migrate command

### DIFF
--- a/package-parser/README.md
+++ b/package-parser/README.md
@@ -32,5 +32,5 @@ A tool to analyze client and API code written in Python.
     ```
 4. Migrate annotations for a new version of the API:
     ```shell
-    parse-package migrate parse-package migrate -a1 data/api/sklearn__api.json -a2 data/api/sklearn__apiv2.json -a data/annotations/annotations.json -o out
+    parse-package migrate -a1 data/api/sklearn__api.json -a2 data/api/sklearn__apiv2.json -a data/annotations/annotations.json -o out
     ```

--- a/package-parser/README.md
+++ b/package-parser/README.md
@@ -27,10 +27,10 @@ A tool to analyze client and API code written in Python.
     parse-package usages -p sklearn -s "Kaggle Kernels" -o out
     ```
 3. Generate annotations for the API:
-   ```shell
-   parse-package annotations -a data/api/sklearn__api.json -u data/usages/sklearn__usage_counts.json -o out/annotations.json
-   ```
+    ```shell
+    parse-package annotations -a data/api/sklearn__api.json -u data/usages/sklearn__usage_counts.json -o out/annotations.json
+    ```
 4. Migrate annotations for a new version of the API:
-   ```shell
-   parse-package migrate parse-package migrate -a1 data/api/sklearn__api.json -a2 data/api/sklearn__apiv2.json -a data/annotations/annotations.json -o out
-   ```
+    ```shell
+    parse-package migrate parse-package migrate -a1 data/api/sklearn__api.json -a2 data/api/sklearn__apiv2.json -a data/annotations/annotations.json -o out
+    ```

--- a/package-parser/README.md
+++ b/package-parser/README.md
@@ -30,3 +30,7 @@ A tool to analyze client and API code written in Python.
    ```shell
    parse-package annotations -a data/api/sklearn__api.json -u data/usages/sklearn__usage_counts.json -o out/annotations.json
    ```
+4. Migrate annotations for a new version of the API:
+   ```shell
+   parse-package migrate parse-package migrate -a1 data/api/sklearn__api.json -a2 data/api/sklearn__apiv2.json -a data/annotations/annotations.json -o out
+   ```

--- a/package-parser/package_parser/cli/_cli.py
+++ b/package-parser/package_parser/cli/_cli.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from package_parser.cli._run_all import _run_all_command
 from package_parser.cli._run_annotations import _run_annotations
 from package_parser.cli._run_api import _run_api_command
-from package_parser.cli._run_usages import _run_usages_command
 from package_parser.cli._run_migrate import _run_migrate_command
+from package_parser.cli._run_usages import _run_usages_command
 
 _API_COMMAND = "api"
 _USAGES_COMMAND = "usages"
@@ -41,12 +41,7 @@ def cli() -> None:
             args.batchsize,
         )
     elif args.command == _MIGRATE_COMMAND:
-        _run_migrate_command(
-            args.apiv1,
-            args.annotations,
-            args.apiv2,
-            args.out
-        )
+        _run_migrate_command(args.apiv1, args.annotations, args.apiv2, args.out)
 
 
 def _get_args() -> argparse.Namespace:
@@ -198,7 +193,8 @@ def _add_all_subparser(subparsers: _SubParsersAction) -> None:
 
 def _add_migrate_subparser(subparsers) -> None:
     generate_parser = subparsers.add_parser(
-        _MIGRATE_COMMAND, help="Migrate Annotations for the new version based on the previous version."
+        _MIGRATE_COMMAND,
+        help="Migrate Annotations for the new version based on the previous version.",
     )
     generate_parser.add_argument(
         "-a1",
@@ -222,9 +218,5 @@ def _add_migrate_subparser(subparsers) -> None:
         required=True,
     )
     generate_parser.add_argument(
-        "-o",
-        "--out",
-        help="Output directory.",
-        type=Path,
-        required=True
+        "-o", "--out", help="Output directory.", type=Path, required=True
     )

--- a/package-parser/package_parser/cli/_cli.py
+++ b/package-parser/package_parser/cli/_cli.py
@@ -9,11 +9,13 @@ from package_parser.cli._run_all import _run_all_command
 from package_parser.cli._run_annotations import _run_annotations
 from package_parser.cli._run_api import _run_api_command
 from package_parser.cli._run_usages import _run_usages_command
+from package_parser.cli._run_migrate import _run_migrate_command
 
 _API_COMMAND = "api"
 _USAGES_COMMAND = "usages"
 _ANNOTATIONS_COMMAND = "annotations"
 _ALL_COMMAND = "all"
+_MIGRATE_COMMAND = "migrate"
 
 
 def cli() -> None:
@@ -38,6 +40,13 @@ def cli() -> None:
             args.processes,
             args.batchsize,
         )
+    elif args.command == _MIGRATE_COMMAND:
+        _run_migrate_command(
+            args.apiv1,
+            args.annotations,
+            args.apiv2,
+            args.out
+        )
 
 
 def _get_args() -> argparse.Namespace:
@@ -52,6 +61,7 @@ def _get_args() -> argparse.Namespace:
     _add_usages_subparser(subparsers)
     _add_annotations_subparser(subparsers)
     _add_all_subparser(subparsers)
+    _add_migrate_subparser(subparsers)
 
     return parser.parse_args()
 
@@ -183,4 +193,38 @@ def _add_all_subparser(subparsers: _SubParsersAction) -> None:
         type=int,
         required=False,
         default=100,
+    )
+
+
+def _add_migrate_subparser(subparsers) -> None:
+    generate_parser = subparsers.add_parser(
+        _MIGRATE_COMMAND, help="Migrate Annotations for the new version based on the previous version."
+    )
+    generate_parser.add_argument(
+        "-a1",
+        "--apiv1",
+        help="File created with the 'api' command from the previous version.",
+        type=Path,
+        required=True,
+    )
+    generate_parser.add_argument(
+        "-a2",
+        "--apiv2",
+        help="File created by the 'api' command from the new version.",
+        type=Path,
+        required=True,
+    )
+    generate_parser.add_argument(
+        "-a",
+        "--annotations",
+        help="File that includes all annotations of the previous version.",
+        type=Path,
+        required=True,
+    )
+    generate_parser.add_argument(
+        "-o",
+        "--out",
+        help="Output directory.",
+        type=Path,
+        required=True
     )

--- a/package-parser/package_parser/cli/_run_migrate.py
+++ b/package-parser/package_parser/cli/_run_migrate.py
@@ -7,8 +7,7 @@ from package_parser.processing.api.model import API
 def _run_migrate_command(
     apiv1_file_path: Path, annotations_file_path: Path, apiv2_file_path: Path, out_dir_path: Path
 ) -> None:
-    apiv1 = _read_api_file(apiv1_file_path)
-    apiv2 = _read_api_file(apiv2_file_path)
+    pass
 
 
 def _read_api_file(api_file_path: Path) -> API:

--- a/package-parser/package_parser/cli/_run_migrate.py
+++ b/package-parser/package_parser/cli/_run_migrate.py
@@ -5,7 +5,10 @@ from package_parser.processing.api.model import API
 
 
 def _run_migrate_command(
-    apiv1_file_path: Path, annotations_file_path: Path, apiv2_file_path: Path, out_dir_path: Path
+    apiv1_file_path: Path,
+    annotations_file_path: Path,
+    apiv2_file_path: Path,
+    out_dir_path: Path,
 ) -> None:
     pass
 

--- a/package-parser/package_parser/cli/_run_migrate.py
+++ b/package-parser/package_parser/cli/_run_migrate.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+from package_parser.processing.api.model import API
+
+
+def _run_migrate_command(
+    apiv1_file_path: Path, annotations_file_path: Path, apiv2_file_path: Path, out_dir_path: Path
+) -> None:
+    apiv1 = _read_api_file(apiv1_file_path)
+    apiv2 = _read_api_file(apiv2_file_path)
+
+
+def _read_api_file(api_file_path: Path) -> API:
+    with open(api_file_path) as api_file:
+        api_json = json.load(api_file)
+
+    return API.from_json(api_json)


### PR DESCRIPTION
Closes #1108.

### Summary of Changes

Created a migrate cli command, that takes two api files, an annotation file, and an output path as input

### Testing Instructions

Run Terminal with `parse-package migrate -a1 apiv1.json -a2 apiv2.json -a annotations.json -o out`
