### PR TITLE
`api` command should list attributes of classes

### DIFF
--- a/package-parser/package_parser/processing/api/_ast_visitor.py
+++ b/package-parser/package_parser/processing/api/_ast_visitor.py
@@ -133,6 +133,7 @@ class _AstVisitor:
 
     def enter_classdef(self, class_node: astroid.ClassDef) -> None:
         qname = class_node.qname()
+        instance_attributes = list(class_node.instance_attrs)
 
         decorators: Optional[astroid.Decorators] = class_node.decorators
         if decorators is not None:
@@ -149,6 +150,7 @@ class _AstVisitor:
             is_public=self.is_public(class_node.name, qname),
             reexported_by=self.reexported.get(qname, []),
             documentation=self.documentation_parser.get_class_documentation(class_node),
+            instance_attributes=instance_attributes,
         )
         self.__declaration_stack.append(class_)
 

--- a/package-parser/package_parser/processing/api/model/_api.py
+++ b/package-parser/package_parser/processing/api/model/_api.py
@@ -206,6 +206,7 @@ class Class:
                 description=json.get("description", ""),
                 full_docstring=json.get("docstring", ""),
             ),
+            json.get("instance_attributes", []),
         )
 
         for method_id in json["methods"]:
@@ -222,6 +223,7 @@ class Class:
         is_public: bool,
         reexported_by: list[str],
         documentation: ClassDocumentation,
+        instance_attributes: list[str],
     ) -> None:
         self.id: str = id_
         self.qname: str = qname
@@ -231,6 +233,7 @@ class Class:
         self.is_public: bool = is_public
         self.reexported_by: list[str] = reexported_by
         self.documentation: ClassDocumentation = documentation
+        self.instance_attributes = instance_attributes
 
     @property
     def name(self) -> str:
@@ -251,6 +254,7 @@ class Class:
             "reexported_by": self.reexported_by,
             "description": self.documentation.description,
             "docstring": self.documentation.full_docstring,
+            "instance_attributes": self.instance_attributes,
         }
 
 


### PR DESCRIPTION
Closes #1107.

### Summary of Changes

added an attribute ´instance_attribute´ to the class 'class'.

### Testing Instructions

run `package-parser api -p sklearn -o ./out` and compare the output with the original file that the class contains.
`package-parser annotations -a ../data/api/sklearn__api.json -u ../data/usages/sklearn_usages_counts.json -o ./out/annotations.json` can verify that no error occur if the file is loaded.