### PR TITLE
ci: add back required workflow to repo

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,9 @@ name: Dependency Review
 on:
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   dependency-review:
+    if: ${{ github.event_name == 'pull_request' }}
     uses: lars-reimann/.github/.github/workflows/dependency-review-reusable.yml@main

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -3,9 +3,11 @@ name: MegaLinter
 on:
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   megalinter:
+    if: ${{ github.event_name == 'pull_request' }}
     uses: lars-reimann/.github/.github/workflows/megalinter-reusable.yml@main
     secrets:
       PAT: ${{ secrets.PAT }}

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -7,7 +7,9 @@ on:
       - edited
       - synchronize
       - reopened
+  merge_group:
 
 jobs:
   check-format:
+    if: ${{ github.event_name == 'pull_request' }}
     uses: lars-reimann/.github/.github/workflows/pr-format-reusable.yml@main


### PR DESCRIPTION
### Summary of Changes

Organization-wide required workflows are currently too strict (see [this discussion](https://github.com/community/community/discussions/43890)). I've disabled them for now and instead added them back directly to the repo.