### PR TITLE
feat: add `@remove` migration

### DIFF
--- a/package-parser/package_parser/processing/migration/_migrate.py
+++ b/package-parser/package_parser/processing/migration/_migrate.py
@@ -15,6 +15,7 @@ from package_parser.processing.migration.annotations import (
 from package_parser.processing.migration.annotations._migrate_move_annotation import (
     migrate_move_annotation,
 )
+from package_parser.processing.migration.annotations._migrate_remove_annotation import migrate_remove_annotation
 from package_parser.processing.migration.model import Mapping
 
 
@@ -58,6 +59,12 @@ def migrate_annotations(
         mapping = _get_mapping_from_annotation(rename_annotation, mappings)
         if mapping is not None:
             for annotation in migrate_rename_annotation(rename_annotation, mapping):
+                migrated_annotation_store.add_annotation(annotation)
+
+    for remove_annotation in annotationsv1.removeAnnotations:
+        mapping = _get_mapping_from_annotation(remove_annotation, mappings)
+        if mapping is not None:
+            for annotation in migrate_remove_annotation(remove_annotation, mapping):
                 migrated_annotation_store.add_annotation(annotation)
 
     for todo_annotation in annotationsv1.todoAnnotations:

--- a/package-parser/package_parser/processing/migration/_migrate.py
+++ b/package-parser/package_parser/processing/migration/_migrate.py
@@ -15,7 +15,9 @@ from package_parser.processing.migration.annotations import (
 from package_parser.processing.migration.annotations._migrate_move_annotation import (
     migrate_move_annotation,
 )
-from package_parser.processing.migration.annotations._migrate_remove_annotation import migrate_remove_annotation
+from package_parser.processing.migration.annotations._migrate_remove_annotation import (
+    migrate_remove_annotation,
+)
 from package_parser.processing.migration.model import Mapping
 
 

--- a/package-parser/package_parser/processing/migration/annotations/_get_annotated_api_element.py
+++ b/package-parser/package_parser/processing/migration/annotations/_get_annotated_api_element.py
@@ -9,10 +9,7 @@ from package_parser.processing.api.model import (
     Result,
 )
 
-ANNOTATABLE_API_ELEMENTS = TypeVar(
-    "ANNOTATABLE_API_ELEMENTS", Class, Function, Parameter
-)
-API_ELEMENTS = TypeVar("API_ELEMENTS", Attribute, Class, Function, Parameter, Result)
+API_ELEMENTS = TypeVar("API_ELEMENTS", Class, Function, Parameter)
 
 
 def get_annotated_api_element(
@@ -31,8 +28,8 @@ def get_annotated_api_element(
 def get_annotated_api_element_by_type(
     annotation: AbstractAnnotation,
     api_element_list: List[Union[Attribute, Class, Function, Parameter, Result]],
-    api_type: type[ANNOTATABLE_API_ELEMENTS],
-) -> Optional[ANNOTATABLE_API_ELEMENTS]:
+    api_type: type[API_ELEMENTS]
+) -> Optional[API_ELEMENTS]:
     for element in api_element_list:
         if isinstance(element, api_type) and element.id == annotation.target:
             return element

--- a/package-parser/package_parser/processing/migration/annotations/_get_annotated_api_element.py
+++ b/package-parser/package_parser/processing/migration/annotations/_get_annotated_api_element.py
@@ -28,7 +28,7 @@ def get_annotated_api_element(
 def get_annotated_api_element_by_type(
     annotation: AbstractAnnotation,
     api_element_list: List[Union[Attribute, Class, Function, Parameter, Result]],
-    api_type: type[API_ELEMENTS]
+    api_type: type[API_ELEMENTS],
 ) -> Optional[API_ELEMENTS]:
     for element in api_element_list:
         if isinstance(element, api_type) and element.id == annotation.target:

--- a/package-parser/package_parser/processing/migration/annotations/_get_annotated_api_element.py
+++ b/package-parser/package_parser/processing/migration/annotations/_get_annotated_api_element.py
@@ -1,0 +1,33 @@
+from typing import List, TypeVar, Optional, Union
+
+from package_parser.processing.annotations.model import AbstractAnnotation
+from package_parser.processing.api.model import Attribute, Result, Class, Function, Parameter
+
+ANNOTATABLE_API_ELEMENTS = TypeVar("ANNOTATABLE_API_ELEMENTS", Class, Function, Parameter)
+API_ELEMENTS = TypeVar("API_ELEMENTS", Attribute, Class, Function, Parameter, Result)
+
+
+def get_annotated_api_element(
+    annotation: AbstractAnnotation, api_element_list: List[Union[Attribute, Class, Function, Parameter, Result]]
+) -> Optional[Union[Class, Function, Parameter]]:
+    for element in api_element_list:
+        if (
+            isinstance(element, (Class, Function, Parameter))
+            and element.id == annotation.target
+        ):
+            return element
+    return None
+
+
+def get_annotated_api_element_by_type(
+    annotation: AbstractAnnotation,
+    api_element_list: List[Union[Attribute, Class, Function, Parameter, Result]],
+    api_type: type[ANNOTATABLE_API_ELEMENTS]
+) -> Optional[ANNOTATABLE_API_ELEMENTS]:
+    for element in api_element_list:
+        if (
+            isinstance(element, api_type)
+            and element.id == annotation.target
+        ):
+            return element
+    return None

--- a/package-parser/package_parser/processing/migration/annotations/_get_annotated_api_element.py
+++ b/package-parser/package_parser/processing/migration/annotations/_get_annotated_api_element.py
@@ -1,14 +1,23 @@
-from typing import List, TypeVar, Optional, Union
+from typing import List, Optional, TypeVar, Union
 
 from package_parser.processing.annotations.model import AbstractAnnotation
-from package_parser.processing.api.model import Attribute, Result, Class, Function, Parameter
+from package_parser.processing.api.model import (
+    Attribute,
+    Class,
+    Function,
+    Parameter,
+    Result,
+)
 
-ANNOTATABLE_API_ELEMENTS = TypeVar("ANNOTATABLE_API_ELEMENTS", Class, Function, Parameter)
+ANNOTATABLE_API_ELEMENTS = TypeVar(
+    "ANNOTATABLE_API_ELEMENTS", Class, Function, Parameter
+)
 API_ELEMENTS = TypeVar("API_ELEMENTS", Attribute, Class, Function, Parameter, Result)
 
 
 def get_annotated_api_element(
-    annotation: AbstractAnnotation, api_element_list: List[Union[Attribute, Class, Function, Parameter, Result]]
+    annotation: AbstractAnnotation,
+    api_element_list: List[Union[Attribute, Class, Function, Parameter, Result]],
 ) -> Optional[Union[Class, Function, Parameter]]:
     for element in api_element_list:
         if (
@@ -22,12 +31,9 @@ def get_annotated_api_element(
 def get_annotated_api_element_by_type(
     annotation: AbstractAnnotation,
     api_element_list: List[Union[Attribute, Class, Function, Parameter, Result]],
-    api_type: type[ANNOTATABLE_API_ELEMENTS]
+    api_type: type[ANNOTATABLE_API_ELEMENTS],
 ) -> Optional[ANNOTATABLE_API_ELEMENTS]:
     for element in api_element_list:
-        if (
-            isinstance(element, api_type)
-            and element.id == annotation.target
-        ):
+        if isinstance(element, api_type) and element.id == annotation.target:
             return element
     return None

--- a/package-parser/package_parser/processing/migration/annotations/_migrate_move_annotation.py
+++ b/package-parser/package_parser/processing/migration/annotations/_migrate_move_annotation.py
@@ -62,7 +62,9 @@ def migrate_move_annotation(
         move_annotation.target = element.id
         return [move_annotation]
 
-    annotated_apiv1_element = get_annotated_api_element(move_annotation, mapping.get_apiv1_elements())
+    annotated_apiv1_element = get_annotated_api_element(
+        move_annotation, mapping.get_apiv1_elements()
+    )
     if annotated_apiv1_element is None:
         return []
 

--- a/package-parser/package_parser/processing/migration/annotations/_migrate_remove_annotation.py
+++ b/package-parser/package_parser/processing/migration/annotations/_migrate_remove_annotation.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from package_parser.processing.annotations.model import (
     AbstractAnnotation,
     EnumReviewResult,
-    MoveAnnotation,
+    RemoveAnnotation,
     TodoAnnotation,
 )
 from package_parser.processing.api.model import (
@@ -24,74 +24,66 @@ from ._get_annotated_api_element import get_annotated_api_element
 from ._get_migration_text import get_migration_text
 
 
-def is_moveable(element: Attribute | Class | Function | Parameter | Result) -> bool:
-    if isinstance(element, (Attribute, Result)):
-        return False
-    if isinstance(element, Function):
-        # check for global function
-        element_parents = element.id.split("/")
-        return len(element_parents) == 3
-    return isinstance(element, Class)
+def is_removeable(element: Attribute | Class | Function | Parameter | Result) -> bool:
+    return isinstance(element, (Class, Function))
 
 
-# pylint: disable=duplicate-code
-def migrate_move_annotation(
-    move_annotation: MoveAnnotation, mapping: Mapping
+def migrate_remove_annotation(
+    remove_annotation: RemoveAnnotation, mapping: Mapping
 ) -> list[AbstractAnnotation]:
-    move_annotation = deepcopy(move_annotation)
-    authors = move_annotation.authors
+    remove_annotation = deepcopy(remove_annotation)
+    authors = remove_annotation.authors
     authors.append(migration_author)
-    move_annotation.authors = authors
-    migrate_text = get_migration_text(move_annotation, mapping)
+    remove_annotation.authors = authors
+    migrate_text = get_migration_text(remove_annotation, mapping)
 
     if isinstance(mapping, (ManyToOneMapping, OneToOneMapping)):
         element = mapping.get_apiv2_elements()[0]
         if isinstance(element, (Attribute, Result)):
             return []
-        if not is_moveable(element):
+        if not is_removeable(element):
             return [
                 TodoAnnotation(
                     element.id,
                     authors,
-                    move_annotation.reviewers,
-                    move_annotation.comment,
+                    remove_annotation.reviewers,
+                    remove_annotation.comment,
                     EnumReviewResult.NONE,
                     migrate_text,
                 )
             ]
-        move_annotation.target = element.id
-        return [move_annotation]
+        remove_annotation.target = element.id
+        return [remove_annotation]
 
-    annotated_apiv1_element = get_annotated_api_element(move_annotation, mapping.get_apiv1_elements())
+    annotated_apiv1_element = get_annotated_api_element(remove_annotation, mapping.get_apiv1_elements())
     if annotated_apiv1_element is None:
         return []
 
-    move_annotations: list[AbstractAnnotation] = []
+    remove_annotations: list[AbstractAnnotation] = []
     for element in mapping.get_apiv2_elements():
         if (
             isinstance(element, type(annotated_apiv1_element))
-            and is_moveable(element)
+            and is_removeable(element)
             and not isinstance(element, (Attribute, Result))
         ):
-            move_annotations.append(
-                MoveAnnotation(
+            remove_annotations.append(
+                RemoveAnnotation(
                     element.id,
                     authors,
-                    move_annotation.reviewers,
-                    move_annotation.comment,
+                    remove_annotation.reviewers,
+                    remove_annotation.comment,
                     EnumReviewResult.NONE,
-                    move_annotation.destination,
                 )
             )
         elif not isinstance(element, (Attribute, Result)):
-            move_annotations.append(
+            remove_annotations.append(
                 TodoAnnotation(
                     element.id,
                     authors,
-                    move_annotation.reviewers,
-                    move_annotation.comment,
-                    EnumReviewResult.UNSURE,
+                    remove_annotation.reviewers,
+                    remove_annotation.comment,
+                    EnumReviewResult.NONE,
                     migrate_text,
                 )
             )
-    return move_annotations
+    return remove_annotations

--- a/package-parser/package_parser/processing/migration/annotations/_migrate_remove_annotation.py
+++ b/package-parser/package_parser/processing/migration/annotations/_migrate_remove_annotation.py
@@ -55,7 +55,9 @@ def migrate_remove_annotation(
         remove_annotation.target = element.id
         return [remove_annotation]
 
-    annotated_apiv1_element = get_annotated_api_element(remove_annotation, mapping.get_apiv1_elements())
+    annotated_apiv1_element = get_annotated_api_element(
+        remove_annotation, mapping.get_apiv1_elements()
+    )
     if annotated_apiv1_element is None:
         return []
 

--- a/package-parser/package_parser/processing/migration/annotations/_migrate_todo_annotation.py
+++ b/package-parser/package_parser/processing/migration/annotations/_migrate_todo_annotation.py
@@ -13,6 +13,7 @@ from package_parser.processing.migration.model import (
 )
 
 from ._constants import migration_author
+from ._get_annotated_api_element import get_annotated_api_element
 from ._get_migration_text import get_migration_text
 
 
@@ -34,15 +35,7 @@ def migrate_todo_annotation(
 
     migrate_text = get_migration_text(todo_annotation, mapping)
 
-    annotated_apiv1_element = None
-    for element in mapping.get_apiv1_elements():
-        if (
-            not isinstance(element, (Attribute, Result))
-            and todo_annotation.target == element.id
-        ):
-            annotated_apiv1_element = element
-            break
-
+    annotated_apiv1_element = get_annotated_api_element(todo_annotation, mapping.get_apiv1_elements())
     if annotated_apiv1_element is None:
         return []
 

--- a/package-parser/package_parser/processing/migration/annotations/_migrate_todo_annotation.py
+++ b/package-parser/package_parser/processing/migration/annotations/_migrate_todo_annotation.py
@@ -35,7 +35,9 @@ def migrate_todo_annotation(
 
     migrate_text = get_migration_text(todo_annotation, mapping)
 
-    annotated_apiv1_element = get_annotated_api_element(todo_annotation, mapping.get_apiv1_elements())
+    annotated_apiv1_element = get_annotated_api_element(
+        todo_annotation, mapping.get_apiv1_elements()
+    )
     if annotated_apiv1_element is None:
         return []
 

--- a/package-parser/package_parser/processing/migration/annotations/_migrate_value_annotation.py
+++ b/package-parser/package_parser/processing/migration/annotations/_migrate_value_annotation.py
@@ -270,7 +270,9 @@ def migrate_constant_annotation(
             constant_annotation.defaultValue,
         )
 
-    parameterv1 = get_annotated_api_element_by_type(constant_annotation, mapping.get_apiv1_elements(), Parameter)
+    parameterv1 = get_annotated_api_element_by_type(
+        constant_annotation, mapping.get_apiv1_elements(), Parameter
+    )
     if parameterv1 is None:
         return None
     if _have_same_type(
@@ -291,7 +293,9 @@ def migrate_constant_annotation(
 def migrate_omitted_annotation(
     omitted_annotation: OmittedAnnotation, parameterv2: Parameter, mapping: Mapping
 ) -> Optional[OmittedAnnotation]:
-    parameterv1 = get_annotated_api_element_by_type(omitted_annotation, mapping.get_apiv1_elements(), Parameter)
+    parameterv1 = get_annotated_api_element_by_type(
+        omitted_annotation, mapping.get_apiv1_elements(), Parameter
+    )
     if parameterv1 is None:
         return None
     type_and_same_value = _have_same_value(parameterv1, parameterv2)
@@ -325,7 +329,9 @@ def migrate_omitted_annotation(
 def migrate_optional_annotation(
     optional_annotation: OptionalAnnotation, parameterv2: Parameter, mapping: Mapping
 ) -> Optional[OptionalAnnotation]:
-    parameterv1 = get_annotated_api_element_by_type(optional_annotation, mapping.get_apiv1_elements(), Parameter)
+    parameterv1 = get_annotated_api_element_by_type(
+        optional_annotation, mapping.get_apiv1_elements(), Parameter
+    )
     if parameterv1 is None:
         return None
     if parameterv2.type is not None and _have_same_type(
@@ -359,7 +365,9 @@ def migrate_optional_annotation(
 def migrate_required_annotation(
     required_annotation: RequiredAnnotation, parameterv2: Parameter, mapping: Mapping
 ) -> Optional[RequiredAnnotation]:
-    parameterv1 = get_annotated_api_element_by_type(required_annotation, mapping.get_apiv1_elements(), Parameter)
+    parameterv1 = get_annotated_api_element_by_type(
+        required_annotation, mapping.get_apiv1_elements(), Parameter
+    )
     if parameterv1 is None:
         return None
     type_and_same_value = _have_same_value(parameterv1, parameterv2)

--- a/package-parser/package_parser/processing/migration/annotations/_migrate_value_annotation.py
+++ b/package-parser/package_parser/processing/migration/annotations/_migrate_value_annotation.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Optional, Tuple, TypeVar
+from typing import Optional, Tuple
 
 from package_parser.processing.annotations.model import (
     AbstractAnnotation,
@@ -14,8 +14,6 @@ from package_parser.processing.annotations.model import (
 from package_parser.processing.api.model import (
     AbstractType,
     Attribute,
-    Class,
-    Function,
     NamedType,
     Parameter,
     Result,
@@ -30,6 +28,7 @@ from package_parser.processing.migration.model import (
 )
 
 from ._constants import migration_author
+from ._get_annotated_api_element import get_annotated_api_element_by_type
 from ._get_migration_text import get_migration_text
 
 
@@ -254,26 +253,6 @@ def _have_same_value(
     return None
 
 
-API_ELEMENTS = TypeVar("API_ELEMENTS", Class, Function, Parameter)
-
-
-def get_api_element_from_mapping(
-    annotation: AbstractAnnotation, mapping: Mapping, api_type: type[API_ELEMENTS]
-) -> Optional[API_ELEMENTS]:
-    element_list = [
-        element
-        for element in mapping.get_apiv1_elements()
-        if (
-            isinstance(element, api_type)
-            and hasattr(element, "id")
-            and element.id == annotation.target
-        )
-    ]
-    if len(element_list) != 1:
-        return None
-    return element_list[0]
-
-
 def migrate_constant_annotation(
     constant_annotation: ConstantAnnotation, parameterv2: Parameter, mapping: Mapping
 ) -> Optional[ConstantAnnotation]:
@@ -291,7 +270,7 @@ def migrate_constant_annotation(
             constant_annotation.defaultValue,
         )
 
-    parameterv1 = get_api_element_from_mapping(constant_annotation, mapping, Parameter)
+    parameterv1 = get_annotated_api_element_by_type(constant_annotation, mapping.get_apiv1_elements(), Parameter)
     if parameterv1 is None:
         return None
     if _have_same_type(
@@ -312,7 +291,7 @@ def migrate_constant_annotation(
 def migrate_omitted_annotation(
     omitted_annotation: OmittedAnnotation, parameterv2: Parameter, mapping: Mapping
 ) -> Optional[OmittedAnnotation]:
-    parameterv1 = get_api_element_from_mapping(omitted_annotation, mapping, Parameter)
+    parameterv1 = get_annotated_api_element_by_type(omitted_annotation, mapping.get_apiv1_elements(), Parameter)
     if parameterv1 is None:
         return None
     type_and_same_value = _have_same_value(parameterv1, parameterv2)
@@ -346,7 +325,7 @@ def migrate_omitted_annotation(
 def migrate_optional_annotation(
     optional_annotation: OptionalAnnotation, parameterv2: Parameter, mapping: Mapping
 ) -> Optional[OptionalAnnotation]:
-    parameterv1 = get_api_element_from_mapping(optional_annotation, mapping, Parameter)
+    parameterv1 = get_annotated_api_element_by_type(optional_annotation, mapping.get_apiv1_elements(), Parameter)
     if parameterv1 is None:
         return None
     if parameterv2.type is not None and _have_same_type(
@@ -380,7 +359,7 @@ def migrate_optional_annotation(
 def migrate_required_annotation(
     required_annotation: RequiredAnnotation, parameterv2: Parameter, mapping: Mapping
 ) -> Optional[RequiredAnnotation]:
-    parameterv1 = get_api_element_from_mapping(required_annotation, mapping, Parameter)
+    parameterv1 = get_annotated_api_element_by_type(required_annotation, mapping.get_apiv1_elements(), Parameter)
     if parameterv1 is None:
         return None
     type_and_same_value = _have_same_value(parameterv1, parameterv2)

--- a/package-parser/tests/processing/migration/annotations/test_move_annotation.py
+++ b/package-parser/tests/processing/migration/annotations/test_move_annotation.py
@@ -23,14 +23,15 @@ from package_parser.processing.migration.annotations import (
 )
 
 
+# pylint: disable=duplicate-code
 def migrate_move_annotation_data_one_to_one_mapping__global_function() -> Tuple[
     Mapping,
     AbstractAnnotation,
     list[AbstractAnnotation],
 ]:
     functionv1 = Function(
-        id="test/test.value.test1.test/test",
-        qname="test.value.test1.test/test",
+        id="test/test.move.test1.test/test",
+        qname="test.move.test1.test/test",
         decorators=[],
         parameters=[],
         results=[],
@@ -41,8 +42,8 @@ def migrate_move_annotation_data_one_to_one_mapping__global_function() -> Tuple[
     )
 
     functionv2 = Function(
-        id="test/test.value.test1.test/new_test",
-        qname="test.value.test1.test/new_test",
+        id="test/test.move.test1.test/new_test",
+        qname="test.move.test1.test/new_test",
         decorators=[],
         parameters=[],
         results=[],
@@ -55,20 +56,20 @@ def migrate_move_annotation_data_one_to_one_mapping__global_function() -> Tuple[
     mapping = OneToOneMapping(1.0, functionv1, functionv2)
 
     annotationv1 = MoveAnnotation(
-        target="test/test.value.test1.test/test",
+        target="test/test.move.test1.test/test",
         authors=["testauthor"],
         reviewers=[],
         comment="",
         reviewResult=EnumReviewResult.NONE,
-        destination="test.value.test1.destination",
+        destination="test.move.test1.destination",
     )
     annotationv2 = MoveAnnotation(
-        target="test/test.value.test1.test/new_test",
+        target="test/test.move.test1.test/new_test",
         authors=["testauthor", migration_author],
         reviewers=[],
         comment="",
         reviewResult=EnumReviewResult.NONE,
-        destination="test.value.test1.destination",
+        destination="test.move.test1.destination",
     )
     return mapping, annotationv1, [annotationv2]
 
@@ -80,8 +81,8 @@ def migrate_move_annotation_data_one_to_one_mapping__class() -> Tuple[
     list[AbstractAnnotation],
 ]:
     classv1 = Class(
-        id_="test/test.value.test2.test/MoveTestClass",
-        qname="test.value.test2.test.TestClass",
+        id_="test/test.move.test2.test/MoveTestClass",
+        qname="test.move.test2.test.TestClass",
         decorators=[],
         superclasses=[],
         is_public=True,
@@ -91,8 +92,8 @@ def migrate_move_annotation_data_one_to_one_mapping__class() -> Tuple[
         instance_attributes=[],
     )
     classv2 = Class(
-        id_="test/test.value.test2.test/NewMoveTestClass",
-        qname="test.value.test2.test.NewMoveTestClass",
+        id_="test/test.move.test2.test/NewMoveTestClass",
+        qname="test.move.test2.test.NewMoveTestClass",
         decorators=[],
         superclasses=[],
         is_public=True,
@@ -105,20 +106,20 @@ def migrate_move_annotation_data_one_to_one_mapping__class() -> Tuple[
     mapping = OneToOneMapping(1.0, classv1, classv2)
 
     annotationv1 = MoveAnnotation(
-        target="test/test.value.test2.test/MoveTestClass",
+        target="test/test.move.test2.test/MoveTestClass",
         authors=["testauthor"],
         reviewers=[],
         comment="",
         reviewResult=EnumReviewResult.NONE,
-        destination="test.value.test2.destination",
+        destination="test.move.test2.destination",
     )
     annotationv2 = MoveAnnotation(
-        target="test/test.value.test2.test/NewMoveTestClass",
+        target="test/test.move.test2.test/NewMoveTestClass",
         authors=["testauthor", migration_author],
         reviewers=[],
         comment="",
         reviewResult=EnumReviewResult.NONE,
-        destination="test.value.test2.destination",
+        destination="test.move.test2.destination",
     )
     return mapping, annotationv1, [annotationv2]
 
@@ -130,8 +131,8 @@ def migrate_move_annotation_data_one_to_many_mapping() -> Tuple[
 ]:
 
     functionv1 = Function(
-        id="test/test.value.test3.test/test",
-        qname="test.value.test3.test.test",
+        id="test/test.move.test3.test/test",
+        qname="test.move.test3.test.test",
         decorators=[],
         parameters=[],
         results=[],
@@ -142,8 +143,8 @@ def migrate_move_annotation_data_one_to_many_mapping() -> Tuple[
     )
 
     functionv2_a = Function(
-        id="test/test.value.test3.test/new_test_a",
-        qname="test.value.test3.test.new_test_a",
+        id="test/test.move.test3.test/new_test_a",
+        qname="test.move.test3.test.new_test_a",
         decorators=[],
         parameters=[],
         results=[],
@@ -154,8 +155,8 @@ def migrate_move_annotation_data_one_to_many_mapping() -> Tuple[
     )
 
     functionv2_b = Function(
-        id="test/test.value.test3.test/TestClass/new_test_b",
-        qname="test.value.test3.test.TestClass.new_test_b",
+        id="test/test.move.test3.test/TestClass/new_test_b",
+        qname="test.move.test3.test.TestClass.new_test_b",
         decorators=[],
         parameters=[],
         results=[],
@@ -168,23 +169,23 @@ def migrate_move_annotation_data_one_to_many_mapping() -> Tuple[
     mapping = OneToManyMapping(1.0, functionv1, [functionv2_a, functionv2_b])
 
     annotationv1 = MoveAnnotation(
-        target="test/test.value.test3.test/test",
+        target="test/test.move.test3.test/test",
         authors=["testauthor"],
         reviewers=[],
         comment="",
         reviewResult=EnumReviewResult.NONE,
-        destination="test.value.test3.destination",
+        destination="test.move.test3.destination",
     )
     annotationv2_a = MoveAnnotation(
-        target="test/test.value.test3.test/new_test_a",
+        target="test/test.move.test3.test/new_test_a",
         authors=["testauthor", migration_author],
         reviewers=[],
         comment="",
         reviewResult=EnumReviewResult.NONE,
-        destination="test.value.test3.destination",
+        destination="test.move.test3.destination",
     )
     annotationv2_b = TodoAnnotation(
-        target="test/test.value.test3.test/TestClass/new_test_b",
+        target="test/test.move.test3.test/TestClass/new_test_b",
         authors=["testauthor", migration_author],
         reviewers=[],
         comment="",

--- a/package-parser/tests/processing/migration/annotations/test_remove_migration.py
+++ b/package-parser/tests/processing/migration/annotations/test_remove_migration.py
@@ -1,0 +1,158 @@
+from typing import Tuple
+
+from package_parser.processing.annotations.model import (
+    AbstractAnnotation,
+    EnumReviewResult,
+    RemoveAnnotation,
+    TodoAnnotation,
+)
+from package_parser.processing.api.model import (
+    Class,
+    ClassDocumentation,
+    Function,
+    FunctionDocumentation,
+)
+from package_parser.processing.migration import (
+    Mapping,
+    OneToManyMapping,
+    OneToOneMapping,
+)
+from package_parser.processing.migration.annotations import (
+    get_migration_text,
+    migration_author,
+)
+
+
+# pylint: disable=duplicate-code
+def migrate_remove_annotation_data_one_to_one_mapping() -> Tuple[
+    Mapping,
+    AbstractAnnotation,
+    list[AbstractAnnotation],
+]:
+    functionv1 = Function(
+        id="test/test.remove.test1.test/test",
+        qname="test.remove.test1.test/test",
+        decorators=[],
+        parameters=[],
+        results=[],
+        is_public=True,
+        reexported_by=[],
+        documentation=FunctionDocumentation("", ""),
+        code="",
+    )
+
+    functionv2 = Function(
+        id="test/test.remove.test1.test/new_test",
+        qname="test.remove.test1.test/new_test",
+        decorators=[],
+        parameters=[],
+        results=[],
+        is_public=True,
+        reexported_by=[],
+        documentation=FunctionDocumentation("", ""),
+        code="",
+    )
+
+    mapping = OneToOneMapping(1.0, functionv1, functionv2)
+
+    annotationv1 = RemoveAnnotation(
+        target="test/test.remove.test1.test/test",
+        authors=["testauthor"],
+        reviewers=[],
+        comment="",
+        reviewResult=EnumReviewResult.NONE,
+    )
+    annotationv2 = RemoveAnnotation(
+        target="test/test.remove.test1.test/new_test",
+        authors=["testauthor", migration_author],
+        reviewers=[],
+        comment="",
+        reviewResult=EnumReviewResult.NONE,
+    )
+    return mapping, annotationv1, [annotationv2]
+
+
+# pylint: disable=duplicate-code
+def migrate_remove_annotation_data_one_to_many_mapping() -> Tuple[
+    Mapping,
+    AbstractAnnotation,
+    list[AbstractAnnotation],
+]:
+
+    classv1 = Class(
+        id_="test/test.remove.test2.test/RemoveTestClass",
+        qname="test.remove.test2.test.RemoveTestClass",
+        decorators=[],
+        superclasses=[],
+        is_public=True,
+        reexported_by=[],
+        documentation=ClassDocumentation("", ""),
+        code="class RemoveTestClass:\n    pass",
+        instance_attributes=[],
+    )
+    classv2_a = Class(
+        id_="test/test.remove.test2.test/NewRemoveTestClass",
+        qname="test.remove.test2.test.NewRemoveTestClass",
+        decorators=[],
+        superclasses=[],
+        is_public=True,
+        reexported_by=[],
+        documentation=ClassDocumentation("", ""),
+        code="class NewRemoveTestClass:\n    pass",
+        instance_attributes=[],
+    )
+    classv2_b = Class(
+        id_="test/test.remove.test2.test/NewRemoveTestClass2",
+        qname="test.remove.test2.test.NewRemoveTestClass2",
+        decorators=[],
+        superclasses=[],
+        is_public=True,
+        reexported_by=[],
+        documentation=ClassDocumentation("", ""),
+        code="class NewRemoveTestClass2:\n    pass",
+        instance_attributes=[],
+    )
+    functionv2 = Function(
+        id="test/test.remove.test2.test/TestClass/new_test",
+        qname="test.remove.test2.test.TestClass.new_test",
+        decorators=[],
+        parameters=[],
+        results=[],
+        is_public=True,
+        reexported_by=[],
+        documentation=FunctionDocumentation("", ""),
+        code="",
+    )
+
+    mapping = OneToManyMapping(1.0, classv1, [classv2_a, classv2_b, functionv2])
+
+    annotationv1 = RemoveAnnotation(
+        target="test/test.remove.test2.test/RemoveTestClass",
+        authors=["testauthor"],
+        reviewers=[],
+        comment="",
+        reviewResult=EnumReviewResult.NONE,
+    )
+    annotationv2_a = RemoveAnnotation(
+        target="test/test.remove.test2.test/NewRemoveTestClass",
+        authors=["testauthor", migration_author],
+        reviewers=[],
+        comment="",
+        reviewResult=EnumReviewResult.NONE,
+    )
+    annotationv2_b = RemoveAnnotation(
+        target="test/test.remove.test2.test/NewRemoveTestClass2",
+        authors=["testauthor", migration_author],
+        reviewers=[],
+        comment="",
+        reviewResult=EnumReviewResult.NONE,
+    )
+    annotationv2_c = TodoAnnotation(
+        target="test/test.remove.test2.test/TestClass/new_test",
+        authors=["testauthor", migration_author],
+        reviewers=[],
+        comment="",
+        reviewResult=EnumReviewResult.NONE,
+        newTodo=get_migration_text(annotationv1, mapping),
+    )
+    return mapping, annotationv1, [annotationv2_a, annotationv2_b, annotationv2_c]

--- a/package-parser/tests/processing/migration/test_migration.py
+++ b/package-parser/tests/processing/migration/test_migration.py
@@ -4,6 +4,8 @@ from package_parser.processing.annotations.model import (
 )
 from package_parser.processing.migration import migrate_annotations
 from package_parser.processing.migration.model import Mapping
+from processing.migration.annotations.test_remove_migration import migrate_remove_annotation_data_one_to_one_mapping, \
+    migrate_remove_annotation_data_one_to_many_mapping
 from tests.processing.migration.annotations.test_boundary_migration import (
     migrate_boundary_annotation_data_one_to_many_mapping,
     migrate_boundary_annotation_data_one_to_one_mapping,
@@ -55,6 +57,9 @@ test_data = [
     migrate_move_annotation_data_one_to_one_mapping__class(),
     migrate_move_annotation_data_one_to_one_mapping__global_function(),
     migrate_move_annotation_data_one_to_many_mapping(),
+    # remove annotation
+    migrate_remove_annotation_data_one_to_one_mapping(),
+    migrate_remove_annotation_data_one_to_many_mapping(),
     # rename annotation
     migrate_rename_annotation_data_one_to_many_mapping__with_changed_new_name(),
     migrate_rename_annotation_data_one_to_one_mapping(),

--- a/package-parser/tests/processing/migration/test_migration.py
+++ b/package-parser/tests/processing/migration/test_migration.py
@@ -4,8 +4,6 @@ from package_parser.processing.annotations.model import (
 )
 from package_parser.processing.migration import migrate_annotations
 from package_parser.processing.migration.model import Mapping
-from tests.processing.migration.annotations.test_remove_migration import migrate_remove_annotation_data_one_to_one_mapping, \
-    migrate_remove_annotation_data_one_to_many_mapping
 from tests.processing.migration.annotations.test_boundary_migration import (
     migrate_boundary_annotation_data_one_to_many_mapping,
     migrate_boundary_annotation_data_one_to_one_mapping,
@@ -21,6 +19,10 @@ from tests.processing.migration.annotations.test_move_annotation import (
     migrate_move_annotation_data_one_to_many_mapping,
     migrate_move_annotation_data_one_to_one_mapping__class,
     migrate_move_annotation_data_one_to_one_mapping__global_function,
+)
+from tests.processing.migration.annotations.test_remove_migration import (
+    migrate_remove_annotation_data_one_to_many_mapping,
+    migrate_remove_annotation_data_one_to_one_mapping,
 )
 from tests.processing.migration.annotations.test_rename_migration import (
     migrate_rename_annotation_data_one_to_many_mapping,

--- a/package-parser/tests/processing/migration/test_migration.py
+++ b/package-parser/tests/processing/migration/test_migration.py
@@ -4,7 +4,7 @@ from package_parser.processing.annotations.model import (
 )
 from package_parser.processing.migration import migrate_annotations
 from package_parser.processing.migration.model import Mapping
-from processing.migration.annotations.test_remove_migration import migrate_remove_annotation_data_one_to_one_mapping, \
+from tests.processing.migration.annotations.test_remove_migration import migrate_remove_annotation_data_one_to_one_mapping, \
     migrate_remove_annotation_data_one_to_many_mapping
 from tests.processing.migration.annotations.test_boundary_migration import (
     migrate_boundary_annotation_data_one_to_many_mapping,


### PR DESCRIPTION
Closes #1144.

### Summary of Changes

- Migration of `@remove` annotations through a mapping from old api elements to new api elements.
If the mapped apiv2 element is removable (a class or function), change the target of the annotation.
Otherwise, mark the api element that are not removable with an `@todo` annotation.
- New methods `get_annotated_api_element` and `get_annotated_api_element_by_type` to get the element from an annotation by its id.

### Testing Instructions

run the migrate command or view and run the `test_migration.py` file